### PR TITLE
fix(pds): include prevData in firehose #commit events

### DIFF
--- a/.changeset/firehose-prevdata.md
+++ b/.changeset/firehose-prevdata.md
@@ -1,0 +1,7 @@
+---
+"@getcirrus/pds": patch
+---
+
+Include `prevData` in firehose `#commit` events.
+
+`prevData` is the MST root CID of the previous commit (the `data` field at the `since` rev) and is effectively required for the inductive version of the firehose. Without it, relays running strict commit validation (e.g. indigo with `LenientSyncValidation` off) fail verification with "missing prevData field" and reject every commit after the first, freezing the repo on that relay. It is now populated from the pre-write repo's `commit.data` at each write path.

--- a/packages/pds/scripts/verify-firehose.ts
+++ b/packages/pds/scripts/verify-firehose.ts
@@ -32,6 +32,7 @@ interface CommitEvent {
 	commit: Cid;
 	rev: string;
 	since: string | null;
+	prevData: Cid;
 	blocks: Uint8Array;
 	ops: CommitOp[];
 	blobs: Cid[];

--- a/packages/pds/scripts/verify-firehose.ts
+++ b/packages/pds/scripts/verify-firehose.ts
@@ -32,7 +32,9 @@ interface CommitEvent {
 	commit: Cid;
 	rev: string;
 	since: string | null;
-	prevData: Cid;
+	// Optional: absent on legacy (pre-prevData) firehose data and on any
+	// initial commit where `since` is null.
+	prevData?: Cid;
 	blocks: Uint8Array;
 	ops: CommitOp[];
 	blobs: Cid[];

--- a/packages/pds/src/account-do.ts
+++ b/packages/pds/src/account-do.ts
@@ -415,6 +415,7 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 					commit: updatedRepo.cid,
 					rev: updatedRepo.commit.rev,
 					since: prevRev,
+					prevData: repo.commit.data,
 					newBlocks,
 					ops: [opWithCid],
 				};
@@ -484,6 +485,7 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 					commit: updatedRepo.cid,
 					rev: updatedRepo.commit.rev,
 					since: prevRev,
+					prevData: repo.commit.data,
 					newBlocks,
 					ops: [deleteOp],
 				};
@@ -589,6 +591,7 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 					commit: updatedRepo.cid,
 					rev: updatedRepo.commit.rev,
 					since: prevRev,
+					prevData: repo.commit.data,
 					newBlocks,
 					ops: [opWithCid],
 				};
@@ -791,6 +794,7 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 					commit: updatedRepo.cid,
 					rev: updatedRepo.commit.rev,
 					since: prevRev,
+					prevData: repo.commit.data,
 					newBlocks,
 					ops: opsWithCids,
 				};

