### PR TITLE
fix(pds): accept create+delete on the same rkey in applyWrites

### DIFF
--- a/.changeset/applywrites-same-rkey-batch.md
+++ b/.changeset/applywrites-same-rkey-batch.md
@@ -1,0 +1,5 @@
+---
+"@getcirrus/pds": patch
+---
+
+`com.atproto.repo.applyWrites` now accepts batches that touch the same rkey more than once, matching the reference PDS. The common case is a create followed by a delete on the same rkey within one batch (an atomic no-op pattern several clients rely on); previously Cirrus rejected this with `400 InvalidRequest: duplicate rkey in batch`. Two creates on the same rkey still fail, but now as `409 RecordAlreadyExists` from the repo layer rather than a pre-flight 400.

--- a/packages/pds/src/xrpc/repo.ts
+++ b/packages/pds/src/xrpc/repo.ts
@@ -513,10 +513,6 @@ export async function applyWrites(
 		value?: unknown;
 		validationStatus?: ValidationStatus;
 	}> = [];
-	// Detect intra-batch rkey duplicates here (client error → 400) so they
-	// don't surface from the DO as 409 RecordAlreadyExists, which is reserved
-	// for collisions against existing repo state.
-	const seenRkeys = new Set<string>();
 
 	for (let i = 0; i < writes.length; i++) {
 		const write = writes[i];
@@ -565,20 +561,6 @@ export async function applyWrites(
 					400,
 				);
 			}
-		}
-
-		if (typeof write.rkey === "string") {
-			const composite = `${write.collection}/${write.rkey}`;
-			if (seenRkeys.has(composite)) {
-				return c.json(
-					{
-						error: "InvalidRequest",
-						message: `Write ${i}: duplicate rkey in batch (${composite})`,
-					},
-					400,
-				);
-			}
-			seenRkeys.add(composite);
 		}
 
 		if (action === "delete") {

--- a/packages/pds/test/xrpc.test.ts
+++ b/packages/pds/test/xrpc.test.ts
@@ -1227,7 +1227,58 @@ describe("XRPC Endpoints", () => {
 			expect(data.results[1].validationStatus).toBe("unknown");
 		});
 
-		it("rejects intra-batch duplicate rkey as 400 InvalidRequest (not 409)", async () => {
+		it("accepts create+delete on the same rkey atomically, leaving no record", async () => {
+			const rkey = genTid();
+			const response = await worker.fetch(
+				new Request("http://pds.test/xrpc/com.atproto.repo.applyWrites", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: `Bearer ${env.AUTH_TOKEN}`,
+					},
+					body: JSON.stringify({
+						repo: env.DID,
+						writes: [
+							{
+								$type: "com.atproto.repo.applyWrites#create",
+								collection: "app.bsky.feed.post",
+								rkey,
+								value: {
+									$type: "app.bsky.feed.post",
+									text: "ephemeral",
+									createdAt: new Date().toISOString(),
+								},
+							},
+							{
+								$type: "com.atproto.repo.applyWrites#delete",
+								collection: "app.bsky.feed.post",
+								rkey,
+							},
+						],
+					}),
+				}),
+				env,
+			);
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as any;
+			expect(data.results).toHaveLength(2);
+			expect(data.results[0].$type).toBe(
+				"com.atproto.repo.applyWrites#createResult",
+			);
+			expect(data.results[1].$type).toBe(
+				"com.atproto.repo.applyWrites#deleteResult",
+			);
+
+			const getResponse = await worker.fetch(
+				new Request(
+					`http://pds.test/xrpc/com.atproto.repo.getRecord?repo=${env.DID}&collection=app.bsky.feed.post&rkey=${rkey}`,
+				),
+				env,
+			);
+			expect(getResponse.status).toBe(404);
+		});
+
+		it("rejects two creates for the same rkey as 409 RecordAlreadyExists", async () => {
 			const dupRkey = genTid();
 			const response = await worker.fetch(
 				new Request("http://pds.test/xrpc/com.atproto.repo.applyWrites", {
@@ -1264,10 +1315,9 @@ describe("XRPC Endpoints", () => {
 				}),
 				env,
 			);
-			expect(response.status).toBe(400);
+			expect(response.status).toBe(409);
 			const data = (await response.json()) as any;
-			expect(data.error).toBe("InvalidRequest");
-			expect(data.message).toMatch(/duplicate rkey in batch/i);
+			expect(data.error).toBe("RecordAlreadyExists");
 		});
 
 		it("rejects validate=true with unknown collection in applyWrites as 400", async () => {


### PR DESCRIPTION
## Summary

- `com.atproto.repo.applyWrites` was rejecting any batch that referenced the same `${collection}/${rkey}` twice with `400 InvalidRequest: duplicate rkey in batch`. That broke a legitimate atomic create+delete pattern used by real-world clients (and exercised by pdscheck's atomic create+delete test) which the reference PDS accepts.
- Drop the pre-flight `seenRkeys` collision check in `packages/pds/src/xrpc/repo.ts`. The downstream apply order in `account-do.ts` already produces the correct outcome: a create followed by a delete on the same key nets to no record, and two creates collide naturally inside the DO and surface as `409 RecordAlreadyExists` (the spec-correct status for an existing-key collision).
- Added tests covering the happy path (create+delete same rkey → 200, no record persists) and the narrow remaining check (two creates same rkey → 409).

## Test plan

- [x] `pnpm --filter @getcirrus/pds test` (293 unit + 84 CLI tests passing)
- [x] `pnpm --filter @getcirrus/pds check`
- [ ] Re-run pdscheck's atomic create+delete test against a Cirrus PDS built from this branch