### PR TITLE
ci: set up pkg.pr.new for PR publishing

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,32 @@
+name: Publish PR Preview
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: latest
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish to pkg.pr.new
+        run: pnpx pkg-pr-new publish --compact './packages/pds' './packages/oauth-provider' './packages/create-pds'


### PR DESCRIPTION
Enables automatic publishing of preview packages on PRs and main branch pushes using pkg.pr.new. Publishes all three packages:
- @ascorbic/pds
- @ascorbic/atproto-oauth-provider
- create-pds