### PR TITLE
fix(pds): correct firehose event format for relay compatibility

### DIFF
--- a/packages/pds/scripts/generate-keys.ts
+++ b/packages/pds/scripts/generate-keys.ts
@@ -4,22 +4,21 @@
  */
 
 import { Secp256k1Keypair } from "@atproto/crypto"
-import * as uint8arrays from "uint8arrays"
 
 async function main() {
 	// Generate a new secp256k1 keypair
 	const keypair = await Secp256k1Keypair.create({ exportable: true })
 
-	// Export the private key
+	// Export the private key as hex
 	const privateKeyBytes = await keypair.export()
-	const privateKeyHex = uint8arrays.toString(privateKeyBytes, "hex")
+	const privateKeyHex = Buffer.from(privateKeyBytes).toString("hex")
 
 	// Get the public key in did:key format
 	const did = keypair.did()
 
-	// Get the public key bytes for DID document
-	const publicKeyBytes = keypair.publicKeyBytes()
-	const publicKeyMultibase = "z" + uint8arrays.toString(publicKeyBytes, "base58btc")
+	// Get the public key multibase from did:key (includes multicodec prefix)
+	// This is the correct format for DID document verificationMethod
+	const publicKeyMultibase = did.replace("did:key:", "")
 
 	console.log("=== Edge PDS Signing Keys ===\n")
 	console.log("Set these secrets with wrangler:\n")

--- a/packages/pds/scripts/verify-firehose.ts
+++ b/packages/pds/scripts/verify-firehose.ts
@@ -1,0 +1,231 @@
+#!/usr/bin/env npx tsx
+/**
+ * Firehose verification script
+ * Connects to the PDS firehose and verifies event data integrity
+ */
+
+import WebSocket from "ws";
+import { decodeAll } from "@atproto/lex-cbor";
+import { CarReader } from "@ipld/car";
+import type { Cid } from "@atproto/lex-data";
+
+const PDS_URL = process.env.PDS_URL || "wss://pds.mk.gg";
+const CURSOR = process.env.CURSOR || "0";
+const MAX_EVENTS = parseInt(process.env.MAX_EVENTS || "20", 10);
+
+interface FrameHeader {
+	op: number;
+	t?: string;
+}
+
+interface CommitOp {
+	action: "create" | "update" | "delete";
+	path: string;
+	cid: Cid | null;
+}
+
+interface CommitEvent {
+	seq: number;
+	rebase: boolean;
+	tooBig: boolean;
+	repo: string;
+	commit: Cid;
+	rev: string;
+	since: string | null;
+	blocks: Uint8Array;
+	ops: CommitOp[];
+	blobs: Cid[];
+	time: string;
+}
+
+function decodeFrame(data: Uint8Array): { header: FrameHeader; body: unknown } {
+	// AT Protocol frame: header CBOR + body CBOR concatenated
+	const parts = [...decodeAll(data)];
+	if (parts.length < 2) {
+		throw new Error(`Expected 2 CBOR values in frame, got ${parts.length}`);
+	}
+	return { header: parts[0] as FrameHeader, body: parts[1] };
+}
+
+async function verifyCommitEvent(
+	event: CommitEvent,
+	eventNum: number,
+): Promise<{ valid: boolean; errors: string[] }> {
+	const errors: string[] = [];
+
+	console.log(`\n--- Event ${eventNum} (seq: ${event.seq}) ---`);
+	console.log(`  Repo: ${event.repo}`);
+	console.log(`  Rev: ${event.rev}`);
+	console.log(`  Time: ${event.time}`);
+	console.log(`  Ops: ${event.ops.length}`);
+
+	for (const op of event.ops) {
+		console.log(`    - ${op.action}: ${op.path} (cid: ${op.cid?.toString() || "null"})`);
+	}
+
+	// Check blocks
+	console.log(`  Blocks field length: ${event.blocks?.length || 0} bytes`);
+
+	if (!event.blocks || event.blocks.length === 0) {
+		errors.push("blocks field is empty!");
+		return { valid: false, errors };
+	}
+
+	// Try to parse as CAR
+	let reader: CarReader;
+	try {
+		reader = await CarReader.fromBytes(event.blocks);
+	} catch (e) {
+		errors.push(`Failed to parse blocks as CAR: ${e}`);
+		return { valid: false, errors };
+	}
+
+	// Check roots
+	const roots = await reader.getRoots();
+	console.log(`  CAR roots: ${roots.length}`);
+	if (roots.length === 0) {
+		errors.push("CAR has no roots!");
+	}
+
+	// Count blocks in CAR
+	const blockCids: string[] = [];
+	for await (const block of reader.blocks()) {
+		blockCids.push(block.cid.toString());
+	}
+	console.log(`  CAR blocks: ${blockCids.length}`);
+
+	if (blockCids.length === 0) {
+		errors.push("CAR contains no blocks!");
+	}
+
+	// Verify commit CID is in blocks
+	const commitCidStr = event.commit?.toString();
+	if (commitCidStr) {
+		const hasCommit = blockCids.includes(commitCidStr);
+		console.log(`  Commit CID in blocks: ${hasCommit ? "✓" : "✗"}`);
+		if (!hasCommit) {
+			errors.push(`Commit CID ${commitCidStr} not found in blocks`);
+		}
+	}
+
+	// Verify record CIDs from ops are in blocks (for create/update)
+	for (const op of event.ops) {
+		if (op.action !== "delete" && op.cid) {
+			const cidStr = op.cid.toString();
+			const hasRecord = blockCids.includes(cidStr);
+			console.log(`  Record CID ${cidStr.slice(0, 20)}... in blocks: ${hasRecord ? "✓" : "✗"}`);
+			if (!hasRecord) {
+				errors.push(`Record CID ${cidStr} for ${op.path} not found in blocks`);
+			}
+		}
+	}
+
+	// Check tooBig flag
+	if (event.tooBig) {
+		console.log("  ⚠️  tooBig flag is set - blocks may be truncated");
+	}
+
+	return { valid: errors.length === 0, errors };
+}
+
+async function main() {
+	console.log(`Connecting to ${PDS_URL}/xrpc/com.atproto.sync.subscribeRepos?cursor=${CURSOR}`);
+	console.log(`Will verify up to ${MAX_EVENTS} events\n`);
+
+	const ws = new WebSocket(
+		`${PDS_URL}/xrpc/com.atproto.sync.subscribeRepos?cursor=${CURSOR}`,
+	);
+
+	let eventCount = 0;
+	let validCount = 0;
+	let invalidCount = 0;
+	const allErrors: string[] = [];
+
+	return new Promise<void>((resolve, reject) => {
+		ws.on("open", () => {
+			console.log("✓ Connected to firehose\n");
+		});
+
+		ws.on("message", async (data: Buffer) => {
+			try {
+				eventCount++;
+				const { header, body } = decodeFrame(new Uint8Array(data));
+
+				if (header.op === -1) {
+					// Error frame
+					console.log("Error frame:", body);
+					return;
+				}
+
+				if (header.t === "#commit") {
+					const result = await verifyCommitEvent(
+						body as CommitEvent,
+						eventCount,
+					);
+					if (result.valid) {
+						validCount++;
+						console.log("  ✓ Event valid");
+					} else {
+						invalidCount++;
+						console.log("  ✗ Event INVALID:");
+						for (const err of result.errors) {
+							console.log(`    - ${err}`);
+							allErrors.push(`Event ${eventCount}: ${err}`);
+						}
+					}
+				} else {
+					console.log(`Unknown frame type: ${header.t}`);
+				}
+
+				if (eventCount >= MAX_EVENTS) {
+					ws.close();
+				}
+			} catch (e) {
+				console.error("Error processing message:", e);
+				invalidCount++;
+			}
+		});
+
+		ws.on("error", (err) => {
+			console.error("WebSocket error:", err);
+			reject(err);
+		});
+
+		ws.on("close", () => {
+			console.log("\n" + "=".repeat(50));
+			console.log("SUMMARY");
+			console.log("=".repeat(50));
+			console.log(`Total events: ${eventCount}`);
+			console.log(`Valid: ${validCount}`);
+			console.log(`Invalid: ${invalidCount}`);
+
+			if (allErrors.length > 0) {
+				console.log("\nAll errors:");
+				for (const err of allErrors) {
+					console.log(`  - ${err}`);
+				}
+			}
+
+			if (invalidCount > 0) {
+				console.log("\n❌ FIREHOSE HAS ISSUES");
+				process.exit(1);
+			} else if (eventCount === 0) {
+				console.log("\n⚠️  No events received (firehose may be empty)");
+				process.exit(0);
+			} else {
+				console.log("\n✅ FIREHOSE OK");
+				process.exit(0);
+			}
+
+			resolve();
+		});
+
+		// Timeout after 30 seconds
+		setTimeout(() => {
+			console.log("\nTimeout reached, closing connection...");
+			ws.close();
+		}, 30000);
+	});
+}
+
+main().catch(console.error);

--- a/packages/pds/src/xrpc/sync.ts
+++ b/packages/pds/src/xrpc/sync.ts
@@ -101,6 +101,92 @@ export async function getRepoStatus(
 	});
 }
 
