### PR TITLE
chore: deprecate @ascorbic packages in favor of @getcirrus

### DIFF
--- a/.changeset/deprecate-packages.md
+++ b/.changeset/deprecate-packages.md
@@ -1,0 +1,11 @@
+---
+"@ascorbic/pds": patch
+"@ascorbic/atproto-oauth-provider": patch
+---
+
+Deprecate packages in favor of @getcirrus/pds and @getcirrus/oauth-provider
+
+These packages have been renamed and will no longer receive updates under the @ascorbic scope. Please migrate to the new package names:
+
+- `@ascorbic/pds` → `@getcirrus/pds`
+- `@ascorbic/atproto-oauth-provider` → `@getcirrus/oauth-provider`

--- a/packages/oauth-provider/README.md
+++ b/packages/oauth-provider/README.md
@@ -1,5 +1,9 @@
 # @ascorbic/atproto-oauth-provider
 
+> **🚨 This package has been renamed to `@getcirrus/oauth-provider`**
+>
+> This package is deprecated and will no longer receive updates. Please migrate to [`@getcirrus/oauth-provider`](https://www.npmjs.com/package/@getcirrus/oauth-provider) for the latest features and bug fixes.
+
 AT Protocol OAuth 2.1 Authorization Server for Cloudflare Workers.
 
 A complete OAuth 2.1 provider implementation that enables "Login with Bluesky" functionality for your PDS. Built specifically for Cloudflare Workers with Durable Objects.

--- a/packages/pds/README.md
+++ b/packages/pds/README.md
@@ -1,5 +1,9 @@
 # @ascorbic/pds
 
+> **🚨 This package has been renamed to `@getcirrus/pds`**
+>
+> This package is deprecated and will no longer receive updates. Please migrate to [`@getcirrus/pds`](https://www.npmjs.com/package/@getcirrus/pds) for the latest features and bug fixes.
+
 A single-user [AT Protocol](https://atproto.com) Personal Data Server (PDS) that runs on Cloudflare Workers. Host your own Bluesky identity with minimal infrastructure.
 
 > **⚠️ Experimental Software**


### PR DESCRIPTION
Add deprecation banners to READMEs and changeset for final release under the @ascorbic scope before migrating to @getcirrus/pds and @getcirrus/oauth-provider.