### PR TITLE
fix(oauth-provider): fix CSP blocking OAuth authorization flow in Chrome

### DIFF
--- a/.changeset/fix-csp-form-action.md
+++ b/.changeset/fix-csp-form-action.md
@@ -2,6 +2,6 @@
 "@getcirrus/oauth-provider": patch
 ---
 
-Fix CSP blocking OAuth form submission in some browsers
+Fix CSP blocking OAuth authorization flow in Chrome
 
-The `form-action 'self'` CSP directive was blocking form submissions during OAuth authorization in some browser configurations. This change makes the CSP dynamic by explicitly including the issuer URL alongside `'self'` to ensure cross-browser compatibility.
+Remove `form-action` from CSP due to inconsistent browser behavior with redirects. Chrome blocks redirects after form submission if the redirect URL isn't in `form-action`, while Firefox does not. Since OAuth requires redirecting to the client's callback URL after consent, `form-action` cannot be used without breaking the flow in Chrome.

--- a/packages/oauth-provider/src/index.ts
+++ b/packages/oauth-provider/src/index.ts
@@ -48,5 +48,5 @@ export {
 export type { GeneratedTokens, GenerateTokensOptions } from "./tokens.js";
 
 // UI
-export { renderConsentUI, renderErrorPage, getConsentUICSP } from "./ui.js";
+export { renderConsentUI, renderErrorPage, CONSENT_UI_CSP } from "./ui.js";
 export type { ConsentUIOptions } from "./ui.js";

--- a/packages/oauth-provider/src/provider.ts
+++ b/packages/oauth-provider/src/provider.ts
@@ -18,7 +18,7 @@ import {
 	isTokenValid,
 	AUTH_CODE_TTL,
 } from "./tokens.js";
-import { renderConsentUI, renderErrorPage, getConsentUICSP } from "./ui.js";
+import { renderConsentUI, renderErrorPage, CONSENT_UI_CSP } from "./ui.js";
 
 /**
  * OAuth provider configuration
@@ -218,7 +218,7 @@ export class ATProtoOAuthProvider {
 			status: 200,
 			headers: {
 				"Content-Type": "text/html; charset=utf-8",
-				"Content-Security-Policy": getConsentUICSP(this.issuer),
+				"Content-Security-Policy": CONSENT_UI_CSP,
 				"Cache-Control": "no-store",
 			},
 		});
@@ -289,7 +289,7 @@ export class ATProtoOAuthProvider {
 				status: 401,
 				headers: {
 					"Content-Type": "text/html; charset=utf-8",
-					"Content-Security-Policy": getConsentUICSP(this.issuer),
+					"Content-Security-Policy": CONSENT_UI_CSP,
 					"Cache-Control": "no-store",
 				},
 			});
@@ -666,7 +666,7 @@ export class ATProtoOAuthProvider {
 			status: 400,
 			headers: {
 				"Content-Type": "text/html; charset=utf-8",
-				"Content-Security-Policy": getConsentUICSP(this.issuer),
+				"Content-Security-Policy": CONSENT_UI_CSP,
 				"Cache-Control": "no-store",
 			},
 		});

--- a/packages/oauth-provider/src/ui.ts
+++ b/packages/oauth-provider/src/ui.ts
@@ -6,22 +6,23 @@
 import type { ClientMetadata } from "./storage.js";
 
 /**
- * Generate Content Security Policy for the consent UI
+ * Content Security Policy for the consent UI
  *
  * - default-src 'none': Deny all by default
  * - style-src 'unsafe-inline': Allow inline styles (our CSS is inline)
  * - img-src https: data:: Allow images from HTTPS URLs (client logos) and data URIs
- * - form-action: Allow form submission to the authorization endpoint
  * - frame-ancestors 'none': Prevent clickjacking by disallowing framing
  * - base-uri 'none': Prevent base tag injection
  *
- * @param issuer The OAuth issuer URL to explicitly allow in form-action
+ * Note: form-action is intentionally omitted. Browser behavior for blocking
+ * redirects after form submission is inconsistent - Chrome blocks redirects
+ * to URLs not in form-action, while Firefox does not. Since OAuth requires
+ * redirecting to the client's callback URL after form submission, we cannot
+ * use form-action without breaking the flow in Chrome.
+ * See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/form-action
  */
-export function getConsentUICSP(issuer: string): string {
-	// Use explicit path to ensure browser compatibility - some browsers require exact path matching
-	const authorizeUrl = `${issuer}/oauth/authorize`;
-	return `default-src 'none'; style-src 'unsafe-inline'; img-src https: data:; form-action 'self' ${authorizeUrl}; frame-ancestors 'none'; base-uri 'none'`;
-}
+export const CONSENT_UI_CSP =
+	"default-src 'none'; style-src 'unsafe-inline'; img-src https: data:; frame-ancestors 'none'; base-uri 'none'";
 
 /**
  * Escape HTML to prevent XSS


### PR DESCRIPTION
Remove `form-action` from CSP due to inconsistent browser behavior with redirects. Chrome blocks redirects after form submission if the redirect URL isn't in `form-action`, while Firefox does not. Since OAuth requires redirecting to the client's callback URL after consent, `form-action` cannot be used without breaking the flow in Chrome.