### PR TITLE
fix(pds): proxy foreign DID requests to AppView for repo endpoints

### DIFF
--- a/.changeset/cruel-mugs-decide.md
+++ b/.changeset/cruel-mugs-decide.md
@@ -1,0 +1,7 @@
+---
+"@getcirrus/pds": patch
+---
+
+Fix foreign DID requests returning 404 for repo endpoints
+
+Previously, `getRecord`, `listRecords`, and `describeRepo` returned 404 when the requested repo DID didn't match the local PDS DID. Now these endpoints proxy foreign DID requests to the Bluesky AppView, enabling clients to fetch records from other users' repositories.


### PR DESCRIPTION
## Summary
- Fix `getRecord`, `listRecords`, and `describeRepo` returning 404 for foreign DIDs
- Use middleware pattern (like `resolveHandle`) to handle local DIDs directly and proxy foreign DIDs to AppView
- Add tests verifying proxy behavior for all three endpoints

## Test plan
- [x] Unit tests pass (177 tests)
- [x] New tests verify foreign DID requests are proxied to api.bsky.app
- Manual verification: `https://pds.mk.gg/xrpc/com.atproto.repo.getRecord?collection=app.bsky.feed.post&repo=did:web:pds.ravingones.com&rkey=3mbm4goi57c2x` should return the record instead of 404