### PR TITLE
feat(pds): emit sync 1.1 firehose events

### DIFF
--- a/.changeset/sync-1-1-compliance.md
+++ b/.changeset/sync-1-1-compliance.md
@@ -1,0 +1,16 @@
+---
+"@getcirrus/pds": minor
+---
+
+The firehose now emits the sync 1.1 message shape, matching what the bsky.network relay and other AT Protocol consumers expect. Existing subscribers will start seeing new fields and new event types; nothing has to change on the consumer side, but the warnings some relays were logging against Cirrus hosts (notably `missing prevData field`) will stop.
+
+What changed on the wire:
+
+- `#commit` messages now include `prevData` (the prior commit's MST root CID), so relays can verify each commit inductively without re-fetching the repo. The CAR slice now also carries the MST covering-proof blocks needed for that verification.
+- Each `ops[]` entry on update and delete now includes `prev`, the previous CID of the touched record. Creates omit it as before.
+- `tooBig` is always `false`. It was previously set based on payload size, which never matched the field's meaning under sync 1.1.
+- New `#account` events are emitted on activation and deactivation, so relays learn about account status changes without polling. Deactivation reports `status: "deactivated"`; activation reports `active: true` with no status.
+- New `#sync` events are emitted on activation (after migration or initial setup), giving relays the current commit block without a diff.
+- `#identity` events now allow the `handle` field to be omitted, per spec.
+- A `#info` frame with `name: "OutdatedCursor"` is sent when a client connects with a cursor older than the retained event window. The stream continues from the oldest available event instead of disconnecting.
+- `applyWrites` rejects calls with more than 200 operations, matching the spec cap.

--- a/packages/pds/src/account-do.ts
+++ b/packages/pds/src/account-do.ts
@@ -21,17 +21,14 @@ import { now as tidNow } from "@atcute/tid";
 import { encode as cborEncode } from "./cbor-compat";
 import { SqliteRepoStorage } from "./storage";
 import { SqliteOAuthStorage } from "./oauth-storage";
-import {
-	Sequencer,
-	type SeqEvent,
-	type SeqCommitEvent,
-	type SeqIdentityEvent,
-	type CommitData,
-} from "./sequencer";
+import { Sequencer, type SeqEvent, type CommitData } from "./sequencer";
 import { BlobStore } from "./blobs";
 import { jsonToLex } from "@atproto/lex-json";
 import type { PDSEnv } from "./types";
 import { RecordAlreadyExistsError, type ValidationStatus } from "./validation";
+
+/** Sync 1.1 spec: at most 200 record operations per commit. */
+const MAX_OPS_PER_COMMIT = 200;
 
 /**
  * Account Durable Object - manages a single user's AT Protocol repository.
@@ -379,7 +376,9 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 		};
 
 		const prevRev = repo.commit.rev;
-		const updatedRepo = await repo.applyWrites([createOp], keypair);
+		const prevData = repo.commit.data;
+		const commit = await repo.formatCommit([createOp], keypair);
+		const updatedRepo = await repo.applyCommit(commit);
 
 		try {
 			const dataKey = `${collection}/${actualRkey}`;
@@ -394,33 +393,21 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 			this.storage!.addCollection(collection);
 
 			if (this.sequencer) {
-				const newBlocks = new BlockMap();
-				const rows = this.ctx.storage.sql
-					.exec(
-						"SELECT cid, bytes FROM blocks WHERE rev = ?",
-						updatedRepo.commit.rev,
-					)
-					.toArray();
-
-				for (const row of rows) {
-					const cid = CID.parse(row.cid as string);
-					const bytes = new Uint8Array(row.bytes as ArrayBuffer);
-					newBlocks.set(cid, bytes);
-				}
-
 				const opWithCid = { ...createOp, cid: recordCid };
 
 				const commitData: CommitData = {
 					did: updatedRepo.did,
-					commit: updatedRepo.cid,
-					rev: updatedRepo.commit.rev,
+					commit: commit.cid,
+					rev: commit.rev,
 					since: prevRev,
-					newBlocks,
+					prevData,
+					newBlocks: commit.newBlocks,
+					relevantBlocks: commit.relevantBlocks,
 					ops: [opWithCid],
 				};
 
 				const event = await this.sequencer.sequenceCommit(commitData);
-				await this.broadcastCommit(event);
+				await this.broadcastEvent(event);
 			}
 
 			this.repo = updatedRepo;
@@ -451,8 +438,8 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 		const repo = await this.getRepo();
 		const keypair = await this.getKeypair();
 
-		const existing = await repo.getRecord(collection, rkey);
-		if (!existing) return null;
+		const existingCid = await repo.data.get(`${collection}/${rkey}`);
+		if (!existingCid) return null;
 
 		const deleteOp: RecordDeleteOp = {
 			action: WriteOpAction.Delete,
@@ -461,35 +448,25 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 		};
 
 		const prevRev = repo.commit.rev;
-		const updatedRepo = await repo.applyWrites([deleteOp], keypair);
+		const prevData = repo.commit.data;
+		const commit = await repo.formatCommit([deleteOp], keypair);
+		const updatedRepo = await repo.applyCommit(commit);
 
 		try {
 			if (this.sequencer) {
-				const newBlocks = new BlockMap();
-				const rows = this.ctx.storage.sql
-					.exec(
-						"SELECT cid, bytes FROM blocks WHERE rev = ?",
-						updatedRepo.commit.rev,
-					)
-					.toArray();
-
-				for (const row of rows) {
-					const cid = CID.parse(row.cid as string);
-					const bytes = new Uint8Array(row.bytes as ArrayBuffer);
-					newBlocks.set(cid, bytes);
-				}
-
 				const commitData: CommitData = {
 					did: updatedRepo.did,
-					commit: updatedRepo.cid,
-					rev: updatedRepo.commit.rev,
+					commit: commit.cid,
+					rev: commit.rev,
 					since: prevRev,
-					newBlocks,
-					ops: [deleteOp],
+					prevData,
+					newBlocks: commit.newBlocks,
+					relevantBlocks: commit.relevantBlocks,
+					ops: [{ ...deleteOp, cid: null, prev: existingCid }],
 				};
 
 				const event = await this.sequencer.sequenceCommit(commitData);
-				await this.broadcastCommit(event);
+				await this.broadcastEvent(event);
 			}
 
 			this.repo = updatedRepo;
@@ -535,9 +512,8 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 		const repo = await this.getRepo();
 		const keypair = await this.getKeypair();
 
-		// Check if record exists to determine create vs update
-		const existing = await repo.getRecord(collection, rkey);
-		const isUpdate = existing !== null;
+		const existingCid = await repo.data.get(`${collection}/${rkey}`);
+		const isUpdate = existingCid !== null;
 
 		const normalizedRecord = jsonToLex(record) as RepoRecord;
 		const op: RecordWriteOp = isUpdate
@@ -555,7 +531,9 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 				} as RecordCreateOp);
 
 		const prevRev = repo.commit.rev;
-		const updatedRepo = await repo.applyWrites([op], keypair);
+		const prevData = repo.commit.data;
+		const commit = await repo.formatCommit([op], keypair);
+		const updatedRepo = await repo.applyCommit(commit);
 
 		try {
 			const dataKey = `${collection}/${rkey}`;
@@ -568,33 +546,25 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 			this.storage!.addCollection(collection);
 
 			if (this.sequencer) {
-				const newBlocks = new BlockMap();
-				const rows = this.ctx.storage.sql
-					.exec(
-						"SELECT cid, bytes FROM blocks WHERE rev = ?",
-						updatedRepo.commit.rev,
-					)
-					.toArray();
-
-				for (const row of rows) {
-					const cid = CID.parse(row.cid as string);
-					const bytes = new Uint8Array(row.bytes as ArrayBuffer);
-					newBlocks.set(cid, bytes);
-				}
-
-				const opWithCid = { ...op, cid: recordCid };
+				const opWithCid: CommitData["ops"][number] = {
+					...op,
+					cid: recordCid,
+				};
+				if (existingCid) opWithCid.prev = existingCid;
 
 				const commitData: CommitData = {
 					did: updatedRepo.did,
-					commit: updatedRepo.cid,
-					rev: updatedRepo.commit.rev,
+					commit: commit.cid,
+					rev: commit.rev,
 					since: prevRev,
-					newBlocks,
+					prevData,
+					newBlocks: commit.newBlocks,
+					relevantBlocks: commit.relevantBlocks,
 					ops: [opWithCid],
 				};
 
 				const event = await this.sequencer.sequenceCommit(commitData);
-				await this.broadcastCommit(event);
+				await this.broadcastEvent(event);
 			}
 
 			this.repo = updatedRepo;
@@ -635,6 +605,14 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 		}>;
 	}> {
 		await this.ensureActive();
+
+		// Spec limit: at most 200 operations per #commit.
+		if (writes.length > MAX_OPS_PER_COMMIT) {
+			throw new Error(
+				`InvalidRequest: applyWrites accepts at most ${MAX_OPS_PER_COMMIT} operations per call, got ${writes.length}`,
+			);
+		}
+
 		const repo = await this.getRepo();
 		const keypair = await this.getKeypair();
 
@@ -729,8 +707,24 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 			}
 		}
 
+		// Capture prev CIDs for every update/delete *before* the write, so the
+		// firehose can emit ops[].prev per sync 1.1. Skipping creates avoids
+		// unnecessary MST lookups; for updates that touch a previously-created
+		// record in the same batch, formatCommit handles the chain — only the
+		// initial repo-state prev matters for the firehose op record.
+		const prevCids = new Map<string, CID>();
+		for (const op of ops) {
+			if (op.action === WriteOpAction.Create) continue;
+			const key = `${op.collection}/${op.rkey}`;
+			if (prevCids.has(key)) continue;
+			const cid = await repo.data.get(key);
+			if (cid) prevCids.set(key, cid);
+		}
+
 		const prevRev = repo.commit.rev;
-		const updatedRepo = await repo.applyWrites(ops, keypair);
+		const prevData = repo.commit.data;
+		const commit = await repo.formatCommit(ops, keypair);
+		const updatedRepo = await repo.applyCommit(commit);
 
 		try {
 			for (const op of ops) {
@@ -745,17 +739,22 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 				cid?: string;
 				validationStatus?: ValidationStatus;
 			}> = [];
-			const opsWithCids: Array<RecordWriteOp & { cid?: CID | null }> = [];
+			const opsWithCids: CommitData["ops"] = [];
 
 			for (let i = 0; i < results.length; i++) {
 				const result = results[i]!;
 				const op = ops[i]!;
+				const prev = prevCids.get(`${op.collection}/${op.rkey}`);
 
 				if (result.action === WriteOpAction.Delete) {
 					finalResults.push({
 						$type: result.$type,
 					});
-					opsWithCids.push(op);
+					opsWithCids.push({
+						...op,
+						cid: null,
+						...(prev ? { prev } : {}),
+					});
 				} else {
 					const dataKey = `${result.collection}/${result.rkey}`;
 					const recordCid = await updatedRepo.data.get(dataKey);
@@ -767,36 +766,28 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 							? { validationStatus: result.validationStatus }
 							: {}),
 					});
-					opsWithCids.push({ ...op, cid: recordCid });
+					opsWithCids.push({
+						...op,
+						cid: recordCid,
+						...(prev ? { prev } : {}),
+					});
 				}
 			}
 
 			if (this.sequencer) {
-				const newBlocks = new BlockMap();
-				const rows = this.ctx.storage.sql
-					.exec(
-						"SELECT cid, bytes FROM blocks WHERE rev = ?",
-						updatedRepo.commit.rev,
-					)
-					.toArray();
-
-				for (const row of rows) {
-					const cid = CID.parse(row.cid as string);
-					const bytes = new Uint8Array(row.bytes as ArrayBuffer);
-					newBlocks.set(cid, bytes);
-				}
-
 				const commitData: CommitData = {
 					did: updatedRepo.did,
-					commit: updatedRepo.cid,
-					rev: updatedRepo.commit.rev,
+					commit: commit.cid,
+					rev: commit.rev,
 					since: prevRev,
-					newBlocks,
+					prevData,
+					newBlocks: commit.newBlocks,
+					relevantBlocks: commit.relevantBlocks,
 					ops: opsWithCids,
 				};
 
 				const event = await this.sequencer.sequenceCommit(commitData);
-				await this.broadcastCommit(event);
+				await this.broadcastEvent(event);
 			}
 
 			this.repo = updatedRepo;
@@ -1082,29 +1073,11 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 	}
 
 	/**
-	 * Encode a commit event frame.
-	 */
-	private encodeCommitFrame(event: SeqCommitEvent): Uint8Array {
-		const header = { op: 1, t: "#commit" };
-		return this.encodeFrame(header, event.event);
-	}
-
-	/**
-	 * Encode an identity event frame.
-	 */
-	private encodeIdentityFrame(event: SeqIdentityEvent): Uint8Array {
-		const header = { op: 1, t: "#identity" };
-		return this.encodeFrame(header, event.event);
-	}
-
-	/**
 	 * Encode any event frame based on its type.
 	 */
 	private encodeEventFrame(event: SeqEvent): Uint8Array {
-		if (event.type === "identity") {
-			return this.encodeIdentityFrame(event);
-		}
-		return this.encodeCommitFrame(event);
+		const header = { op: 1, t: `#${event.type}` };
+		return this.encodeFrame(header, event.event);
 	}
 
 	/**
@@ -1113,6 +1086,16 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 	private encodeErrorFrame(error: string, message: string): Uint8Array {
 		const header = { op: -1 };
 		const body = { error, message };
+		return this.encodeFrame(header, body);
+	}
+
+	/**
+	 * Encode an #info message (op:1, t:'#info'). Used for non-fatal
+	 * conditions like OutdatedCursor where the stream continues.
+	 */
+	private encodeInfoFrame(name: string, message: string): Uint8Array {
+		const header = { op: 1, t: "#info" };
+		const body = { name, message };
 		return this.encodeFrame(header, body);
 	}
 
@@ -1126,7 +1109,6 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 
 		const latestSeq = this.sequencer.getLatestSeq();
 
-		// Check if cursor is in the future
 		if (cursor > latestSeq) {
 			const frame = this.encodeErrorFrame(
 				"FutureCursor",
@@ -1137,15 +1119,27 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 			return;
 		}
 
-		// Backfill from cursor
-		const events = await this.sequencer.getEventsSince(cursor, 1000);
+		// If the cursor predates the oldest retained event, warn the client
+		// with #info OutdatedCursor and resume from the earliest available
+		// event. The stream stays open — they just miss the pruned range.
+		const earliestSeq = this.sequencer.getEarliestSeq();
+		let effectiveCursor = cursor;
+		if (earliestSeq !== null && cursor < earliestSeq - 1) {
+			const info = this.encodeInfoFrame(
+				"OutdatedCursor",
+				"Requested cursor exceeded retention window; some events skipped",
+			);
+			ws.send(info);
+			effectiveCursor = earliestSeq - 1;
+		}
+
+		const events = await this.sequencer.getEventsSince(effectiveCursor, 1000);
 
 		for (const event of events) {
 			const frame = this.encodeEventFrame(event);
 			ws.send(frame);
 		}
 
-		// Update cursor in attachment
 		if (events.length > 0) {
 			const lastEvent = events[events.length - 1];
 			if (lastEvent) {
@@ -1157,21 +1151,19 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 	}
 
 	/**
-	 * Broadcast a commit event to all connected firehose clients.
+	 * Broadcast a sequenced event to all connected firehose clients.
 	 */
-	private async broadcastCommit(event: SeqEvent): Promise<void> {
+	private async broadcastEvent(event: SeqEvent): Promise<void> {
 		const frame = this.encodeEventFrame(event);
 
 		for (const ws of this.ctx.getWebSockets()) {
 			try {
 				ws.send(frame);
 
-				// Update cursor
 				const attachment = ws.deserializeAttachment() as { cursor: number };
 				attachment.cursor = event.seq;
 				ws.serializeAttachment(attachment);
 			} catch (e) {
-				// Client disconnected, will be cleaned up
 				console.error("Error broadcasting to WebSocket:", e);
 			}
 		}
@@ -1284,19 +1276,62 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 	}
 
 	/**
-	 * RPC method: Activate account
+	 * RPC method: Activate account.
+	 * Emits #account + #identity + #sync per sync 1.1, so relays pick up
+	 * the new state without polling. #sync is only emitted when a repo
+	 * root exists (i.e. after migration import or initial commit).
 	 */
 	async rpcActivateAccount(): Promise<void> {
 		const storage = await this.getStorage();
+		const wasActive = await storage.getActive();
 		await storage.setActive(true);
+		if (wasActive || !this.sequencer) return;
+
+		const account = await this.sequencer.sequenceAccount({
+			did: this.env.DID,
+			active: true,
+		});
+		await this.broadcastEvent(account);
+
+		const identity = await this.sequencer.sequenceIdentity({
+			did: this.env.DID,
+		});
+		await this.broadcastEvent(identity);
+
+		const root = await storage.getRoot();
+		if (root) {
+			const commitBytes = await storage.getBytes(root);
+			if (commitBytes) {
+				const repo = await this.getRepo();
+				const blocks = new BlockMap();
+				blocks.set(root, commitBytes);
+				const sync = await this.sequencer.sequenceSync({
+					did: this.env.DID,
+					rev: repo.commit.rev,
+					cid: root,
+					blocks,
+				});
+				await this.broadcastEvent(sync);
+			}
+		}
 	}
 
 	/**
-	 * RPC method: Deactivate account
+	 * RPC method: Deactivate account.
+	 * Emits #account(active=false, status='deactivated') per sync 1.1.
 	 */
 	async rpcDeactivateAccount(): Promise<void> {
 		const storage = await this.getStorage();
+		const wasActive = await storage.getActive();
 		await storage.setActive(false);
+		if (!wasActive || !this.sequencer) return;
+
+		const account = await this.sequencer.sequenceAccount({
+			did: this.env.DID,
+			active: false,
+			status: "deactivated",
+		});
+		await this.broadcastEvent(account);
 	}
 
 	// ============================================
@@ -1391,48 +1426,16 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 
 	/**
 	 * Emit an identity event to notify downstream services to refresh identity cache.
+	 * `handle` is optional per sync 1.1.
 	 */
-	async rpcEmitIdentityEvent(handle: string): Promise<{ seq: number }> {
+	async rpcEmitIdentityEvent(handle?: string): Promise<{ seq: number }> {
 		await this.ensureStorageInitialized();
-
-		const time = new Date().toISOString();
-
-		// Get next sequence number
-		const result = this.ctx.storage.sql
-			.exec(
-				`INSERT INTO firehose_events (event_type, payload)
-				 VALUES ('identity', ?)
-				 RETURNING seq`,
-				new Uint8Array(0), // Empty payload, we just need seq
-			)
-			.one();
-		const seq = result.seq as number;
-
-		// Build identity event frame
-		const header = { op: 1, t: "#identity" };
-		const body = {
-			seq,
+		const event = await this.sequencer!.sequenceIdentity({
 			did: this.env.DID,
-			time,
-			handle,
-		};
-
-		const headerBytes = cborEncode(header);
-		const bodyBytes = cborEncode(body);
-		const frame = new Uint8Array(headerBytes.length + bodyBytes.length);
-		frame.set(headerBytes, 0);
-		frame.set(bodyBytes, headerBytes.length);
-
-		// Broadcast to all connected clients
-		for (const ws of this.ctx.getWebSockets()) {
-			try {
-				ws.send(frame);
-			} catch (e) {
-				console.error("Error broadcasting identity event:", e);
-			}
-		}
-
-		return { seq };
+			...(handle ? { handle } : {}),
+		});
+		await this.broadcastEvent(event);
+		return { seq: event.seq };
 	}
 
 	// ============================================

--- a/packages/pds/src/sequencer.ts
+++ b/packages/pds/src/sequencer.ts
@@ -1,6 +1,6 @@
 import { encode as cborEncode, decode as cborDecode } from "./cbor-compat";
 import { CID } from "@atproto/lex-data";
-import { blocksToCarFile, type BlockMap } from "@atproto/repo";
+import { blocksToCarFile, BlockMap } from "@atproto/repo";
 import type { RecordWriteOp } from "@atproto/repo";
 
 /**
@@ -14,6 +14,7 @@ export interface CommitEvent {
 	commit: CID;
 	rev: string;
 	since: string | null;
+	prevData: CID | null;
 	blocks: Uint8Array;
 	ops: RepoOp[];
 	blobs: CID[];
@@ -26,7 +27,38 @@ export interface CommitEvent {
 export interface IdentityEvent {
 	seq: number;
 	did: string;
-	handle: string;
+	handle?: string;
+	time: string;
+}
+
+/**
+ * Sync event payload — broadcast after operations that change repo state
+ * without a commit diff (rebase, key rotation, repo import).
+ * `blocks` is a CAR containing just the current commit block.
+ */
+export interface SyncEvent {
+	seq: number;
+	did: string;
+	rev: string;
+	blocks: Uint8Array;
+	time: string;
+}
+
+/**
+ * Account event payload — broadcast on activation, deactivation, takedown,
+ * or deletion. `status` is omitted when active=true.
+ */
+export type AccountStatus =
+	| "takendown"
+	| "suspended"
+	| "deleted"
+	| "deactivated";
+
+export interface AccountEvent {
+	seq: number;
+	did: string;
+	active: boolean;
+	status?: AccountStatus;
 	time: string;
 }
 
@@ -37,6 +69,7 @@ export interface RepoOp {
 	action: "create" | "update" | "delete";
 	path: string;
 	cid: CID | null;
+	prev?: CID;
 }
 
 /**
@@ -60,27 +93,65 @@ export interface SeqIdentityEvent {
 }
 
 /**
- * Sequenced event (commit or identity)
+ * Sequenced sync event wrapper
  */
-export type SeqEvent = SeqCommitEvent | SeqIdentityEvent;
+export interface SeqSyncEvent {
+	seq: number;
+	type: "sync";
+	event: SyncEvent;
+	time: string;
+}
 
 /**
- * Data needed to sequence a commit
+ * Sequenced account event wrapper
+ */
+export interface SeqAccountEvent {
+	seq: number;
+	type: "account";
+	event: AccountEvent;
+	time: string;
+}
+
+/**
+ * Sequenced event (commit, identity, sync, or account)
+ */
+export type SeqEvent =
+	| SeqCommitEvent
+	| SeqIdentityEvent
+	| SeqSyncEvent
+	| SeqAccountEvent;
+
+/**
+ * Data needed to sequence a commit. Pass `newBlocks` and `relevantBlocks`
+ * from @atproto/repo's CommitData; both are needed in the CAR slice so
+ * relays can run the sync 1.1 MST inversion check.
  */
 export interface CommitData {
 	did: string;
 	commit: CID;
 	rev: string;
 	since: string | null;
+	prevData: CID | null;
 	newBlocks: BlockMap;
-	ops: Array<RecordWriteOp & { cid?: CID | null }>;
+	relevantBlocks: BlockMap;
+	ops: Array<RecordWriteOp & { cid?: CID | null; prev?: CID }>;
+}
+
+/**
+ * Data needed to sequence a sync event.
+ */
+export interface SyncEventData {
+	did: string;
+	rev: string;
+	cid: CID;
+	blocks: BlockMap;
 }
 
 /**
  * Sequencer manages the firehose event log.
  *
  * Stores commit events in SQLite and provides methods for:
- * - Sequencing new commits
+ * - Sequencing new commits, identity, sync, and account events
  * - Backfilling events from a cursor
  * - Getting the latest sequence number
  */
@@ -91,33 +162,39 @@ export class Sequencer {
 	 * Add a commit to the firehose sequence.
 	 * Returns the complete sequenced event for broadcasting.
 	 */
-	async sequenceCommit(data: CommitData): Promise<SeqEvent> {
-		// Create CAR slice with commit diff
-		const carBytes = await blocksToCarFile(data.commit, data.newBlocks);
+	async sequenceCommit(data: CommitData): Promise<SeqCommitEvent> {
+		// Sync 1.1: CAR slice must contain both newly created blocks AND the
+		// MST covering proof for the touched paths so consumers can invert
+		// the MST and verify the commit without re-fetching the repo.
+		const blocksToSend = new BlockMap();
+		blocksToSend.addMap(data.newBlocks);
+		blocksToSend.addMap(data.relevantBlocks);
+
+		const carBytes = await blocksToCarFile(data.commit, blocksToSend);
 		const time = new Date().toISOString();
 
-		// Build event payload
 		const eventPayload: Omit<CommitEvent, "seq"> = {
 			repo: data.did,
 			commit: data.commit,
 			rev: data.rev,
 			since: data.since,
+			prevData: data.prevData,
 			blocks: carBytes,
-			ops: data.ops.map(
-				(op): RepoOp => ({
+			ops: data.ops.map((op): RepoOp => {
+				const out: RepoOp = {
 					action: op.action as "create" | "update" | "delete",
 					path: `${op.collection}/${op.rkey}`,
 					cid: ("cid" in op && op.cid ? op.cid : null) as CID | null,
-				}),
-			),
+				};
+				if (op.prev) out.prev = op.prev;
+				return out;
+			}),
 			rebase: false,
-			tooBig: carBytes.length > 1_000_000,
+			tooBig: false,
 			blobs: [],
 			time,
 		};
 
-		// Store in SQLite
-		// Type assertion: CBOR handles CID/Uint8Array serialization
 		const payload = cborEncode(eventPayload);
 		const result = this.sql
 			.exec(
@@ -137,6 +214,115 @@ export class Sequencer {
 				...eventPayload,
 				seq,
 			},
+			time,
+		};
+	}
+
+	/**
+	 * Add an identity event to the firehose.
+	 * `handle` is optional per sync 1.1; presence does not signal change.
+	 */
+	async sequenceIdentity(input: {
+		did: string;
+		handle?: string;
+	}): Promise<SeqIdentityEvent> {
+		const time = new Date().toISOString();
+
+		const eventPayload: Omit<IdentityEvent, "seq"> = {
+			did: input.did,
+			time,
+			...(input.handle ? { handle: input.handle } : {}),
+		};
+
+		const payload = cborEncode(eventPayload);
+		const result = this.sql
+			.exec(
+				`INSERT INTO firehose_events (event_type, payload)
+       VALUES ('identity', ?)
+       RETURNING seq`,
+				payload,
+			)
+			.one();
+
+		const seq = result.seq as number;
+
+		return {
+			seq,
+			type: "identity",
+			event: { ...eventPayload, seq },
+			time,
+		};
+	}
+
+	/**
+	 * Add a sync event to the firehose.
+	 * Used after repo state changes that don't produce a commit diff
+	 * (import, rebase, key rotation, account activation).
+	 */
+	async sequenceSync(data: SyncEventData): Promise<SeqSyncEvent> {
+		const carBytes = await blocksToCarFile(data.cid, data.blocks);
+		const time = new Date().toISOString();
+
+		const eventPayload: Omit<SyncEvent, "seq"> = {
+			did: data.did,
+			rev: data.rev,
+			blocks: carBytes,
+			time,
+		};
+
+		const payload = cborEncode(eventPayload);
+		const result = this.sql
+			.exec(
+				`INSERT INTO firehose_events (event_type, payload)
+       VALUES ('sync', ?)
+       RETURNING seq`,
+				payload,
+			)
+			.one();
+
+		const seq = result.seq as number;
+
+		return {
+			seq,
+			type: "sync",
+			event: { ...eventPayload, seq },
+			time,
+		};
+	}
+
+	/**
+	 * Add an account status event to the firehose.
+	 */
+	async sequenceAccount(input: {
+		did: string;
+		active: boolean;
+		status?: AccountStatus;
+	}): Promise<SeqAccountEvent> {
+		const time = new Date().toISOString();
+
+		const eventPayload: Omit<AccountEvent, "seq"> = {
+			did: input.did,
+			active: input.active,
+			time,
+			...(input.status ? { status: input.status } : {}),
+		};
+
+		const payload = cborEncode(eventPayload);
+		const result = this.sql
+			.exec(
+				`INSERT INTO firehose_events (event_type, payload)
+       VALUES ('account', ?)
+       RETURNING seq`,
+				payload,
+			)
+			.one();
+
+		const seq = result.seq as number;
+
+		return {
+			seq,
+			type: "account",
+			event: { ...eventPayload, seq },
 			time,
 		};
 	}
@@ -172,7 +358,6 @@ export class Sequencer {
 				if (payload.length === 0) {
 					continue;
 				}
-				// Decode identity event with proper payload
 				const decoded = cborDecode(payload) as Omit<IdentityEvent, "seq">;
 				events.push({
 					seq,
@@ -180,8 +365,23 @@ export class Sequencer {
 					event: { ...decoded, seq },
 					time,
 				});
+			} else if (eventType === "sync") {
+				const decoded = cborDecode(payload) as Omit<SyncEvent, "seq">;
+				events.push({
+					seq,
+					type: "sync",
+					event: { ...decoded, seq },
+					time,
+				});
+			} else if (eventType === "account") {
+				const decoded = cborDecode(payload) as Omit<AccountEvent, "seq">;
+				events.push({
+					seq,
+					type: "account",
+					event: { ...decoded, seq },
+					time,
+				});
 			} else {
-				// Commit event
 				const decoded = cborDecode(payload) as Omit<CommitEvent, "seq">;
 				events.push({
 					seq,
@@ -204,6 +404,19 @@ export class Sequencer {
 			.exec("SELECT MAX(seq) as seq FROM firehose_events")
 			.one();
 		return (result?.seq as number) ?? 0;
+	}
+
+	/**
+	 * Get the earliest sequence number still in the log.
+	 * Used to detect cursors that fall before the backfill window
+	 * (so the firehose can send an OutdatedCursor info frame).
+	 */
+	getEarliestSeq(): number | null {
+		const result = this.sql
+			.exec("SELECT MIN(seq) as seq FROM firehose_events")
+			.one();
+		const seq = result?.seq;
+		return typeof seq === "number" ? seq : null;
 	}
 
 	/**

--- a/packages/pds/test/firehose.test.ts
+++ b/packages/pds/test/firehose.test.ts
@@ -3,7 +3,12 @@ import { CarReader } from "@ipld/car";
 import { decodeAll } from "@atproto/lex-cbor";
 import { env, worker, runInDurableObject } from "./helpers";
 import type { AccountDurableObject } from "../src/account-do";
-import type { SeqCommitEvent, SeqIdentityEvent } from "../src/sequencer";
+import type {
+	SeqCommitEvent,
+	SeqIdentityEvent,
+	SeqSyncEvent,
+	SeqAccountEvent,
+} from "../src/sequencer";
 
 /**
  * Decode a firehose frame into header and body.
@@ -441,6 +446,419 @@ describe("Firehose (subscribeRepos)", () => {
 				expect(result).toHaveProperty("seq");
 				expect(typeof result.seq).toBe("number");
 				expect(result.seq).toBeGreaterThan(0);
+			});
+		});
+
+		it("emits an identity event without a handle (handle is optional per sync 1.1)", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const sequencer = (instance as any).sequencer;
+				const seqBefore = sequencer.getLatestSeq();
+
+				await instance.rpcEmitIdentityEvent();
+
+				const events = await sequencer.getEventsSince(seqBefore, 10);
+				const identityEvent = events.find(
+					(e: any) => e.type === "identity",
+				) as SeqIdentityEvent | undefined;
+				expect(identityEvent).toBeDefined();
+				expect(identityEvent!.event.did).toBe(env.DID);
+				expect(identityEvent!.event.handle).toBeUndefined();
+			});
+		});
+	});
+
+	describe("sync 1.1 #commit shape", () => {
+		it("emits prevData on every commit so relays can run MST inversion", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const sequencer = (instance as any).sequencer;
+				const seqBefore = sequencer.getLatestSeq();
+
+				await instance.rpcCreateRecord(
+					"app.bsky.feed.post",
+					"prevdata-test-1",
+					{
+						text: "first",
+						createdAt: new Date().toISOString(),
+					},
+				);
+				await instance.rpcCreateRecord(
+					"app.bsky.feed.post",
+					"prevdata-test-2",
+					{
+						text: "second",
+						createdAt: new Date().toISOString(),
+					},
+				);
+
+				const events = (await sequencer.getEventsSince(
+					seqBefore,
+					10,
+				)) as SeqCommitEvent[];
+				expect(events.length).toBeGreaterThanOrEqual(2);
+
+				// Every commit must carry prevData. Decoded events come back
+				// with prevData as a CidLinkWrapper — access via .$link.
+				for (const event of events) {
+					expect(event.event.prevData).toBeDefined();
+					expect(event.event.prevData).not.toBeNull();
+					expect(
+						(event.event.prevData as unknown as { $link: string }).$link,
+					).toMatch(/^bafy/);
+				}
+
+				// MST root changes after each write, so the two prevData CIDs
+				// from consecutive writes must differ.
+				const [first, second] = events;
+				const firstLink = (
+					first!.event.prevData as unknown as { $link: string }
+				).$link;
+				const secondLink = (
+					second!.event.prevData as unknown as { $link: string }
+				).$link;
+				expect(firstLink).not.toBe(secondLink);
+			});
+		});
+
+		it("sets tooBig=false unconditionally (deprecated per sync 1.1)", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const sequencer = (instance as any).sequencer;
+				const seqBefore = sequencer.getLatestSeq();
+
+				await instance.rpcCreateRecord("app.bsky.feed.post", "toobig-test", {
+					text: "small",
+					createdAt: new Date().toISOString(),
+				});
+
+				const [event] = (await sequencer.getEventsSince(
+					seqBefore,
+					1,
+				)) as SeqCommitEvent[];
+				expect(event!.event.tooBig).toBe(false);
+			});
+		});
+
+		it("sets ops[].prev on delete and update, omits on create", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const sequencer = (instance as any).sequencer;
+
+				const createResult = await instance.rpcCreateRecord(
+					"app.bsky.feed.post",
+					"prev-test-record",
+					{
+						text: "v1",
+						createdAt: new Date().toISOString(),
+					},
+				);
+				const originalCid = createResult.cid;
+
+				const seqBeforeUpdate = sequencer.getLatestSeq();
+				const updateResult = await instance.rpcPutRecord(
+					"app.bsky.feed.post",
+					"prev-test-record",
+					{
+						text: "v2",
+						createdAt: new Date().toISOString(),
+					},
+				);
+				const updatedCid = updateResult.cid;
+
+				const seqBeforeDelete = sequencer.getLatestSeq();
+				await instance.rpcDeleteRecord(
+					"app.bsky.feed.post",
+					"prev-test-record",
+				);
+
+				const updateEvents = (await sequencer.getEventsSince(
+					seqBeforeUpdate,
+					1,
+				)) as SeqCommitEvent[];
+				const updateOp = updateEvents[0]!.event.ops[0]!;
+				expect(updateOp.action).toBe("update");
+				expect((updateOp.prev as unknown as { $link: string }).$link).toBe(
+					originalCid,
+				);
+
+				const deleteEvents = (await sequencer.getEventsSince(
+					seqBeforeDelete,
+					1,
+				)) as SeqCommitEvent[];
+				const deleteOp = deleteEvents[0]!.event.ops[0]!;
+				expect(deleteOp.action).toBe("delete");
+				expect(deleteOp.cid).toBeNull();
+				expect((deleteOp.prev as unknown as { $link: string }).$link).toBe(
+					updatedCid,
+				);
+
+				// Sanity: creates have no prev field.
+				const seqBeforeCreate = sequencer.getLatestSeq();
+				await instance.rpcCreateRecord("app.bsky.feed.post", "no-prev-test", {
+					text: "fresh",
+					createdAt: new Date().toISOString(),
+				});
+				const createEvents = (await sequencer.getEventsSince(
+					seqBeforeCreate,
+					1,
+				)) as SeqCommitEvent[];
+				const createOp = createEvents[0]!.event.ops[0]!;
+				expect(createOp.action).toBe("create");
+				expect(createOp.prev).toBeUndefined();
+			});
+		});
+
+		it("prevData on commit N equals the prior commit's data MST root", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const sequencer = (instance as any).sequencer;
+				const seqBefore = sequencer.getLatestSeq();
+
+				await instance.rpcCreateRecord("app.bsky.feed.post", "prevdata-link-a", {
+					text: "a",
+					createdAt: new Date().toISOString(),
+				});
+				await instance.rpcCreateRecord("app.bsky.feed.post", "prevdata-link-b", {
+					text: "b",
+					createdAt: new Date().toISOString(),
+				});
+
+				const events = (await sequencer.getEventsSince(
+					seqBefore,
+					10,
+				)) as SeqCommitEvent[];
+				expect(events.length).toBeGreaterThanOrEqual(2);
+				const [first, second] = events;
+
+				// Decode the first commit block from its CAR to read its `data` field.
+				const firstReader = await CarReader.fromBytes(first!.event.blocks);
+				const firstRoots = await firstReader.getRoots();
+				const firstCommitBlock = await firstReader.get(firstRoots[0]!);
+				expect(firstCommitBlock).toBeDefined();
+				// The commit object is DAG-CBOR. Decode and pull out `data`.
+				const { decode: decodeCbor } = await import("../src/cbor-compat");
+				const decodedCommit = decodeCbor(firstCommitBlock!.bytes) as {
+					data: { $link: string };
+				};
+				expect(decodedCommit.data?.$link).toMatch(/^bafy/);
+
+				const secondPrevDataLink = (
+					second!.event.prevData as unknown as { $link: string }
+				).$link;
+				expect(secondPrevDataLink).toBe(decodedCommit.data.$link);
+			});
+		});
+
+		it("rejects applyWrites with more than 200 ops (sync 1.1 cap)", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const writes = Array.from({ length: 201 }, (_, i) => ({
+					$type: "com.atproto.repo.applyWrites#create",
+					collection: "app.bsky.feed.post",
+					value: {
+						text: `bulk ${i}`,
+						createdAt: new Date().toISOString(),
+					},
+				}));
+				await expect(instance.rpcApplyWrites(writes)).rejects.toThrow(
+					/at most 200 operations/,
+				);
+			});
+		});
+	});
+
+	describe("sync 1.1 #account and #sync events", () => {
+		it("emits #account(active=false) on deactivate and #account+#sync on activate", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const sequencer = (instance as any).sequencer;
+
+				// Make sure there's a repo root so activate can emit #sync.
+				await instance.rpcCreateRecord("app.bsky.feed.post", "ensure-root", {
+					text: "x",
+					createdAt: new Date().toISOString(),
+				});
+
+				const seqBeforeDeactivate = sequencer.getLatestSeq();
+				await instance.rpcDeactivateAccount();
+				const deactivateEvents = await sequencer.getEventsSince(
+					seqBeforeDeactivate,
+					10,
+				);
+				const accountEvt = deactivateEvents.find(
+					(e: any) => e.type === "account",
+				) as SeqAccountEvent | undefined;
+				expect(accountEvt).toBeDefined();
+				expect(accountEvt!.event.active).toBe(false);
+				expect(accountEvt!.event.status).toBe("deactivated");
+
+				const seqBeforeActivate = sequencer.getLatestSeq();
+				await instance.rpcActivateAccount();
+				const activateEvents = await sequencer.getEventsSince(
+					seqBeforeActivate,
+					10,
+				);
+				const account = activateEvents.find(
+					(e: any) => e.type === "account",
+				) as SeqAccountEvent | undefined;
+				const identity = activateEvents.find(
+					(e: any) => e.type === "identity",
+				) as SeqIdentityEvent | undefined;
+				const sync = activateEvents.find(
+					(e: any) => e.type === "sync",
+				) as SeqSyncEvent | undefined;
+
+				expect(account).toBeDefined();
+				expect(account!.event.active).toBe(true);
+				expect(account!.event.status).toBeUndefined();
+
+				expect(identity).toBeDefined();
+				expect(identity!.event.did).toBe(env.DID);
+
+				expect(sync).toBeDefined();
+				expect(sync!.event.did).toBe(env.DID);
+				expect(sync!.event.blocks).toBeInstanceOf(Uint8Array);
+				expect(sync!.event.blocks.length).toBeGreaterThan(0);
+
+				// Sync event's blocks CAR contains exactly the current commit block.
+				const reader = await CarReader.fromBytes(sync!.event.blocks);
+				const roots = await reader.getRoots();
+				expect(roots).toHaveLength(1);
+				const commitBlock = await reader.get(roots[0]!);
+				expect(commitBlock).toBeDefined();
+			});
+		});
+
+		it("idempotent activate/deactivate do not emit duplicate events", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const sequencer = (instance as any).sequencer;
+
+				await instance.rpcActivateAccount(); // ensure active
+				const seqBefore = sequencer.getLatestSeq();
+				await instance.rpcActivateAccount(); // no-op
+				expect(sequencer.getLatestSeq()).toBe(seqBefore);
+			});
+		});
+
+		it("#sync and #account frames decode to the right t-tag", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const encodeEventFrame = (instance as any).encodeEventFrame.bind(
+					instance,
+				);
+
+				const accountEvt: SeqAccountEvent = {
+					seq: 1,
+					type: "account",
+					time: new Date().toISOString(),
+					event: {
+						seq: 1,
+						did: env.DID,
+						active: true,
+						time: new Date().toISOString(),
+					},
+				};
+				const accountFrame = encodeEventFrame(accountEvt);
+				const accountDecoded = decodeFrame(accountFrame);
+				expect((accountDecoded.header as any).t).toBe("#account");
+
+				const syncEvt: SeqSyncEvent = {
+					seq: 2,
+					type: "sync",
+					time: new Date().toISOString(),
+					event: {
+						seq: 2,
+						did: env.DID,
+						rev: "3kt7qsl4nrk2x",
+						blocks: new Uint8Array(),
+						time: new Date().toISOString(),
+					},
+				};
+				const syncFrame = encodeEventFrame(syncEvt);
+				const syncDecoded = decodeFrame(syncFrame);
+				expect((syncDecoded.header as any).t).toBe("#sync");
+			});
+		});
+	});
+
+	describe("#info OutdatedCursor", () => {
+		it("sends an OutdatedCursor info frame when cursor is before retention window", async () => {
+			const id = env.ACCOUNT.idFromName("account");
+			const stub = env.ACCOUNT.get(id);
+
+			await runInDurableObject(stub, async (instance: AccountDurableObject) => {
+				await instance.getStorage();
+				const sequencer = (instance as any).sequencer;
+				const backfillFirehose = (instance as any).backfillFirehose.bind(
+					instance,
+				);
+
+				// Generate a few events so getEarliestSeq is non-null.
+				await instance.rpcCreateRecord(
+					"app.bsky.feed.post",
+					"outdated-cursor-seed-1",
+					{ text: "a", createdAt: new Date().toISOString() },
+				);
+				await instance.rpcCreateRecord(
+					"app.bsky.feed.post",
+					"outdated-cursor-seed-2",
+					{ text: "b", createdAt: new Date().toISOString() },
+				);
+
+				// Prune so the earliest seq is no longer 1; cursor of 0
+				// becomes "before the retention window".
+				await sequencer.pruneOldEvents(1);
+				const earliest = sequencer.getEarliestSeq();
+				expect(earliest).toBeGreaterThan(1);
+
+				// Capture frames the backfill would send.
+				const sent: Uint8Array[] = [];
+				const fakeWs = {
+					send(frame: Uint8Array) {
+						sent.push(frame);
+					},
+					deserializeAttachment() {
+						return { cursor: 0 };
+					},
+					serializeAttachment() {},
+					close() {},
+				};
+
+				await backfillFirehose(fakeWs as any, 0);
+
+				expect(sent.length).toBeGreaterThan(0);
+				const { header, body } = decodeFrame(sent[0]!);
+				expect(header).toMatchObject({ op: 1, t: "#info" });
+				expect(body).toMatchObject({ name: "OutdatedCursor" });
 			});
 		});
 	});


### PR DESCRIPTION
## Summary

Brings Cirrus's firehose up to AT Protocol sync 1.1 so the bsky.network relay's strict-validation warnings (notably `missing prevData field`, logged against `wisp.mk.gg` and other Cirrus hosts) stop firing, and so account/sync state propagates to relays without polling. Diagnosed from public relay log charts shared by [@calabro.io](https://bsky.app/profile/calabro.io) on [this thread](https://bsky.app/profile/bad-example.com/post/3mml3poj2bk27); cross-referenced against the upstream PDS reference impl at `bluesky-social/atproto/packages/pds/src/sequencer/events.ts`.

## What changed on the wire

**`#commit`**
- Adds `prevData` (the prior commit's MST root CID) so consumers can run the inductive MST-inversion verification.
- CAR slice now contains both `newBlocks` and `relevantBlocks` (the covering proof). Previously Cirrus shipped only the new-this-rev blocks via `SELECT bytes FROM blocks WHERE rev = ?`.
- Each `ops[]` entry gets `prev` on update/delete (prior record CID), omitted on create.
- `tooBig` pinned to `false`. It was previously `carBytes.length > 1_000_000`, which is meaningless under the modern spec — `tooBig` is deprecated.
- `rebase: false` retained for back-compat (unchanged).

**New event types**
- `#sync` — `{did, rev, blocks: CAR with the commit block, time}`. Emitted on activation so relays pick up the current state (e.g. after migration import) without diffing.
- `#account` — `{did, active, status?}` with `status ∈ {takendown, suspended, deleted, deactivated}`. Emitted on `rpcActivateAccount` (active=true) and `rpcDeactivateAccount` (active=false, status='deactivated'). Both previously just flipped a SQLite flag.

**`#identity`**
- `handle` is now optional (per spec — presence does not signal a change).
- `rpcEmitIdentityEvent` now routes through `sequencer.sequenceIdentity` instead of writing empty payloads to the DB.

**Cursor handling**
- A `#info` frame with `name: "OutdatedCursor"` is sent when a client connects with a cursor before the retention window; the stream continues from the oldest available event instead of disconnecting.

**Spec caps**
- `applyWrites` rejects >200 operations.

## Implementation notes

- All four write paths (`rpcCreateRecord`, `rpcDeleteRecord`, `rpcPutRecord`, `rpcApplyWrites`) refactored from `repo.applyWrites(ops, keypair)` to `repo.formatCommit(ops, keypair)` + `repo.applyCommit(commit)` so the `CommitData` (with `newBlocks`, `relevantBlocks`, etc.) is exposed to the sequencer.
- Frame encoding generalized to `{op: 1, t: '#${event.type}'}` — single dispatch path for all four event kinds.
- `broadcastCommit` → `broadcastEvent` (the function was already generic over `SeqEvent`).
- `prevData` is captured as `repo.commit.data` *before* `applyCommit`. The signed commit object's `prev` field (prior commit CID) is unchanged — that's a different concept, handled by `@atproto/repo`.

## Test plan

- [x] All 279 pre-existing PDS tests still pass.
- [x] 10 new tests in `firehose.test.ts` covering: `prevData` presence + linkage to prior commit's `data` CID, `ops[].prev` for update/delete and absence for create, `tooBig=false`, the 200-op rejection, `#account` + `#identity` + `#sync` emitted on activate, `#account` on deactivate, idempotent activate not double-emitting, frame `t`-tag dispatch for `#sync`/`#account`, `OutdatedCursor` info frame, optional handle on `#identity`.
- [x] `pnpm exec tsc --noEmit` introduces zero new TypeScript errors (16 pre-existing unrelated errors remain).
- [x] `pnpm build` succeeds.
- [ ] After merge + deploy, monitor the relay dashboards in the [referenced thread](https://bsky.app/profile/bad-example.com/post/3mml3poj2bk27) — `wisp.mk.gg`'s `missing prevData field` count should drop to zero.