### PR TITLE
Fix Two OAuth token refresh bugs

### DIFF
--- a/.changeset/oauth-refresh-token-fixes.md
+++ b/.changeset/oauth-refresh-token-fixes.md
@@ -1,0 +1,9 @@
+---
+"@getcirrus/oauth-provider": patch
+"@getcirrus/pds": patch
+---
+
+Fix two OAuth token refresh bugs that prevented spec-compliant clients (e.g. tangled.org via indigo) from refreshing their session after the access token expired.
+
+- Track access and refresh expiry separately on `TokenData` (`accessExpiresAt` / `refreshExpiresAt`) instead of a single `expiresAt`. `cleanup()` now prunes by `refreshExpiresAt`, so a row isn't deleted while its refresh token is still valid. The PDS SQLite store migrates legacy `oauth_tokens` rows in place, deriving `refresh_expires_at` as `MAX(expires_at, issued_at + REFRESH_TOKEN_TTL)`.
+- The PDS auth middleware now sends `WWW-Authenticate: DPoP error="invalid_token"` on 401 responses for invalid/expired OAuth access tokens, as required by the atproto XRPC spec. Clients that gate refresh on this header (indigo, and others) will now refresh automatically instead of staying logged-in-but-broken until the user signs out.

--- a/packages/oauth-provider/src/storage.ts
+++ b/packages/oauth-provider/src/storage.ts
@@ -41,8 +41,10 @@ export interface TokenData {
 	dpopJkt?: string;
 	/** Issuance timestamp (Unix ms) */
 	issuedAt: number;
-	/** Expiration timestamp (Unix ms) */
-	expiresAt: number;
+	/** Access token expiration timestamp (Unix ms) */
+	accessExpiresAt: number;
+	/** Refresh token expiration timestamp (Unix ms) */
+	refreshExpiresAt: number;
 	/** Whether the token has been revoked */
 	revoked?: boolean;
 }
