### PR TITLE
fix: reduce access token lifetime from 2h to 15m

### DIFF
--- a/packages/pds/src/session.ts
+++ b/packages/pds/src/session.ts
@@ -1,7 +1,9 @@
 import { SignJWT, jwtVerify, type JWTPayload } from "jose";
 import { compare } from "bcryptjs";
 
-const ACCESS_TOKEN_LIFETIME = "2h";
+// Match official PDS: 15 minutes for access tokens (spec allows 1-5 min, max 1 hour)
+// Short lifetime forces regular refresh, keeping sessions active in the app
+const ACCESS_TOKEN_LIFETIME = "15m";
 const REFRESH_TOKEN_LIFETIME = "90d";
 
 /**


### PR DESCRIPTION
Reduces access token lifetime from 2 hours to 15 minutes to match
the official Bluesky PDS implementation and AT Protocol spec.

The AT Protocol OAuth spec states that access tokens should have
1-5 minute lifetime (max 1 hour), with the reference implementation
using 15 minutes. Short-lived tokens force regular refresh cycles,
which keeps sessions fresh and prevents the auth loss issue where
the Bluesky app would lose authentication and require account
switching to recover.

This aligns with the official PDS behavior and ensures proper
session management in both the Bluesky app and web interface.

Fixes authentication loss issue where requests would fail until
reloading the page or switching accounts.