### PR TITLE
fix(oauth-provider): accept query-only granular scopes

### DIFF
--- a/.changeset/oauth-scope-query-form.md
+++ b/.changeset/oauth-scope-query-form.md
@@ -1,0 +1,5 @@
+---
+"@getcirrus/oauth-provider": patch
+---
+
+Fix `parseScope` rejecting valid granular scopes that use the query-only form (e.g. `repo?collection=a&collection=b`) with `Unknown scope resource`. The parser previously only looked for `:` as the prefix delimiter, but per `@atproto/oauth-scopes` syntax a scope can use `prefix:positional`, `prefix?query`, or both. This affected permission sets whose `repo` permission listed multiple collections, since those expand to a single query-form token.

--- a/packages/oauth-provider/src/scopes.ts
+++ b/packages/oauth-provider/src/scopes.ts
@@ -124,7 +124,10 @@ export function parseScope(
 		}
 
 		const colon = scope.indexOf(":");
-		const resource = colon === -1 ? scope : scope.slice(0, colon);
+		const question = scope.indexOf("?");
+		const end =
+			colon === -1 ? question : question === -1 ? colon : Math.min(colon, question);
+		const resource = end === -1 ? scope : scope.slice(0, end);
 		const parser =
 			STRUCTURAL_PARSERS[
 				resource as (typeof GRANULAR_RESOURCES)[number]

--- a/packages/oauth-provider/test/scopes.test.ts
+++ b/packages/oauth-provider/test/scopes.test.ts
@@ -60,6 +60,21 @@ describe("parseScope", () => {
 		expect(() => parseScope("atproto madeup:thing")).toThrow(ScopeParseError);
 	});
 
+	it("accepts repo scopes in query-only form (no positional)", () => {
+		const set = parseScope("atproto repo?collection=app.bsky.feed.post");
+		expect(set.has("repo?collection=app.bsky.feed.post")).toBe(true);
+	});
+
+	it("accepts repo scopes with multiple collections", () => {
+		const scope =
+			"repo?collection=site.standard.document" +
+			"&collection=site.standard.graph.recommend" +
+			"&collection=site.standard.graph.subscription" +
+			"&collection=site.standard.publication";
+		const set = parseScope(`atproto ${scope}`);
+		expect(set.has(scope)).toBe(true);
+	});
+
 	it("rejects include: scopes by default (strict mode)", () => {
 		expect(() =>
 			parseScope("atproto include:com.example.basic?aud=did:web:foo%23svc"),


### PR DESCRIPTION
## Summary

- `parseScope` rejected canonical granular scopes that use the query-only form (`prefix?query`), e.g. `repo?collection=a&collection=b`, with `Unknown scope resource`. It only looked for `:` to find the resource prefix.
- Fix: use the earlier of `:` and `?` as the prefix delimiter, matching `@atproto/oauth-scopes` syntax. Now `repo?collection=…&collection=…` is recognised as a `repo` permission.
- Real-world hit: expanding `include:site.standard.authFull` (a permission set with multiple collections in one `repo` permission) serialises to a single query-form token, which then failed to parse.

## Test plan

- [x] New regression tests in `packages/oauth-provider/test/scopes.test.ts` covering the bare `repo?collection=…` form and the multi-collection case from the `standard.site` failure.
- [x] `pnpm vitest run test/scopes.test.ts` — 28 passing.