### PR TITLE
fix(pds): store blobs from Worker, not the firehose-holding DO

### DIFF
--- a/.changeset/blob-upload-off-do.md
+++ b/.changeset/blob-upload-off-do.md
@@ -2,8 +2,6 @@
 "@getcirrus/pds": patch
 ---
 
-Store uploaded blobs from the stateless Worker instead of the account Durable Object.
+Fix blob uploads intermittently desyncing the PDS from the relay.
 
-`uploadBlob` routed the blob through the AccountDurableObject, which computed the CID and did the R2 put inside the DO. That DO is single-threaded and also holds the relay's `subscribeRepos` firehose WebSocket; awaiting an R2 put inside it pins the input gate (R2 latency is independent of object size — even a small link-card image can stall), and Cloudflare resets the object with "Durable Object storage operation exceeded timeout", dropping the firehose connection and leaving the relay desynced until a manual `requestCrawl`.
-
-The Worker now computes the CID and writes to R2 directly (mirroring the existing `getBlob` download path) and only calls the DO for the small `imported_blobs` tracking row.
+Uploading a blob (commonly a link-card thumbnail) could occasionally fail and leave the relay no longer tracking the repo, so new posts stopped federating until a manual crawl request. Blob uploads are now reliable and no longer drop the firehose connection.

--- a/.changeset/blob-upload-off-do.md
+++ b/.changeset/blob-upload-off-do.md
@@ -1,0 +1,9 @@
+---
+"@getcirrus/pds": patch
+---
+
+Store uploaded blobs from the stateless Worker instead of the account Durable Object.
+
+`uploadBlob` routed the blob through the AccountDurableObject, which computed the CID and did the R2 put inside the DO. That DO is single-threaded and also holds the relay's `subscribeRepos` firehose WebSocket; awaiting an R2 put inside it pins the input gate (R2 latency is independent of object size — even a small link-card image can stall), and Cloudflare resets the object with "Durable Object storage operation exceeded timeout", dropping the firehose connection and leaving the relay desynced until a manual `requestCrawl`.
+
+The Worker now computes the CID and writes to R2 directly (mirroring the existing `getBlob` download path) and only calls the DO for the small `imported_blobs` tracking row.

--- a/packages/pds/src/account-do.ts
+++ b/packages/pds/src/account-do.ts
@@ -28,7 +28,7 @@ import {
 	type SeqIdentityEvent,
 	type CommitData,
 } from "./sequencer";
-import { BlobStore, type BlobRef } from "./blobs";
+import { BlobStore } from "./blobs";
 import { jsonToLex } from "@atproto/lex-json";
 import type { PDSEnv } from "./types";
 import { RecordAlreadyExistsError, type ValidationStatus } from "./validation";
@@ -1038,28 +1038,23 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 	}
 
 	/**
-	 * RPC method: Upload a blob to R2
+	 * RPC method: Record an already-stored blob's metadata.
+	 *
+	 * The blob bytes are written to R2 by the stateless Worker, not here.
+	 * This DO is single-threaded and also holds the relay's firehose
+	 * WebSocket; awaiting an R2 put inside it (R2 latency is independent of
+	 * object size — even a small image can stall) pins the input gate, and
+	 * Cloudflare resets the object when a storage op can't complete in time,
+	 * dropping the firehose and desyncing the relay. Only the tiny tracking
+	 * row needs the DO's SQLite.
 	 */
