### PR TITLE
fix(oauth): correct response_mode default and add userinfo endpoint

### DIFF
--- a/.changeset/calm-shirts-serve.md
+++ b/.changeset/calm-shirts-serve.md
@@ -1,0 +1,7 @@
+---
+"@getcirrus/pds": patch
+---
+
+Add /oauth/userinfo endpoint
+
+Returns the user's DID (sub) and handle (preferred_username) for OpenID Connect compatibility.

--- a/.changeset/private-key-jwt.md
+++ b/.changeset/private-key-jwt.md
@@ -1,0 +1,11 @@
+---
+"@getcirrus/oauth-provider": minor
+---
+
+Add private_key_jwt client authentication and fix response_mode default
+
+- Implement RFC 7523 JWT Bearer client authentication for confidential OAuth clients
+- Add `private_key_jwt` to `token_endpoint_auth_methods_supported` in metadata
+- Support inline JWKS and remote JWKS URI for client public keys
+- Fix default `response_mode` from `fragment` to `query` for authorization code flow
+- Add `userinfo_endpoint` to OAuth server metadata

--- a/packages/oauth-provider/src/client-auth.ts
+++ b/packages/oauth-provider/src/client-auth.ts
@@ -1,0 +1,241 @@
+/**
+ * Client authentication for confidential clients using private_key_jwt
+ * Implements RFC 7523 (JWT Bearer Client Authentication)
+ */
+
+import { jwtVerify, createRemoteJWKSet, importJWK, errors } from "jose";
+import type { JWTPayload } from "jose";
+import type { ClientMetadata, JWK } from "./storage.js";
+
+const { JOSEError } = errors;
+
+/** Expected assertion type for private_key_jwt */
+export const JWT_BEARER_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+
+/**
+ * Client authentication error
+ */
+export class ClientAuthError extends Error {
+	constructor(
+		message: string,
+		public readonly code: string
+	) {
+		super(message);
+		this.name = "ClientAuthError";
+	}
+}
+
+/**
+ * Result of client authentication
+ */
+export interface ClientAuthResult {
+	/** Whether client authentication was performed */
+	authenticated: boolean;
+	/** The client ID from the assertion (if authenticated) */
+	clientId?: string;
+}
+
+/**
+ * Options for client authentication
+ */
+export interface ClientAuthOptions {
+	/** Token endpoint URL (for audience validation) */
+	tokenEndpoint: string;
+	/** Fetch function for fetching remote JWKS (for testing) */
+	fetch?: typeof globalThis.fetch;
+	/** Check if a JTI has been used (for replay prevention) */
+	checkJti?: (jti: string) => Promise<boolean>;
+}
+
+/**
+ * Parse client assertion from request parameters
+ */
+export function parseClientAssertion(params: Record<string, string>): {
+	assertionType?: string;
+	assertion?: string;
+} {
+	return {
+		assertionType: params.client_assertion_type,
+		assertion: params.client_assertion,
+	};
+}
+
+/**
+ * Verify a client assertion JWT
+ * @param assertion The JWT assertion
+ * @param client The client metadata (with JWKS)
+ * @param options Verification options
+ * @returns The verified JWT payload
+ * @throws ClientAuthError if verification fails
+ */
+export async function verifyClientAssertion(
+	assertion: string,
+	client: ClientMetadata,
+	options: ClientAuthOptions
+): Promise<JWTPayload> {
+	const { tokenEndpoint, fetch: fetchFn = globalThis.fetch.bind(globalThis), checkJti } = options;
+
+	// Get the key resolver
+	let keyResolver: Parameters<typeof jwtVerify>[1];
+
+	if (client.jwks && client.jwks.keys.length > 0) {
+		// For inline JWKS, we need to find the right key based on the JWT header
+		keyResolver = async (header) => {
+			const keys = client.jwks!.keys;
+			// Find key by kid if present, otherwise use first key with matching alg
+			let key: JWK | undefined;
+			if (header.kid) {
+				key = keys.find((k) => k.kid === header.kid);
+			}
+			if (!key) {
+				key = keys.find((k) => !k.alg || k.alg === header.alg);
+			}
+			if (!key) {
+				key = keys[0];
+			}
+			if (!key) {
+				throw new ClientAuthError("No suitable key found in client JWKS", "invalid_client");
+			}
+			// Pass the algorithm from the header when the JWK doesn't have one
+			const alg = key.alg ?? header.alg;
+			return importJWK(key as Parameters<typeof importJWK>[0], alg);
+		};
+	} else if (client.jwksUri) {
+		// Use remote JWKS
+		keyResolver = createRemoteJWKSet(new URL(client.jwksUri), {
+			[Symbol.for("fetch")]: fetchFn,
+		});
+	} else {
+		throw new ClientAuthError("Client has no JWKS configured", "invalid_client");
+	}
+
+	let payload: JWTPayload;
+	try {
+		const result = await jwtVerify(assertion, keyResolver, {
+			algorithms: ["ES256"], // ATProto requires ES256
+			clockTolerance: 30, // 30 seconds clock skew tolerance
+			maxTokenAge: "5m", // JWTs should be short-lived
+		});
+		payload = result.payload;
+	} catch (err) {
+		if (err instanceof JOSEError) {
+			throw new ClientAuthError(`JWT verification failed: ${err.message}`, "invalid_client");
+		}
+		throw new ClientAuthError(
+			`JWT verification failed: ${err instanceof Error ? err.message : String(err)}`,
+			"invalid_client"
+		);
+	}
+
+	// Validate required claims per RFC 7523
+
+	// iss (issuer) must equal client_id
+	if (payload.iss !== client.clientId) {
+		throw new ClientAuthError(
+			`JWT issuer mismatch: expected ${client.clientId}, got ${payload.iss}`,
+			"invalid_client"
+		);
+	}
+
+	// sub (subject) must equal client_id
+	if (payload.sub !== client.clientId) {
+		throw new ClientAuthError(
+			`JWT subject mismatch: expected ${client.clientId}, got ${payload.sub}`,
+			"invalid_client"
+		);
+	}
+
+	// aud (audience) must include the token endpoint
+	const aud = Array.isArray(payload.aud) ? payload.aud : payload.aud ? [payload.aud] : [];
+	if (!aud.includes(tokenEndpoint)) {
+		throw new ClientAuthError(
+			`JWT audience must include token endpoint: ${tokenEndpoint}`,
+			"invalid_client"
+		);
+	}
+
+	// jti (JWT ID) must be present and unique
+	if (!payload.jti) {
+		throw new ClientAuthError("JWT must include jti claim", "invalid_client");
+	}
+
+	// Check jti for replay prevention if callback provided
+	if (checkJti) {
+		const isUnique = await checkJti(payload.jti);
+		if (!isUnique) {
+			throw new ClientAuthError("JWT has already been used (replay detected)", "invalid_client");
+		}
+	}
+
+	// iat (issued at) must be present (verified by jose maxTokenAge)
+	if (!payload.iat) {
+		throw new ClientAuthError("JWT must include iat claim", "invalid_client");
+	}
+
+	return payload;
+}
+
+/**
+ * Authenticate a client from request parameters
+ * @param params Request parameters containing client_id, client_assertion_type, client_assertion
+ * @param getClient Function to resolve client metadata
+ * @param options Authentication options
+ * @returns Authentication result
+ * @throws ClientAuthError if authentication fails
+ */
+export async function authenticateClient(
+	params: Record<string, string>,
+	getClient: (clientId: string) => Promise<ClientMetadata | null>,
+	options: ClientAuthOptions
+): Promise<ClientAuthResult> {
+	const clientId = params.client_id;
+	if (!clientId) {
+		throw new ClientAuthError("Missing client_id", "invalid_request");
+	}
+
+	const { assertionType, assertion } = parseClientAssertion(params);
+
+	// Resolve client metadata
+	const client = await getClient(clientId);
+	if (!client) {
+		throw new ClientAuthError(`Unknown client: ${clientId}`, "invalid_client");
+	}
+
+	const authMethod = client.tokenEndpointAuthMethod ?? "none";
+
+	// Public client (no authentication required)
+	if (authMethod === "none") {
+		// If assertion is provided for public client, that's an error
+		if (assertion || assertionType) {
+			throw new ClientAuthError(
+				"Client assertion not expected for public client",
+				"invalid_request"
+			);
+		}
+		return { authenticated: false, clientId };
+	}
+
+	// Confidential client (private_key_jwt required)
+	if (authMethod === "private_key_jwt") {
+		if (!assertionType || !assertion) {
+			throw new ClientAuthError(
+				"Client assertion required for confidential client",
+				"invalid_client"
+			);
+		}
+
+		if (assertionType !== JWT_BEARER_ASSERTION_TYPE) {
+			throw new ClientAuthError(
+				`Unsupported assertion type: ${assertionType}. Expected: ${JWT_BEARER_ASSERTION_TYPE}`,
+				"invalid_client"
+			);
+		}
+
+		// Verify the JWT assertion
+		await verifyClientAssertion(assertion, client, options);
+
+		return { authenticated: true, clientId };
+	}
+
+	throw new ClientAuthError(`Unsupported auth method: ${authMethod}`, "invalid_client");
+}