@@ -258,7 +260,7 @@ export class InMemoryOAuthStorage implements OAuthStorage {
 	async getTokenByAccess(accessToken: string): Promise<TokenData | null> {
 		const data = this.tokens.get(accessToken);
 		if (!data) return null;
-		if (data.revoked || Date.now() > data.expiresAt) {
+		if (data.revoked || Date.now() > data.accessExpiresAt) {
 			return null;
 		}
 		return data;
@@ -269,8 +271,7 @@ export class InMemoryOAuthStorage implements OAuthStorage {
 		if (!accessToken) return null;
 		const data = this.tokens.get(accessToken);
 		if (!data) return null;
-		if (data.revoked) return null;
-		// Refresh tokens don't use accessToken expiresAt
+		if (data.revoked || Date.now() > data.refreshExpiresAt) return null;
 		return data;
 	}
 

--- a/packages/oauth-provider/src/tokens.ts
+++ b/packages/oauth-provider/src/tokens.ts
@@ -85,6 +85,7 @@ export function generateTokens(options: GenerateTokensOptions): {
 		scope,
 		dpopJkt,
 		accessTokenTtl = ACCESS_TOKEN_TTL,
+		refreshTokenTtl = REFRESH_TOKEN_TTL,
 	} = options;
 
 	const accessToken = generateRandomToken(32);
@@ -99,7 +100,8 @@ export function generateTokens(options: GenerateTokensOptions): {
 		scope,
 		dpopJkt,
 		issuedAt: now,
-		expiresAt: now + accessTokenTtl,
+		accessExpiresAt: now + accessTokenTtl,
+		refreshExpiresAt: now + refreshTokenTtl,
 		revoked: false,
 	};
 
@@ -120,12 +122,14 @@ export function generateTokens(options: GenerateTokensOptions): {
  * @param existingData The existing token data
  * @param rotateRefreshToken Whether to generate a new refresh token
  * @param accessTokenTtl Custom access token TTL in ms
+ * @param refreshTokenTtl Custom refresh token TTL in ms (used when rotating)
  * @returns Updated tokens and token data
  */
 export function refreshTokens(
 	existingData: TokenData,
 	rotateRefreshToken: boolean = false,
 	accessTokenTtl: number = ACCESS_TOKEN_TTL,
+	refreshTokenTtl: number = REFRESH_TOKEN_TTL,
 ): {
 	tokens: GeneratedTokens;
 	tokenData: TokenData;
@@ -141,7 +145,10 @@ export function refreshTokens(
 		accessToken,
 		refreshToken,
 		issuedAt: now,
-		expiresAt: now + accessTokenTtl,
+		accessExpiresAt: now + accessTokenTtl,
+		refreshExpiresAt: rotateRefreshToken
+			? now + refreshTokenTtl
+			: existingData.refreshExpiresAt,
 	};
 
 	const tokens: GeneratedTokens = {
@@ -214,7 +221,7 @@ export function isTokenValid(tokenData: TokenData): boolean {
 	if (tokenData.revoked) {
 		return false;
 	}
-	if (Date.now() > tokenData.expiresAt) {
+	if (Date.now() > tokenData.accessExpiresAt) {
 		return false;
 	}
 	return true;

--- a/packages/pds/src/middleware/auth.ts
+++ b/packages/pds/src/middleware/auth.ts
@@ -42,6 +42,10 @@ export async function requireAuth(
 					message: "Invalid OAuth access token",
 				},
 				401,
+				{
+					"WWW-Authenticate":
+						'DPoP error="invalid_token", error_description="Invalid access token"',
+				},
 			);
 		}
 

--- a/packages/pds/src/oauth-storage.ts
+++ b/packages/pds/src/oauth-storage.ts
@@ -1,9 +1,10 @@
-import type {
-	AuthCodeData,
-	ClientMetadata,
-	OAuthStorage,
-	PARData,
-	TokenData,
+import {
+	type AuthCodeData,
+	type ClientMetadata,
+	type OAuthStorage,
+	type PARData,
+	type TokenData,
+	REFRESH_TOKEN_TTL,
 } from "@getcirrus/oauth-provider";
 
 /**
@@ -41,13 +42,11 @@ export class SqliteOAuthStorage implements OAuthStorage {
 				scope TEXT NOT NULL,
 				dpop_jkt TEXT,
 				issued_at INTEGER NOT NULL,
-				expires_at INTEGER NOT NULL,
+				access_expires_at INTEGER NOT NULL,
+				refresh_expires_at INTEGER NOT NULL,
 				revoked INTEGER NOT NULL DEFAULT 0
 			);
 
-			CREATE INDEX IF NOT EXISTS idx_tokens_refresh ON oauth_tokens(refresh_token);
-			CREATE INDEX IF NOT EXISTS idx_tokens_sub ON oauth_tokens(sub);
-			CREATE INDEX IF NOT EXISTS idx_tokens_expires ON oauth_tokens(expires_at);
 
 			-- Cached client metadata
 			CREATE TABLE IF NOT EXISTS oauth_clients (
@@ -86,8 +85,10 @@ export class SqliteOAuthStorage implements OAuthStorage {
 			CREATE INDEX IF NOT EXISTS idx_challenges_created ON oauth_webauthn_challenges(created_at);
 		`);
 
-		// Migration: add columns for client auth metadata if missing
+		// Migrations for older OAuth schema versions
 		this.migrateClientTable();
+		this.migrateTokensTable();
+		this.ensureTokenIndexes();
 	}
 
 	private migrateClientTable(): void {
@@ -106,6 +107,67 @@ export class SqliteOAuthStorage implements OAuthStorage {
 		}
 	}
 
+	private migrateTokensTable(): void {
+		const columns = this.sql
+			.exec("PRAGMA table_info(oauth_tokens)")
+			.toArray()
+			.map((r) => r.name as string);
+
+		if (columns.length === 0) return;
+		if (
+			columns.includes("access_expires_at") &&
+			columns.includes("refresh_expires_at")
+		) {
+			return;
+		}
+
+		this.sql.exec(`
+			CREATE TABLE oauth_tokens_new (
+				access_token TEXT PRIMARY KEY,
+				refresh_token TEXT NOT NULL UNIQUE,
+				client_id TEXT NOT NULL,
+				sub TEXT NOT NULL,
+				scope TEXT NOT NULL,
+				dpop_jkt TEXT,
+				issued_at INTEGER NOT NULL,
+				access_expires_at INTEGER NOT NULL,
+				refresh_expires_at INTEGER NOT NULL,
+				revoked INTEGER NOT NULL DEFAULT 0
+			);
+		`);
+
+		this.sql.exec(
+			`INSERT INTO oauth_tokens_new (
+				access_token, refresh_token, client_id, sub, scope, dpop_jkt, issued_at, access_expires_at, refresh_expires_at, revoked
+			)
+			SELECT
+				access_token, refresh_token, client_id, sub, scope, dpop_jkt, issued_at,
+				expires_at AS access_expires_at,
+				MAX(expires_at, issued_at + ?) AS refresh_expires_at,
+				revoked
+			FROM oauth_tokens`,
+			REFRESH_TOKEN_TTL,
+		);
+
+		this.sql.exec("DROP TABLE oauth_tokens");
+		this.sql.exec("ALTER TABLE oauth_tokens_new RENAME TO oauth_tokens");
+	}
+
+	private ensureTokenIndexes(): void {
+		this.sql.exec(
+			"CREATE INDEX IF NOT EXISTS idx_tokens_refresh ON oauth_tokens(refresh_token)",
+		);
+		this.sql.exec(
+			"CREATE INDEX IF NOT EXISTS idx_tokens_sub ON oauth_tokens(sub)",
+		);
+		this.sql.exec(
+			"CREATE INDEX IF NOT EXISTS idx_tokens_access_expires ON oauth_tokens(access_expires_at)",
+		);
+		this.sql.exec(
+			"CREATE INDEX IF NOT EXISTS idx_tokens_refresh_expires ON oauth_tokens(refresh_expires_at)",
+		);
+	}
+
 	/**
 	 * Clean up expired entries. Should be called periodically.
 	 */
@@ -113,7 +175,7 @@ export class SqliteOAuthStorage implements OAuthStorage {
 		const now = Date.now();
 		this.sql.exec("DELETE FROM oauth_auth_codes WHERE expires_at < ?", now);
 		this.sql.exec(
-			"DELETE FROM oauth_tokens WHERE expires_at < ? AND revoked = 0",
+			"DELETE FROM oauth_tokens WHERE refresh_expires_at < ?",
 			now,
 		);
 		this.sql.exec("DELETE FROM oauth_par_requests WHERE expires_at < ?", now);
@@ -189,8 +251,8 @@ export class SqliteOAuthStorage implements OAuthStorage {
 	async saveTokens(data: TokenData): Promise<void> {
 		this.sql.exec(
 			`INSERT INTO oauth_tokens
-			(access_token, refresh_token, client_id, sub, scope, dpop_jkt, issued_at, expires_at, revoked)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			(access_token, refresh_token, client_id, sub, scope, dpop_jkt, issued_at, access_expires_at, refresh_expires_at, revoked)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			data.accessToken,
 			data.refreshToken,
 			data.clientId,
@@ -198,7 +260,8 @@ export class SqliteOAuthStorage implements OAuthStorage {
 			data.scope,
 			data.dpopJkt ?? null,
 			data.issuedAt,
-			data.expiresAt,
+			data.accessExpiresAt,
+			data.refreshExpiresAt,
 			data.revoked ? 1 : 0,
 		);
 	}
@@ -206,7 +269,7 @@ export class SqliteOAuthStorage implements OAuthStorage {
 	async getTokenByAccess(accessToken: string): Promise<TokenData | null> {
 		const rows = this.sql
 			.exec(
-				`SELECT access_token, refresh_token, client_id, sub, scope, dpop_jkt, issued_at, expires_at, revoked
+				`SELECT access_token, refresh_token, client_id, sub, scope, dpop_jkt, issued_at, access_expires_at, refresh_expires_at, revoked
 				FROM oauth_tokens WHERE access_token = ?`,
 				accessToken,
 			)
@@ -216,9 +279,9 @@ export class SqliteOAuthStorage implements OAuthStorage {
 
 		const row = rows[0]!;
 		const revoked = Boolean(row.revoked);
-		const expiresAt = row.expires_at as number;
+		const accessExpiresAt = row.access_expires_at as number;
 
-		if (revoked || Date.now() > expiresAt) {
+		if (revoked || Date.now() > accessExpiresAt) {
 			return null;
 		}
 
@@ -230,7 +293,8 @@ export class SqliteOAuthStorage implements OAuthStorage {
 			scope: row.scope as string,
 			dpopJkt: (row.dpop_jkt as string) ?? undefined,
 			issuedAt: row.issued_at as number,
-			expiresAt,
+			accessExpiresAt,
+			refreshExpiresAt: row.refresh_expires_at as number,
 			revoked,
 		};
 	}
@@ -238,7 +302,7 @@ export class SqliteOAuthStorage implements OAuthStorage {
 	async getTokenByRefresh(refreshToken: string): Promise<TokenData | null> {
 		const rows = this.sql
 			.exec(
-				`SELECT access_token, refresh_token, client_id, sub, scope, dpop_jkt, issued_at, expires_at, revoked
+				`SELECT access_token, refresh_token, client_id, sub, scope, dpop_jkt, issued_at, access_expires_at, refresh_expires_at, revoked
 				FROM oauth_tokens WHERE refresh_token = ?`,
 				refreshToken,
 			)
@@ -249,7 +313,9 @@ export class SqliteOAuthStorage implements OAuthStorage {
 		const row = rows[0]!;
 		const revoked = Boolean(row.revoked);
 
-		if (revoked) return null;
+		const refreshExpiresAt = row.refresh_expires_at as number;
+
+		if (revoked || Date.now() > refreshExpiresAt) return null;
 
 		return {
 			accessToken: row.access_token as string,
@@ -259,7 +325,8 @@ export class SqliteOAuthStorage implements OAuthStorage {
 			scope: row.scope as string,
 			dpopJkt: (row.dpop_jkt as string) ?? undefined,
 			issuedAt: row.issued_at as number,
-			expiresAt: row.expires_at as number,
+			accessExpiresAt: row.access_expires_at as number,
+			refreshExpiresAt,
 			revoked,
 		};
 	}

--- a/packages/pds/test/storage.test.ts
+++ b/packages/pds/test/storage.test.ts
@@ -5,6 +5,8 @@ import { encode, cidForCbor, type LexValue } from "@atproto/lex-cbor";
 import { BlockMap, CidSet } from "@atproto/repo";
 import { AccountDurableObject } from "../src/account-do";
 import { SqliteRepoStorage } from "../src/storage";
+import { SqliteOAuthStorage } from "../src/oauth-storage";
+import { REFRESH_TOKEN_TTL } from "@getcirrus/oauth-provider";
 
 // Helper to create a CID from data
 async function createCid(
@@ -329,6 +331,107 @@ describe("AccountDurableObject", () => {
 			const repo = await instance.getRepo();
 			expect(repo.cid.toString()).toBe(firstRepoCid);
 			expect(repo.did).toBe(env.DID);
+		});
+	});
+});
+
+
+describe("SqliteOAuthStorage", () => {
+	it("preserves refresh-valid tokens when access token has expired", async () => {
+		const id = env.ACCOUNT.newUniqueId();
+		const stub = env.ACCOUNT.get(id);
+
+		await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+			const oauthStorage = await instance.getOAuthStorage();
+			const now = Date.now();
+			const tokenData = {
+				accessToken: "expired-access-token",
+				refreshToken: "still-valid-refresh-token",
+				clientId: "did:web:app.example",
+				sub: env.DID,
+				scope: "atproto",
+				issuedAt: now - 2 * 60 * 60 * 1000,
+				accessExpiresAt: now - 60 * 1000,
+				refreshExpiresAt: now + 24 * 60 * 60 * 1000,
+				revoked: false,
+			};
+
+			await oauthStorage.saveTokens(tokenData);
+			oauthStorage.cleanup();
+
+			const tokenByRefresh = await oauthStorage.getTokenByRefresh(
+				tokenData.refreshToken,
+			);
+			expect(tokenByRefresh).not.toBeNull();
+			expect(tokenByRefresh?.refreshToken).toBe(tokenData.refreshToken);
+			expect(await oauthStorage.getTokenByAccess(tokenData.accessToken)).toBeNull();
+		});
+	});
+
+	it("migrates legacy oauth_tokens schema without failing on missing new columns", async () => {
+		const id = env.ACCOUNT.newUniqueId();
+		const stub = env.ACCOUNT.get(id);
+
+		await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+			const sql = (instance as unknown as { ctx: { storage: { sql: SqlStorage } } })
+				.ctx.storage.sql;
+			const now = Date.now();
+			const issuedAt = now - 2 * 60 * 60 * 1000;
+			const expiresAt = now - 60 * 1000;
+
+			sql.exec(`
+				CREATE TABLE oauth_tokens (
+					access_token TEXT PRIMARY KEY,
+					refresh_token TEXT NOT NULL UNIQUE,
+					client_id TEXT NOT NULL,
+					sub TEXT NOT NULL,
+					scope TEXT NOT NULL,
+					dpop_jkt TEXT,
+					issued_at INTEGER NOT NULL,
+					expires_at INTEGER NOT NULL,
+					revoked INTEGER NOT NULL DEFAULT 0
+				);
+			`);
+
+			sql.exec(
+				`INSERT INTO oauth_tokens
+				(access_token, refresh_token, client_id, sub, scope, dpop_jkt, issued_at, expires_at, revoked)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				"legacy-access",
+				"legacy-refresh",
+				"did:web:app.example",
+				env.DID,
+				"atproto",
+				null,
+				issuedAt,
+				expiresAt,
+				0,
+			);
+
+			const oauthStorage = new SqliteOAuthStorage(sql);
+			expect(() => oauthStorage.initSchema()).not.toThrow();
+
+			const columns = sql
+				.exec("PRAGMA table_info(oauth_tokens)")
+				.toArray()
+				.map((row) => row.name as string);
+
+			expect(columns).toContain("access_expires_at");
+			expect(columns).toContain("refresh_expires_at");
+			expect(columns).not.toContain("expires_at");
+
+			const migratedRow = sql
+				.exec(
+					`SELECT access_expires_at, refresh_expires_at FROM oauth_tokens WHERE access_token = ?`,
+					"legacy-access",
+				)
+				.one();
+
+			expect(migratedRow).toBeDefined();
+			expect(migratedRow.access_expires_at as number).toBe(expiresAt);
+			expect(migratedRow.refresh_expires_at as number).toBe(
+				Math.max(expiresAt, issuedAt + REFRESH_TOKEN_TTL),
+			);
 		});
 	});
 });

--- a/packages/pds/test/xrpc.test.ts
+++ b/packages/pds/test/xrpc.test.ts
@@ -1,6 +1,43 @@
 import { describe, it, expect } from "vitest";
 import { env, worker } from "./helpers";
+import {
+	SignJWT,
+	base64url,
+	calculateJwkThumbprint,
+	exportJWK,
+	generateKeyPair,
+} from "jose";
 
+
+async function createValidDpopProof(options: {
+	accessToken: string;
+	method: string;
+	url: string;
+}): Promise<{ dpopProof: string; dpopJkt: string }> {
+	const { accessToken, method, url } = options;
+	const { privateKey, publicKey } = await generateKeyPair("ES256");
+	const publicJwk = await exportJWK(publicKey);
+	delete publicJwk.key_ops;
+	delete publicJwk.ext;
+
+	const tokenHash = await crypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(accessToken),
+	);
+	const ath = base64url.encode(new Uint8Array(tokenHash));
+	const dpopProof = await new SignJWT({
+		jti: crypto.randomUUID(),
+		htm: method,
+		htu: url,
+		iat: Math.floor(Date.now() / 1000),
+		ath,
+	})
+		.setProtectedHeader({ typ: "dpop+jwt", alg: "ES256", jwk: publicJwk })
+		.sign(privateKey);
+	const dpopJkt = await calculateJwkThumbprint(publicJwk, "sha256");
+
+	return { dpopProof, dpopJkt };
+}
 describe("XRPC Endpoints", () => {
 	describe("Health Check", () => {
 		it("should return status and version", async () => {
@@ -105,6 +142,58 @@ describe("XRPC Endpoints", () => {
 			});
 		});
 
+
+		it("returns DPoP invalid_token challenge for expired OAuth access tokens", async () => {
+			const now = Date.now();
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+			const accessToken = "expired-dpop-access-token";
+			const requestUrl = "http://pds.test/xrpc/com.atproto.repo.createRecord";
+			const { dpopProof, dpopJkt } = await createValidDpopProof({
+				accessToken,
+				method: "POST",
+				url: requestUrl,
+			});
+
+			await stub.rpcSaveTokens({
+				accessToken,
+				refreshToken: "expired-dpop-refresh-token",
+				clientId: "did:web:app.example",
+				sub: env.DID,
+				scope: "atproto",
+				dpopJkt,
+				issuedAt: now - 2 * 60 * 60 * 1000,
+				expiresAt: now - 60 * 1000,
+				revoked: false,
+			});
+
+			const response = await worker.fetch(
+				new Request(requestUrl, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: `DPoP ${accessToken}`,
+						DPoP: dpopProof,
+					},
+					body: JSON.stringify({
+						repo: env.DID,
+						collection: "app.bsky.feed.post",
+						record: {
+							$type: "app.bsky.feed.post",
+							text: "Should fail with OAuth challenge",
+							createdAt: new Date().toISOString(),
+						},
+					}),
+				}),
+				env,
+			);
+
+			expect(response.status).toBe(401);
+			expect(response.headers.get("WWW-Authenticate")).toContain(
+				'error="invalid_token"',
+			);
+			expect(response.headers.get("WWW-Authenticate")).toContain("DPoP");
+		});
 		it("should accept request with valid token", async () => {
 			const response = await worker.fetch(
 				new Request("http://pds.test/xrpc/com.atproto.repo.createRecord", {

--- a/packages/pds/test/xrpc.test.ts
+++ b/packages/pds/test/xrpc.test.ts
@@ -163,7 +163,8 @@ describe("XRPC Endpoints", () => {
 				scope: "atproto",
 				dpopJkt,
 				issuedAt: now - 2 * 60 * 60 * 1000,
-				expiresAt: now - 60 * 1000,
+				accessExpiresAt: now - 60 * 1000,
+				refreshExpiresAt: now + 30 * 24 * 60 * 60 * 1000,
 				revoked: false,
 			});
 

--- a/plans/complete/oauth-provider.md
+++ b/plans/complete/oauth-provider.md
@@ -90,6 +90,7 @@ packages/pds/src/
 ## Post-Completion Updates
 
 - ✅ PDS auth middleware now returns DPoP `WWW-Authenticate` invalid_token challenges on 401 responses so OAuth clients can trigger automatic refresh.
+- ✅ OAuth token storage now uses separate access/refresh expiries, and cleanup prunes by refresh expiry so refresh remains possible after access expiry.
 
 ## OAuth Endpoints
 

--- a/plans/complete/oauth-provider.md
+++ b/plans/complete/oauth-provider.md
@@ -87,6 +87,10 @@ packages/pds/src/
    - Bearer tokens (session JWTs)
    - DPoP tokens (OAuth access tokens)
 
+## Post-Completion Updates
+
+- ✅ PDS auth middleware now returns DPoP `WWW-Authenticate` invalid_token challenges on 401 responses so OAuth clients can trigger automatic refresh.
+
 ## OAuth Endpoints
 
 | Endpoint                                  | Method | Description                               |


### PR DESCRIPTION
# The two bugs:

## The user-facing bug I observed

After I set up my PDS using cirrus, I logged into [tangled.org](https://tangled.org/) using OAuth.  Everything worked great for a while, but the next morning I was unable to edit my profile even though I was still logged into the site.  Logging out and then back in fixed the issue, but I repeatedly saw this issue.  It would occur 60 minutes after logging in.

## OAuth token expiry

I realized: although every row in the `oauth_tokens` table has an `access_token` and a `refresh_token`, it only has a single `expires_at` column which represents when the `access_token` expires.  This `expires_at` column is used to determine whether or not a row in the `oauth_tokens` table should be deleted in the `cleanup()` function.
If the `cleanup()` function runs before the third party application (in this case [tangled.org](https://tangled.org/)) attempts to use the `refresh_token` to refresh, then refreshing will fail because the corresponding row in the `oauth_tokens` table is gone.

## `WWW-Authenticate` header

Also, when a third party application makes a request to the PDS with an expired `access_token`, we respond with a 401, but it's not clear from the response _why_ the request is unauthorized.  According to the [AT Protocol spec](https://atproto.com/specs/xrpc#summary-of-http-status-codes):
> `401 Unauthorized`: Authentication is required for this endpoint. There should be a `WWW-Authenticate` header.

[tangled.org](https://tangled.org/) uses [indigo](https://github.com/boltlessengineer/indigo) as its OAuth client; here's how it handles 401 responses from a PDS:

1. If the `WWW-Authenticate` header is blank, simply return the 401 response.  Otherwise, continue.  ([code link](https://github.com/boltlessengineer/indigo/blob/11dd65f391eaa4b70a00032ae564509675db52d0/atproto/auth/oauth/session.go#L344))
2. Determine if the access token is expired by parsing the `WWW-Authenticate` header for `error=invalid_token`. ([code link](https://github.com/boltlessengineer/indigo/blob/11dd65f391eaa4b70a00032ae564509675db52d0/atproto/auth/oauth/session.go#L290-L296))
3. If the access token is indeed expired, refresh it. ([code link](https://github.com/boltlessengineer/indigo/blob/11dd65f391eaa4b70a00032ae564509675db52d0/atproto/auth/oauth/session.go#L375-L376))

That means [tangled.org](https://tangled.org/) (and other spec-compliant apps) will only attempt to refresh a token if we attach the `WWW-Authenticate` header with `error=invalid_token` to the 401 response.

# My changes:

## 861652143501fd4567cddb5ad33f727988ce306a

Add `WWW-Authenticate` header with `error=invalid_token` to 401 responses when the token is invalid.

## 091b46932f3656d9d66a5b77a4ee351762746f21

Replace `oauth_tokens.expires_at` with `access_expires_at` and `refresh_expires_at`.
When `cleanup()` runs, determine which rows in `oauth_tokens` to delete based on `refresh_expires_at`, not `access_expires_at`.

Also, a mostly unrelated change that I think makes sense, but would be happy to undo: delete expired `oauth_tokens` even if they have been revoked.

# Demo

This version is running right now at https://pds.aidanlavis.dev/

### Before:

https://github.com/user-attachments/assets/3adbf5d2-135d-4bf1-b6de-1d2a2933dae7

### After:

https://github.com/user-attachments/assets/51c3a041-a566-4dcd-94a1-1417b3398b97