-	async rpcUploadBlob(bytes: Uint8Array, mimeType: string): Promise<BlobRef> {
-		if (!this.blobStore) {
-			throw new Error("Blob storage not configured");
-		}
-
-		// Enforce size limit (60MB)
-		const MAX_BLOB_SIZE = 60 * 1024 * 1024;
-		if (bytes.length > MAX_BLOB_SIZE) {
-			throw new Error(
-				`Blob too large: ${bytes.length} bytes (max ${MAX_BLOB_SIZE})`,
-			);
-		}
-
-		const blobRef = await this.blobStore.putBlob(bytes, mimeType);
-
-		// Track the imported blob for migration progress
+	async rpcTrackBlob(
+		cid: string,
+		size: number,
+		mimeType: string,
+	): Promise<void> {
 		const storage = await this.getStorage();
-		storage.trackImportedBlob(blobRef.ref.$link, bytes.length, mimeType);
-
-		return blobRef;
+		storage.trackImportedBlob(cid, size, mimeType);
 	}
 
 	/**

--- a/packages/pds/src/xrpc/repo.ts
+++ b/packages/pds/src/xrpc/repo.ts
@@ -10,6 +10,7 @@ import {
 	type ValidationStatus,
 } from "../validation.js";
 import { detectContentType } from "../format.js";
+import { BlobStore } from "../blobs.js";
 import { buildScopeChecker, requireScope } from "../middleware/auth.js";
 
 function invalidRecordError(
@@ -680,24 +681,30 @@ export async function uploadBlob(
 		);
 	}
 
-	try {
-		const blobRef = await accountDO.rpcUploadBlob(bytes, contentType);
-		return c.json({ blob: blobRef });
-	} catch (err) {
-		if (
-			err instanceof Error &&
-			err.message.includes("Blob storage not configured")
-		) {
-			return c.json(
-				{
-					error: "ServiceUnavailable",
-					message: "Blob storage is not configured",
-				},
-				503,
-			);
-		}
-		throw err;
+	if (!c.env.BLOBS) {
+		return c.json(
+			{
+				error: "ServiceUnavailable",
+				message: "Blob storage is not configured",
+			},
+			503,
+		);
 	}
+
+	// Store the blob from the stateless Worker, not the DO. The DO is
+	// single-threaded and holds the relay's firehose WebSocket; awaiting an
+	// R2 put inside it (R2 latency is independent of object size) pins the
+	// input gate, and Cloudflare resets the object when a storage op times
+	// out, dropping the firehose and desyncing the relay. The DO only
+	// records the tracking metadata. This mirrors sync.getBlob.
+	const blobStore = new BlobStore(c.env.BLOBS, c.env.DID);
+	const blobRef = await blobStore.putBlob(bytes, contentType);
+	await accountDO.rpcTrackBlob(
+		blobRef.ref.$link,
+		blobRef.size,
+		blobRef.mimeType,
+	);
+	return c.json({ blob: blobRef });
 }
 
 export async function importRepo(


### PR DESCRIPTION
## Summary

- Follow-up to #162. A blob upload (even a small link-card OG image) intermittently triggered `Durable Object storage operation exceeded timeout which caused object to be reset` on `com.atproto.repo.uploadBlob`, which dropped the relay's `subscribeRepos` firehose connection and left it desynced until a manual `requestCrawl`.
- Root cause: `uploadBlob` computed the CID and did the R2 `put` **inside the AccountDurableObject**. That DO is single-threaded and also holds the firehose WebSocket; awaiting an R2 put inside it pins the input gate, and R2 latency is independent of object size — even a small image can stall long enough for Cloudflare to reset the object.
- Fix: the stateless Worker now computes the CID and writes to R2 directly, mirroring the existing `sync.getBlob` download path (which already bypasses the DO with the comment "R2ObjectBody can't be serialized across RPC"). The DO is only called for the small `imported_blobs` tracking row via a new `rpcTrackBlob`. `rpcUploadBlob` is removed.

## Why #162 didn't cover this

#162 fixed in-memory `Repo` divergence in the record-write paths. This is a different mechanism: the whole DO is reset, not a caught write error, so that fix can't apply. The two together close both desync paths.

## Test plan

- [x] `pnpm --filter @getcirrus/pds test:unit` — 273 tests pass (incl. `blobs.test.ts`)
- [ ] Production: post a link card with an OG thumbnail repeatedly; confirm the relay keeps tracking with no manual `requestCrawl`