--- a/packages/oauth-provider/src/client-resolver.ts
+++ b/packages/oauth-provider/src/client-resolver.ts
@@ -8,7 +8,7 @@ import {
 	oauthClientMetadataSchema,
 	type OAuthClientMetadata,
 } from "@atproto/oauth-types";
-import type { ClientMetadata, OAuthStorage } from "./storage.js";
+import type { ClientMetadata, OAuthStorage, JWK } from "./storage.js";
 
 export type { OAuthClientMetadata };
 
@@ -174,6 +174,9 @@ export class ClientResolver {
 			redirectUris: doc.redirect_uris,
 			logoUri: doc.logo_uri,
 			clientUri: doc.client_uri,
+			tokenEndpointAuthMethod: (doc.token_endpoint_auth_method as "none" | "private_key_jwt") ?? "none",
+			jwks: doc.jwks as { keys: JWK[] } | undefined,
+			jwksUri: doc.jwks_uri,
 			cachedAt: Date.now(),
 		};
 

--- a/packages/oauth-provider/src/index.ts
+++ b/packages/oauth-provider/src/index.ts
@@ -15,6 +15,7 @@ export type {
 	TokenData,
 	ClientMetadata,
 	PARData,
+	JWK,
 } from "./storage.js";
 
 // PKCE
