### PR TITLE
feat(pds): implement applyWrites endpoint

### DIFF
--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -142,6 +142,9 @@ app.post("/xrpc/com.atproto.repo.deleteRecord", requireAuth, (c) =>
 app.post("/xrpc/com.atproto.repo.uploadBlob", requireAuth, (c) =>
 	repo.uploadBlob(c, getAccountDO(c.env)),
 );
+app.post("/xrpc/com.atproto.repo.applyWrites", requireAuth, (c) =>
+	repo.applyWrites(c, getAccountDO(c.env)),
+);
 
 // Server identity
 app.get("/xrpc/com.atproto.server.describeServer", server.describeServer);


### PR DESCRIPTION
## Summary
- Implements `com.atproto.repo.applyWrites` endpoint for batch record operations
- Supports create, update, and delete operations in a single request
- Required by Bluesky clients for efficient repository mutations

## Test plan
- [x] All 79 tests pass (6 new tests for applyWrites)
- [ ] Test with Bluesky app to verify batch operations work

🤖 Generated with [Claude Code](https://claude.com/claude-code)