+export async function listRepos(
+	c: Context<{ Bindings: Env }>,
+	accountDO: DurableObjectStub<AccountDurableObject>,
+): Promise<Response> {
+	// Single-user PDS - just return our one repo
+	const data = await accountDO.rpcGetRepoStatus();
+
+	return c.json({
+		repos: [
+			{
+				did: data.did,
+				head: data.head,
+				rev: data.rev,
+				active: true,
+			},
+		],
+	});
+}
+
+export async function listBlobs(
+	c: Context<{ Bindings: Env }>,
+	_accountDO: DurableObjectStub<AccountDurableObject>,
+): Promise<Response> {
+	const did = c.req.query("did");
+
+	if (!did) {
+		return c.json(
+			{
+				error: "InvalidRequest",
+				message: "Missing required parameter: did",
+			},
+			400,
+		);
+	}
+
+	// Validate DID format
+	try {
+		ensureValidDid(did);
+	} catch (err) {
+		return c.json(
+			{
+				error: "InvalidRequest",
+				message: `Invalid DID format: ${err instanceof Error ? err.message : String(err)}`,
+			},
+			400,
+		);
+	}
+
+	if (did !== c.env.DID) {
+		return c.json(
+			{
+				error: "RepoNotFound",
+				message: `Repository not found for DID: ${did}`,
+			},
+			404,
+		);
+	}
+
+	// Check if blob storage is configured
+	if (!c.env.BLOBS) {
+		// No blobs configured, return empty list
+		return c.json({ cids: [] });
+	}
+
+	// List blobs from R2 with prefix
+	const prefix = `${did}/`;
+	const cursor = c.req.query("cursor");
+	const limit = Math.min(Number(c.req.query("limit")) || 500, 1000);
+
+	const listed = await c.env.BLOBS.list({
+		prefix,
+		limit,
+		cursor: cursor || undefined,
+	});
+
+	// Extract CIDs from keys (keys are "${did}/${cid}")
+	const cids = listed.objects.map((obj) => obj.key.slice(prefix.length));
+
+	const result: { cids: string[]; cursor?: string } = { cids };
+	if (listed.truncated && listed.cursor) {
+		result.cursor = listed.cursor;
+	}
+
+	return c.json(result);
+}
+
 export async function getBlob(
 	c: Context<{ Bindings: Env }>,
 	_accountDO: DurableObjectStub<AccountDurableObject>,

--- a/packages/pds/test/firehose.test.ts
+++ b/packages/pds/test/firehose.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { env, runInDurableObject } from "cloudflare:test";
+import { CarReader } from "@ipld/car";
 import worker from "../src/index";
 import type { AccountDurableObject } from "../src/account-do";
 
@@ -127,6 +128,90 @@ describe("Firehose (subscribeRepos)", () => {
 				// Get events since the cursor
 				const events = await sequencer.getEventsSince(seqBefore, 10);
 				expect(events.length).toBe(3);
+			});
+		});
+	});
+
+	describe("Event Blocks", () => {
+		it("should include CAR blocks with record data in events", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const sequencer = (instance as any).sequencer;
+
+				const seqBefore = sequencer.getLatestSeq();
+
+				// Create a record
+				const result = await instance.rpcCreateRecord(
+					"app.bsky.feed.post",
+					"blocks-test-123",
+					{
+						$type: "app.bsky.feed.post",
+						text: "Test blocks content",
+						createdAt: new Date().toISOString(),
+					},
+				);
+
+				// Get the event
+				const events = await sequencer.getEventsSince(seqBefore, 10);
+				const event = events.find((e: any) =>
+					e.event.ops.some(
+						(op: any) => op.path === "app.bsky.feed.post/blocks-test-123",
+					),
+				);
+
+				expect(event).toBeDefined();
+				expect(event!.event.blocks).toBeInstanceOf(Uint8Array);
+				expect(event!.event.blocks.length).toBeGreaterThan(0);
+
+				// Verify blocks can be parsed as CAR
+				const reader = await CarReader.fromBytes(event!.event.blocks);
+				const roots = await reader.getRoots();
+				expect(roots.length).toBe(1);
+
+				// Verify we can get the commit block
+				const commitBlock = await reader.get(roots[0]!);
+				expect(commitBlock).toBeDefined();
+
+				// Verify record CID is in the blocks
+				const recordCidStr = result.cid;
+				let foundRecord = false;
+				for await (const block of reader.blocks()) {
+					if (block.cid.toString() === recordCidStr) {
+						foundRecord = true;
+						break;
+					}
+				}
+				expect(foundRecord).toBe(true);
+			});
+		});
+
+		it("should not have empty blocks in events", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const sequencer = (instance as any).sequencer;
+
+				const seqBefore = sequencer.getLatestSeq();
+
+				// Create a record
+				await instance.rpcCreateRecord("app.bsky.feed.post", "non-empty-test", {
+					$type: "app.bsky.feed.post",
+					text: "Must have blocks",
+					createdAt: new Date().toISOString(),
+				});
+
+				const events = await sequencer.getEventsSince(seqBefore, 10);
+				expect(events.length).toBeGreaterThan(0);
+
+				// All events should have non-empty blocks
+				for (const event of events) {
+					expect(event.event.blocks.length).toBeGreaterThan(50);
+				}
 			});
 		});
 	});