@@ -50,3 +51,13 @@ export type { GeneratedTokens, GenerateTokensOptions } from "./tokens.js";
 // UI
 export { renderConsentUI, renderErrorPage, CONSENT_UI_CSP } from "./ui.js";
 export type { ConsentUIOptions } from "./ui.js";
+
+// Client authentication
+export {
+	authenticateClient,
+	verifyClientAssertion,
+	parseClientAssertion,
+	ClientAuthError,
+	JWT_BEARER_ASSERTION_TYPE,
+} from "./client-auth.js";
+export type { ClientAuthResult, ClientAuthOptions } from "./client-auth.js";

--- a/packages/oauth-provider/src/storage.ts
+++ b/packages/oauth-provider/src/storage.ts
@@ -48,6 +48,24 @@ export interface TokenData {
 }
 
 /**
+ * JSON Web Key for client authentication
+ */
+export interface JWK {
+	kty: string;
+	use?: string;
+	key_ops?: string[];
+	alg?: string;
+	kid?: string;
+	// EC key parameters
+	crv?: string;
+	x?: string;
+	y?: string;
+	// RSA key parameters (not used for ATProto but included for completeness)
+	n?: string;
+	e?: string;
+}
+
+/**
  * OAuth client metadata (discovered from DID document)
  */
 export interface ClientMetadata {
@@ -61,6 +79,12 @@ export interface ClientMetadata {
 	logoUri?: string;
 	/** Client homepage URI (optional) */
 	clientUri?: string;
+	/** Token endpoint auth method ("none" for public, "private_key_jwt" for confidential) */
+	tokenEndpointAuthMethod?: "none" | "private_key_jwt";
+	/** JSON Web Key Set for confidential client authentication */
+	jwks?: { keys: JWK[] };
+	/** URI to fetch JWKS from (alternative to inline jwks) */
+	jwksUri?: string;
 	/** When the metadata was cached (Unix ms) */
 	cachedAt?: number;
 }

--- a/packages/oauth-provider/test/client-auth.test.ts
+++ b/packages/oauth-provider/test/client-auth.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+	authenticateClient,
+	verifyClientAssertion,
+	parseClientAssertion,
+	ClientAuthError,
+	JWT_BEARER_ASSERTION_TYPE,
+} from "../src/client-auth.js";
+import type { ClientMetadata, JWK } from "../src/storage.js";
+import { generateClientKeyPair, createClientAssertion } from "./helpers.js";
+
+describe("Client Authentication", () => {
+	const tokenEndpoint = "https://pds.example.com/oauth/token";
+	const usedNonces = new Set<string>();
+
+	function checkJti(jti: string): Promise<boolean> {
+		if (usedNonces.has(jti)) {
+			return Promise.resolve(false);
+		}
+		usedNonces.add(jti);
+		return Promise.resolve(true);
+	}
+
+	beforeEach(() => {
+		usedNonces.clear();
+	});
+
+	describe("parseClientAssertion", () => {
+		it("extracts assertion type and assertion from params", () => {
+			const params = {
+				client_assertion_type: JWT_BEARER_ASSERTION_TYPE,
+				client_assertion: "test.jwt.token",
+			};
+
+			const result = parseClientAssertion(params);
+
+			expect(result.assertionType).toBe(JWT_BEARER_ASSERTION_TYPE);
+			expect(result.assertion).toBe("test.jwt.token");
+		});
+
+		it("returns undefined for missing fields", () => {
+			const result = parseClientAssertion({});
+
+			expect(result.assertionType).toBeUndefined();
+			expect(result.assertion).toBeUndefined();
+		});
+	});
+
+	describe("verifyClientAssertion", () => {
+		let clientKeyPair: Awaited<ReturnType<typeof generateClientKeyPair>>;
+		let confidentialClient: ClientMetadata;
+
+		beforeEach(async () => {
+			clientKeyPair = await generateClientKeyPair("ES256", "key-1");
+			confidentialClient = {
+				clientId: "did:web:confidential-client.example.com",
+				clientName: "Confidential Client",
+				redirectUris: ["https://confidential-client.example.com/callback"],
+				tokenEndpointAuthMethod: "private_key_jwt",
+				jwks: {
+					keys: [clientKeyPair.publicJwk as JWK],
+				},
+			};
+		});
+
+		it("verifies a valid client assertion", async () => {
+			const assertion = await createClientAssertion(
+				clientKeyPair.privateKey,
+				{
+					iss: confidentialClient.clientId,
+					sub: confidentialClient.clientId,
+					aud: tokenEndpoint,
+				},
+				clientKeyPair.publicJwk
+			);
+
+			const payload = await verifyClientAssertion(assertion, confidentialClient, {
+				tokenEndpoint,
+				checkJti,
+			});
+
+			expect(payload.iss).toBe(confidentialClient.clientId);
+			expect(payload.sub).toBe(confidentialClient.clientId);
+		});
+
+		it("rejects assertion with wrong issuer", async () => {
+			const assertion = await createClientAssertion(
+				clientKeyPair.privateKey,
+				{
+					iss: "did:web:wrong-issuer.example.com",
+					sub: confidentialClient.clientId,
+					aud: tokenEndpoint,
+				},
+				clientKeyPair.publicJwk
+			);
+
+			await expect(
+				verifyClientAssertion(assertion, confidentialClient, {
+					tokenEndpoint,
+					checkJti,
+				})
+			).rejects.toThrow(ClientAuthError);
+		});
+
+		it("rejects assertion with wrong subject", async () => {
+			const assertion = await createClientAssertion(
+				clientKeyPair.privateKey,
+				{
+					iss: confidentialClient.clientId,
+					sub: "did:web:wrong-subject.example.com",
+					aud: tokenEndpoint,
+				},
+				clientKeyPair.publicJwk
+			);
+
+			await expect(
+				verifyClientAssertion(assertion, confidentialClient, {
+					tokenEndpoint,
+					checkJti,
+				})
+			).rejects.toThrow(ClientAuthError);
+		});
+
+		it("rejects assertion with wrong audience", async () => {
+			const assertion = await createClientAssertion(
+				clientKeyPair.privateKey,
+				{
+					iss: confidentialClient.clientId,
+					sub: confidentialClient.clientId,
+					aud: "https://wrong-endpoint.example.com/oauth/token",
+				},
+				clientKeyPair.publicJwk
+			);
+
+			await expect(
+				verifyClientAssertion(assertion, confidentialClient, {
+					tokenEndpoint,
+					checkJti,
+				})
+			).rejects.toThrow(ClientAuthError);
+		});
+
+		it("accepts audience as array containing token endpoint", async () => {
+			const assertion = await createClientAssertion(
+				clientKeyPair.privateKey,
+				{
+					iss: confidentialClient.clientId,
+					sub: confidentialClient.clientId,
+					aud: [tokenEndpoint, "https://other.example.com"],
+				},
+				clientKeyPair.publicJwk
+			);
+
+			const payload = await verifyClientAssertion(assertion, confidentialClient, {
+				tokenEndpoint,
+				checkJti,
+			});
+
+			expect(payload.iss).toBe(confidentialClient.clientId);
+		});
+
+		it("rejects replayed assertions (same jti)", async () => {
+			const jti = "unique-jti-12345";
+
+			const assertion = await createClientAssertion(
+				clientKeyPair.privateKey,
+				{
+					iss: confidentialClient.clientId,
+					sub: confidentialClient.clientId,
+					aud: tokenEndpoint,
+					jti,
+				},
+				clientKeyPair.publicJwk
+			);
+
+			// First use should succeed
+			await verifyClientAssertion(assertion, confidentialClient, {
+				tokenEndpoint,
+				checkJti,
+			});
+
+			// Second use should fail (replay)
+			await expect(
+				verifyClientAssertion(assertion, confidentialClient, {
+					tokenEndpoint,
+					checkJti,
+				})
+			).rejects.toThrow(/replay/i);
+		});
+
+		it("rejects assertion signed with wrong key", async () => {
+			const wrongKeyPair = await generateClientKeyPair("ES256");
+
+			const assertion = await createClientAssertion(
+				wrongKeyPair.privateKey,
+				{
+					iss: confidentialClient.clientId,
+					sub: confidentialClient.clientId,
+					aud: tokenEndpoint,
+				},
+				wrongKeyPair.publicJwk
+			);
+
+			await expect(
+				verifyClientAssertion(assertion, confidentialClient, {
+					tokenEndpoint,
+					checkJti,
+				})
+			).rejects.toThrow(ClientAuthError);
+		});
+
+		it("rejects client with no JWKS", async () => {
+			const clientWithoutJwks: ClientMetadata = {
+				...confidentialClient,
+				jwks: undefined,
+				jwksUri: undefined,
+			};
+
+			const assertion = await createClientAssertion(
+				clientKeyPair.privateKey,
+				{
+					iss: clientWithoutJwks.clientId,
+					sub: clientWithoutJwks.clientId,
+					aud: tokenEndpoint,
+				},
+				clientKeyPair.publicJwk
+			);
+
+			await expect(
+				verifyClientAssertion(assertion, clientWithoutJwks, {
+					tokenEndpoint,
+					checkJti,
+				})
+			).rejects.toThrow(/JWKS/i);
+		});
+	});
+
+	describe("authenticateClient", () => {
+		let clientKeyPair: Awaited<ReturnType<typeof generateClientKeyPair>>;
+		let publicClient: ClientMetadata;
+		let confidentialClient: ClientMetadata;
+
+		beforeEach(async () => {
+			clientKeyPair = await generateClientKeyPair("ES256", "key-1");
+
+			publicClient = {
+				clientId: "did:web:public-client.example.com",
+				clientName: "Public Client",
+				redirectUris: ["https://public-client.example.com/callback"],
+				tokenEndpointAuthMethod: "none",
+			};
+
+			confidentialClient = {
+				clientId: "did:web:confidential-client.example.com",
+				clientName: "Confidential Client",
+				redirectUris: ["https://confidential-client.example.com/callback"],
+				tokenEndpointAuthMethod: "private_key_jwt",
+				jwks: {
+					keys: [clientKeyPair.publicJwk as JWK],
+				},
+			};
+		});
+
+		async function getClient(clientId: string): Promise<ClientMetadata | null> {
+			if (clientId === publicClient.clientId) return publicClient;
+			if (clientId === confidentialClient.clientId) return confidentialClient;
+			return null;
+		}
+
+		it("allows public client without assertion", async () => {
+			const result = await authenticateClient(
+				{ client_id: publicClient.clientId },
+				getClient,
+				{ tokenEndpoint, checkJti }
+			);
+
+			expect(result.authenticated).toBe(false);
+			expect(result.clientId).toBe(publicClient.clientId);
+		});
+
+		it("rejects public client with assertion", async () => {
+			const assertion = await createClientAssertion(
+				clientKeyPair.privateKey,
+				{
+					iss: publicClient.clientId,
+					sub: publicClient.clientId,
+					aud: tokenEndpoint,
+				},
+				clientKeyPair.publicJwk
+			);
+
+			await expect(
+				authenticateClient(
+					{
+						client_id: publicClient.clientId,
+						client_assertion_type: JWT_BEARER_ASSERTION_TYPE,
+						client_assertion: assertion,
+					},
+					getClient,
+					{ tokenEndpoint, checkJti }
+				)
+			).rejects.toThrow(/not expected/i);
+		});
+
+		it("requires assertion for confidential client", async () => {
+			await expect(
+				authenticateClient(
+					{ client_id: confidentialClient.clientId },
+					getClient,
+					{ tokenEndpoint, checkJti }
+				)
+			).rejects.toThrow(/required/i);
+		});
+
+		it("authenticates confidential client with valid assertion", async () => {
+			const assertion = await createClientAssertion(
+				clientKeyPair.privateKey,
+				{
+					iss: confidentialClient.clientId,
+					sub: confidentialClient.clientId,
+					aud: tokenEndpoint,
+				},
+				clientKeyPair.publicJwk
+			);
+
+			const result = await authenticateClient(
+				{
+					client_id: confidentialClient.clientId,
+					client_assertion_type: JWT_BEARER_ASSERTION_TYPE,
+					client_assertion: assertion,
+				},
+				getClient,
+				{ tokenEndpoint, checkJti }
+			);
+
+			expect(result.authenticated).toBe(true);
+			expect(result.clientId).toBe(confidentialClient.clientId);
+		});
+
+		it("rejects unknown assertion type", async () => {
+			const assertion = await createClientAssertion(
+				clientKeyPair.privateKey,
+				{
+					iss: confidentialClient.clientId,
+					sub: confidentialClient.clientId,
+					aud: tokenEndpoint,
+				},
+				clientKeyPair.publicJwk
+			);
+
+			await expect(
+				authenticateClient(
+					{
+						client_id: confidentialClient.clientId,
+						client_assertion_type: "wrong:assertion:type",
+						client_assertion: assertion,
+					},
+					getClient,
+					{ tokenEndpoint, checkJti }
+				)
+			).rejects.toThrow(/Unsupported assertion type/i);
+		});
+
+		it("rejects unknown client", async () => {
+			await expect(
+				authenticateClient(
+					{ client_id: "did:web:unknown.example.com" },
+					getClient,
+					{ tokenEndpoint, checkJti }
+				)
+			).rejects.toThrow(/Unknown client/i);
+		});
+
+		it("requires client_id", async () => {
+			await expect(
+				authenticateClient({}, getClient, { tokenEndpoint, checkJti })
+			).rejects.toThrow(/Missing client_id/i);
+		});
+	});
+});

