### PR TITLE
feat(pds): provision custom domain in init

### DIFF
--- a/.changeset/custom-domain-config.md
+++ b/.changeset/custom-domain-config.md
@@ -1,0 +1,5 @@
+---
+"@getcirrus/pds": minor
+---
+
+Add custom domain configuration to `pds init`. Users are now prompted to configure Cloudflare custom domain routing, which sets up the wrangler.jsonc routes config with `custom_domain: true`. On deploy, Cloudflare will automatically configure DNS records and SSL certificates.

--- a/packages/create-pds/templates/pds-worker/wrangler.jsonc
+++ b/packages/create-pds/templates/pds-worker/wrangler.jsonc
@@ -32,14 +32,6 @@
 			"bucket_name": "pds-blobs"
 		}
 	],
-	// Custom domain routing (set by `pds init`)
-	// Cloudflare will automatically configure DNS and SSL
-	// "routes": [
-	// 	{
-	// 		"pattern": "pds.example.com",
-	// 		"custom_domain": true
-	// 	}
-	// ],
 	// Environment variables (public config)
 	// These are set by `pds init` or can be edited manually
 	"vars": {

--- a/packages/pds/src/cli/utils/wrangler.ts
+++ b/packages/pds/src/cli/utils/wrangler.ts
@@ -92,14 +92,6 @@ export function setCustomDomain(hostname: string): void {
 }
 
 /**
- * Get current routes from wrangler config
- */
-export function getRoutes(): Array<{ pattern: string; custom_domain?: boolean }> {
-	const { rawConfig } = experimental_readRawConfig({});
-	return (rawConfig.routes as Array<{ pattern: string; custom_domain?: boolean }>) || [];
-}
-
-/**
  * Set a secret using wrangler secret put
  */
 export async function setSecret(


### PR DESCRIPTION
Add custom domain configuration to `pds init`. Users are now prompted to configure Cloudflare custom domain routing, which sets up the wrangler.jsonc routes config with `custom_domain: true`. On deploy, Cloudflare will automatically configure DNS records and SSL certificates.