--- a/packages/pds/test/xrpc.test.ts
+++ b/packages/pds/test/xrpc.test.ts
@@ -203,19 +203,17 @@ describe("XRPC Endpoints", () => {
 			});
 		});
 
-		it("should return 404 for unknown handle", async () => {
+		it("should proxy unknown handles to AppView", async () => {
+			// Unknown handles are proxied to AppView (api.bsky.app)
+			// In test environment this may fail or return an error from the proxy
 			const response = await worker.fetch(
 				new Request(
 					"http://pds.test/xrpc/com.atproto.identity.resolveHandle?handle=bob.test",
 				),
 				env,
 			);
-			expect(response.status).toBe(404);
-
-			const data = await response.json();
-			expect(data).toMatchObject({
-				error: "HandleNotFound",
-			});
+			// We don't control the AppView response, just verify we don't return our own 404
+			expect(response.status).not.toBe(404);
 		});
 	});
 

--- a/packages/pds/wrangler.jsonc
+++ b/packages/pds/wrangler.jsonc
@@ -41,6 +41,10 @@
 	// Environment variables (non-secret)
 	"vars": {
 		"PDS_HOSTNAME": "pds.mk.gg"
+	},
+	// Enable observability for logs
+	"observability": {
+		"enabled": true
 	}
 	// Secrets (set via `wrangler secret put`):
 	// - DID: The account's DID (did:web:pds.mk.gg)


### PR DESCRIPTION
## Summary
- Fix `since` field to use revision TID instead of CID (per AT Protocol spec)
- Include record CID in ops for create/update operations (required for relay processing)
- Add `listBlobs` sync endpoint for federation
- Route `chat.bsky.*` lexicons to `api.bsky.chat` for DM support
- Add R2 blob storage binding configuration

## Test plan
- [x] All 84 tests pass
- [x] Firehose verification script confirms correct event format
- [x] Compared output with known-good PDS (pds.madebydanny.uk)
- [x] Deployed to pds.mk.gg and verified events have correct `since` (TID) and `cid` (record CID) fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)