--- a/packages/oauth-provider/test/oauth-flow.test.ts
+++ b/packages/oauth-provider/test/oauth-flow.test.ts
@@ -107,12 +107,11 @@ describe("OAuth Flow", () => {
 			const location = response.headers.get("Location");
 			expect(location).toBeDefined();
 
-			// Default response_mode is fragment, so check hash
+			// Default response_mode is query for authorization code flow
 			const redirectUrl = new URL(location!);
-			const hashParams = new URLSearchParams(redirectUrl.hash.slice(1));
-			expect(hashParams.has("code")).toBe(true);
-			expect(hashParams.get("state")).toBe("test-state");
-			expect(hashParams.get("iss")).toBe("https://pds.example.com");
+			expect(redirectUrl.searchParams.has("code")).toBe(true);
+			expect(redirectUrl.searchParams.get("state")).toBe("test-state");
+			expect(redirectUrl.searchParams.get("iss")).toBe("https://pds.example.com");
 		});
 
 		it("redirects with error after consent denial", async () => {
@@ -140,9 +139,8 @@ describe("OAuth Flow", () => {
 			expect(response.status).toBe(302);
 			const location = response.headers.get("Location");
 			const redirectUrl = new URL(location!);
-			// Default response_mode is fragment
-			const hashParams = new URLSearchParams(redirectUrl.hash.slice(1));
-			expect(hashParams.get("error")).toBe("access_denied");
+			// Default response_mode is query for authorization code flow
+			expect(redirectUrl.searchParams.get("error")).toBe("access_denied");
 		});
 	});
 
