### PR TITLE
fix(pds): Make `getRepoStatus` lexicon-compliant

### DIFF
--- a/packages/pds/src/xrpc/sync.ts
+++ b/packages/pds/src/xrpc/sync.ts
@@ -78,13 +78,23 @@ export async function getRepoStatus(
 		);
 	}
 
-	const data = await accountDO.rpcGetRepoStatus();
+	const [data, active] = await Promise.all([
+		accountDO.rpcGetRepoStatus(),
+		accountDO.rpcGetActive(),
+	]);
+
+	if (active) {
+		return c.json({
+			did: data.did,
+			active: true,
+			rev: data.rev,
+		});
+	}
 
 	return c.json({
 		did: data.did,
-		active: true,
-		status: "active",
-		rev: data.rev,
+		active: false,
+		status: "deactivated",
 	});
 }
 

--- a/packages/pds/test/xrpc.test.ts
+++ b/packages/pds/test/xrpc.test.ts
@@ -1055,13 +1055,58 @@ describe("XRPC Endpoints", () => {
 			);
 			expect(response.status).toBe(200);
 
-			const data = await response.json();
+			const data = (await response.json()) as Record<string, unknown>;
 			expect(data).toMatchObject({
 				did: env.DID,
 				active: true,
-				status: "active",
 				rev: expect.any(String),
 			});
+			expect(data.status).toBeUndefined();
+		});
+
+		it("should return deactivated status when account is inactive", async () => {
+			const deactivateResponse = await worker.fetch(
+				new Request(
+					"http://pds.test/xrpc/com.atproto.server.deactivateAccount",
+					{
+						method: "POST",
+						headers: {
+							Authorization: `Bearer ${env.AUTH_TOKEN}`,
+						},
+					},
+				),
+				env,
+			);
+			expect(deactivateResponse.status).toBe(200);
+
+			const response = await worker.fetch(
+				new Request(
+					`http://pds.test/xrpc/com.atproto.sync.getRepoStatus?did=${env.DID}`,
+				),
+				env,
+			);
+			expect(response.status).toBe(200);
+
+			const data = (await response.json()) as Record<string, unknown>;
+			expect(data).toMatchObject({
+				did: env.DID,
+				active: false,
+				status: "deactivated",
+			});
+			expect(data.rev).toBeUndefined();
+
+			await worker.fetch(
+				new Request(
+					"http://pds.test/xrpc/com.atproto.server.activateAccount",
+					{
+						method: "POST",
+						headers: {
+							Authorization: `Bearer ${env.AUTH_TOKEN}`,
+						},
+					},
+				),
+				env,
+			);
 		});
 
 		it("should export repo as CAR file", async () => {


### PR DESCRIPTION
## Summary

- Updated `com.atproto.sync.getRepoStatus` lexicon-compliant: omit `status` for active accounts, return `status: "deactivated"` (and no`rev`) when inactive.
- Read actual account active state via `rpcGetActive()` instead of hardcoding `active: true`
- Add test coverage for both active and deactivated states

## Why

Strict ATProto clients/tools (e.g. [atproto.at](https://atproto.at/)) couldn't parse our responses. Per the lexicon, `status` is reserved for inactive/error reason codes (`takendown`, `suspended`, `deleted`, `deactivated`, etc.) and should be omitted for active repos. The previous implementation also misreported deactivated accounts as active.

## Test plan

- [ ] `pnpm --filter @getcirrus/pds test xrpc.test.ts` passes
- [ ] `GET /xrpc/com.atproto.sync.getRepoStatus?did=<did>` on an active account returns `{ did, active: true, rev }` with no `status`
- [ ] After `com.atproto.server.deactivateAccount`, the same endpoint returns `{ did, active: false, status: "deactivated" }` with no `rev`
- [ ] [atproto.at](https://atproto.at/) status page parses the response correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)