### PR TITLE
feat(pds): add putRecord endpoint for profile editing

### DIFF
--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -178,6 +178,9 @@ app.post("/xrpc/com.atproto.repo.uploadBlob", requireAuth, (c) =>
 app.post("/xrpc/com.atproto.repo.applyWrites", requireAuth, (c) =>
 	repo.applyWrites(c, getAccountDO(c.env)),
 );
+app.post("/xrpc/com.atproto.repo.putRecord", requireAuth, (c) =>
+	repo.putRecord(c, getAccountDO(c.env)),
+);
 
 // Server identity
 app.get("/xrpc/com.atproto.server.describeServer", server.describeServer);

--- a/packages/pds/src/xrpc/repo.ts
+++ b/packages/pds/src/xrpc/repo.ts
@@ -253,6 +253,47 @@ export async function deleteRecord(
 	return c.json(result);
 }
 
+export async function putRecord(
+	c: Context<{ Bindings: Env }>,
+	accountDO: DurableObjectStub<AccountDurableObject>,
+): Promise<Response> {
+	const body = await c.req.json();
+	const { repo, collection, rkey, record } = body;
+
+	if (!repo || !collection || !rkey || !record) {
+		return c.json(
+			{
+				error: "InvalidRequest",
+				message: "Missing required parameters: repo, collection, rkey, record",
+			},
+			400,
+		);
+	}
+
+	if (repo !== c.env.DID) {
+		return c.json(
+			{
+				error: "InvalidRepo",
+				message: `Invalid repository: ${repo}`,
+			},
+			400,
+		);
+	}
+
+	try {
+		const result = await accountDO.rpcPutRecord(collection, rkey, record);
+		return c.json(result);
+	} catch (err) {
+		return c.json(
+			{
+				error: "InvalidRequest",
+				message: err instanceof Error ? err.message : String(err),
+			},
+			400,
+		);
+	}
+}
+
 export async function applyWrites(
 	c: Context<{ Bindings: Env }>,
 	accountDO: DurableObjectStub<AccountDurableObject>,


### PR DESCRIPTION
## Summary
- Add `com.atproto.repo.putRecord` endpoint that creates or updates records
- Enables profile editing (displayName, description, avatar, banner, etc.)
- Properly sequences updates to firehose with correct CID in ops

## Test plan
- [x] All 84 tests pass
- [x] Deployed and tested profile update manually
- [x] Verified firehose emits correct update events

## Future work
- Add lexicon validation for records before storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)