### PR TITLE
feat(pds): implement com.atproto.sync.getRecord endpoint

### DIFF
--- a/.changeset/sync-get-record.md
+++ b/.changeset/sync-get-record.md
@@ -1,0 +1,7 @@
+---
+"@getcirrus/pds": minor
+---
+
+feat: implement com.atproto.sync.getRecord endpoint
+
+Add support for the `com.atproto.sync.getRecord` endpoint, which returns a CAR file containing the commit block and all MST blocks needed to prove the existence (or non-existence) of a record. This enables tools like pdsls to verify record signatures.

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -202,6 +202,9 @@ app.get("/xrpc/com.atproto.sync.listRepos", (c) =>
 app.get("/xrpc/com.atproto.sync.listBlobs", (c) =>
 	sync.listBlobs(c, getAccountDO(c.env)),
 );
+app.get("/xrpc/com.atproto.sync.getRecord", (c) =>
+	sync.getRecord(c, getAccountDO(c.env)),
+);
 
 // WebSocket firehose
 app.get("/xrpc/com.atproto.sync.subscribeRepos", async (c) => {


### PR DESCRIPTION
Add support for the com.atproto.sync.getRecord endpoint which returns a CAR file containing the proof blocks needed to verify record existence or non-existence in the repository.

Implementation:
- Add rpcGetRecordProof method to AccountDurableObject using @atproto/repo's getRecords function
- Add getRecord handler in sync.ts with parameter validation
- Wire up endpoint in index.ts
- Add comprehensive tests for the endpoint

This enables tools like pdsls to verify record signatures against the repository's Merkle tree.