### PR TITLE
fix(pds): response payload of `checkAccountStatus`

### DIFF
--- a/.changeset/check-account-status-private-state.md
+++ b/.changeset/check-account-status-private-state.md
@@ -1,0 +1,5 @@
+---
+"@getcirrus/pds": patch
+---
+
+Fix `com.atproto.server.checkAccountStatus` response to be lexicon-compliant: `privateStateValues` is a required `integer` (not nullable), so return `0` instead of `null` in both the activated and not-activated branches.

--- a/packages/pds/src/xrpc/server.ts
+++ b/packages/pds/src/xrpc/server.ts
@@ -355,7 +355,7 @@ export async function checkAccountStatus(
 			repoRev: status.rev,
 			repoBlocks,
 			indexedRecords,
-			privateStateValues: null,
+			privateStateValues: 0,
 			expectedBlobs,
 			importedBlobs,
 		});
@@ -369,7 +369,7 @@ export async function checkAccountStatus(
 			repoRev: null,
 			repoBlocks: 0,
 			indexedRecords: 0,
-			privateStateValues: null,
+			privateStateValues: 0,
 			expectedBlobs: 0,
 			importedBlobs: 0,
 		});


### PR DESCRIPTION
The lexicon for `com.atproto.server.checkAccountStatus` requires `privateStateValues` to be an integer (`null` is not valid here).

https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/server/checkAccountStatus.json#L30

I believe this is the cause of #150.