--- a/packages/pds/src/sequencer.ts
+++ b/packages/pds/src/sequencer.ts
@@ -16,8 +16,9 @@ export interface CommitEvent {
 	since: string | null;
 	// Root CID of the MST for the previous commit (the `data` field of the
 	// commit at the `since` rev). Required for relays doing inductive firehose
-	// verification (com.atproto.sync.subscribeRepos#commit `prevData`).
-	prevData: CID;
+	// verification (com.atproto.sync.subscribeRepos#commit `prevData`). Nullable
+	// to mirror `since`; in practice every write has a prior commit so it is set.
+	prevData: CID | null;
 	blocks: Uint8Array;
 	ops: RepoOp[];
 	blobs: CID[];
@@ -76,7 +77,7 @@ export interface CommitData {
 	commit: CID;
 	rev: string;
 	since: string | null;
-	prevData: CID;
+	prevData: CID | null;
 	newBlocks: BlockMap;
 	ops: Array<RecordWriteOp & { cid?: CID | null }>;
 }

--- a/packages/pds/src/sequencer.ts
+++ b/packages/pds/src/sequencer.ts
@@ -14,6 +14,10 @@ export interface CommitEvent {
 	commit: CID;
 	rev: string;
 	since: string | null;
+	// Root CID of the MST for the previous commit (the `data` field of the
+	// commit at the `since` rev). Required for relays doing inductive firehose
+	// verification (com.atproto.sync.subscribeRepos#commit `prevData`).
+	prevData: CID;
 	blocks: Uint8Array;
 	ops: RepoOp[];
 	blobs: CID[];
@@ -72,6 +76,7 @@ export interface CommitData {
 	commit: CID;
 	rev: string;
 	since: string | null;
+	prevData: CID;
 	newBlocks: BlockMap;
 	ops: Array<RecordWriteOp & { cid?: CID | null }>;
 }
@@ -102,6 +107,7 @@ export class Sequencer {
 			commit: data.commit,
 			rev: data.rev,
 			since: data.since,
+			prevData: data.prevData,
 			blocks: carBytes,
 			ops: data.ops.map(
 				(op): RepoOp => ({

--- a/packages/pds/test/firehose.test.ts
+++ b/packages/pds/test/firehose.test.ts
@@ -343,6 +343,45 @@ describe("Firehose (subscribeRepos)", () => {
 			});
 		});
 
+		it("should include prevData matching the previous commit's MST root", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const sequencer = (instance as any).sequencer;
+				const encodeEventFrame = (instance as any).encodeEventFrame.bind(
+					instance,
+				);
+
+				// Load the repo and capture the current (soon-to-be-previous) state.
+				await instance.rpcGetRepoStatus();
+				const prevRepo = (instance as any).repo;
+				const expectedPrevData = prevRepo.commit.data.toString();
+				const expectedSince = prevRepo.commit.rev;
+
+				const seqBefore = sequencer.getLatestSeq();
+				await instance.rpcCreateRecord("app.bsky.feed.post", "prevdata-test", {
+					text: "prevData test",
+					createdAt: new Date().toISOString(),
+				});
+
+				const events = await sequencer.getEventsSince(seqBefore, 1);
+				const frame = encodeEventFrame(events[0] as SeqCommitEvent);
+				const { body } = decodeFrame(frame);
+				const commitBody = body as {
+					prevData?: { toString(): string };
+					since?: string;
+				};
+
+				// prevData must be present (relays require it for verification)
+				// and equal the data CID of the commit at the `since` rev.
+				expect(commitBody.prevData).toBeDefined();
+				expect(commitBody.prevData!.toString()).toBe(expectedPrevData);
+				expect(commitBody.since).toBe(expectedSince);
+			});
+		});
+
 		it("should encode identity events with #identity frame type", async () => {
 			const id = env.ACCOUNT.idFromName("account");
 			const stub = env.ACCOUNT.get(id);


### PR DESCRIPTION
Closes #169

## Problem

Cirrus's firehose `#commit` events omit the `prevData` field — the MST root CID of the previous commit (the `data` field at the `since` rev), which is *"effectively required for the 'inductive' version of firehose"* per the lexicon. Relays running strict commit validation (indigo with `LenientSyncValidation` off) fail verification with `"missing prevData field"` and reject every commit after the first, **freezing the repo** on that relay.

Demonstrated on two independent repos: a strict relay (relay.feeds.blue) and a lenient relay (bsky.network) read the firehose to the **same cursor**, yet the strict relay is frozen ~106 days while the lenient one is at head — the divergence is purely strict-vs-lenient validation of the missing field. The relay.feeds.blue operator confirmed they run standard indigo with `LenientSyncValidation` off.

## Change

The previous commit's MST root is already in scope at every write path in `account-do.ts` (the `repo` object captured before `applyWrites`, alongside the existing `prevRev`). Populate `prevData = repo.commit.data`:

- `sequencer.ts`: add `prevData: CID` to `CommitData` and `CommitEvent`; set it in `sequenceCommit`'s payload (flows through the existing CBOR encoder).
- `account-do.ts`: set `prevData: repo.commit.data` in the `CommitData` at `rpcCreateRecord`, `rpcDeleteRecord`, `rpcPutRecord`, `rpcApplyWrites`.
- `test/firehose.test.ts`: new test asserting `prevData` is present and equals the prior commit's `data` CID.
- `scripts/verify-firehose.ts`: add `prevData` to its `CommitEvent` interface.

## Verification

- `pnpm --filter @getcirrus/pds build` ✅
- `pnpm --filter @getcirrus/pds test:unit` ✅ (280 passed, incl. new prevData test)
- `pnpm knip` ✅

Related: #167 / #168 (`getLatestCommit`) is a separate conformance gap, not the indexing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)