@@ -171,9 +169,8 @@ describe("OAuth Flow", () => {
 			const response = await provider.handleAuthorize(request);
 			const location = response.headers.get("Location")!;
 			const redirectUrl = new URL(location);
-			// Default response_mode is fragment
-			const hashParams = new URLSearchParams(redirectUrl.hash.slice(1));
-			const code = hashParams.get("code")!;
+			// Default response_mode is query for authorization code flow
+			const code = redirectUrl.searchParams.get("code")!;
 
 			return { code, challenge };
 		}
@@ -421,8 +418,8 @@ describe("OAuth Flow", () => {
 			});
 			const authResponse = await provider.handleAuthorize(authRequest);
 			const location = authResponse.headers.get("Location")!;
-			const hashParams = new URLSearchParams(new URL(location).hash.slice(1));
-			const code = hashParams.get("code")!;
+			const redirectUrl = new URL(location);
+			const code = redirectUrl.searchParams.get("code")!;
 
 			const dpopProof1 = await createDpopProof(
 				keyPair.privateKey,
@@ -507,8 +504,8 @@ describe("OAuth Flow", () => {
 			});
 			const authResponse = await provider.handleAuthorize(authRequest);
 			const location = authResponse.headers.get("Location")!;
-			const hashParams = new URLSearchParams(new URL(location).hash.slice(1));
-			const code = hashParams.get("code")!;
+			const redirectUrl = new URL(location);
+			const code = redirectUrl.searchParams.get("code")!;
 
 			const dpopProof1 = await createDpopProof(
 				keyPair1.privateKey,

--- a/packages/pds/src/oauth.ts
+++ b/packages/pds/src/oauth.ts
@@ -178,6 +178,27 @@ export function createOAuthApp(
 		return provider.handlePAR(c.req.raw);
 	});
 
+	// UserInfo endpoint (OpenID Connect)
+	// Returns user claims for the authenticated user
+	oauth.get("/oauth/userinfo", async (c) => {
+		const provider = getProvider(c.env);
+		const tokenData = await provider.verifyAccessToken(c.req.raw);
+
+		if (!tokenData) {
+			return c.json(
+				{ error: "invalid_token", error_description: "Invalid or expired token" },
+				401,
+			);
+		}
+
+		// Return OpenID Connect userinfo response
+		// sub is required, we also include preferred_username (handle)
+		return c.json({
+			sub: tokenData.sub,
+			preferred_username: c.env.HANDLE,
+		});
+	});
+
 	// Token revocation endpoint
 	oauth.post("/oauth/revoke", async (c) => {
 		// Parse the token from the request


### PR DESCRIPTION
## Summary

Fixes #73 - Login denied on pckt.blog

- **Fix `response_mode` default**: Changed from `fragment` to `query` for authorization code flow per RFC 6749. Server-side apps can now receive the authorization code in the query string (`?code=...`) instead of the URL fragment (`#code=...`).

- **Add `/oauth/userinfo` endpoint**: Returns the user's DID (`sub`) and handle (`preferred_username`) for OpenID Connect compatibility. This endpoint is required by some OAuth clients after token exchange.

- **Add `private_key_jwt` client authentication**: Implements RFC 7523 JWT Bearer client authentication for confidential OAuth clients, with inline JWKS and remote JWKS URI support.

## Test plan

- [x] All existing OAuth tests pass (66 tests)
- [x] New client-auth tests pass (17 tests)
- [x] Tested login flow with pckt.blog - successful authentication
- [x] Verified tokens are issued and userinfo endpoint returns correct data