### PR TITLE
feat(oauth-provider): advertise jwks_uri in authorization-server metadata

### DIFF
--- a/.changeset/oauth-jwks-uri.md
+++ b/.changeset/oauth-jwks-uri.md
@@ -1,0 +1,6 @@
+---
+"@getcirrus/oauth-provider": minor
+"@getcirrus/pds": patch
+---
+
+Advertise a `jwks_uri` in OAuth authorization-server metadata and serve an empty JWKS at `/oauth/jwks`. OAuth clients that run JWKS discovery against the metadata endpoint no longer fail when talking to Cirrus. The key set is empty because Cirrus signs access tokens with HS256 (symmetric `JWT_SECRET`) — there are no public keys to publish.

--- a/packages/oauth-provider/src/provider.ts
+++ b/packages/oauth-provider/src/provider.ts
@@ -901,6 +901,7 @@ export class ATProtoOAuthProvider {
 			authorization_endpoint: `${this.issuer}/oauth/authorize`,
 			token_endpoint: `${this.issuer}/oauth/token`,
 			userinfo_endpoint: `${this.issuer}/oauth/userinfo`,
+			jwks_uri: `${this.issuer}/oauth/jwks`,
 			response_types_supported: ["code"],
 			response_modes_supported: ["fragment", "query"],
 			grant_types_supported: ["authorization_code", "refresh_token"],
@@ -932,6 +933,24 @@ export class ATProtoOAuthProvider {
 		} as OAuthAuthorizationServerMetadata;
 
 		return new Response(JSON.stringify(metadata), {
+			status: 200,
+			headers: {
+				"Content-Type": "application/json",
+				"Cache-Control": "max-age=3600",
+			},
+		});
+	}
+
+	/**
+	 * Handle JWKS request (GET /oauth/jwks)
+	 *
+	 * Cirrus signs access tokens with HS256 (symmetric secret), so there are no
+	 * public keys to publish for token verification. The endpoint exists for
+	 * ecosystem compatibility — RFC 8414 marks `jwks_uri` as RECOMMENDED and
+	 * some OAuth clients fetch it unconditionally during discovery.
+	 */
+	handleJwks(): Response {
+		return new Response(JSON.stringify({ keys: [] }), {
 			status: 200,
 			headers: {
 				"Content-Type": "application/json",

--- a/packages/oauth-provider/test/oauth-flow.test.ts
+++ b/packages/oauth-provider/test/oauth-flow.test.ts
@@ -462,6 +462,18 @@ describe("OAuth Flow", () => {
 			expect(json.response_types_supported).toContain("code");
 			expect(json.code_challenge_methods_supported).toContain("S256");
 			expect(json.dpop_signing_alg_values_supported).toContain("ES256");
+			expect(json.jwks_uri).toBe("https://pds.example.com/oauth/jwks");
+		});
+	});
+
+	describe("JWKS Endpoint", () => {
+		it("returns an empty JWKS", async () => {
+			const response = provider.handleJwks();
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toBe("application/json");
+
+			const json = (await response.json()) as { keys: unknown[] };
+			expect(json).toEqual({ keys: [] });
 		});
 	});
 

--- a/packages/pds/src/oauth.ts
+++ b/packages/pds/src/oauth.ts
@@ -262,6 +262,12 @@ export function createOAuthApp(
 		return provider.handleMetadata();
 	});
 
+	// JWKS endpoint (empty — Cirrus signs tokens with HS256)
+	oauth.get("/oauth/jwks", (c) => {
+		const provider = getProvider(c.env);
+		return provider.handleJwks();
+	});
+
 	// Protected resource metadata (for token introspection discovery)
 	oauth.get("/.well-known/oauth-protected-resource", (c) => {
 		const issuer = `https://${c.env.PDS_HOSTNAME}`;

--- a/packages/pds/test/oauth.test.ts
+++ b/packages/pds/test/oauth.test.ts
@@ -40,6 +40,31 @@ describe("OAuth 2.1 Endpoints", () => {
 			);
 		});
 
+		it("should advertise jwks_uri pointing at /oauth/jwks", async () => {
+			const response = await worker.fetch(
+				new Request("http://pds.test/.well-known/oauth-authorization-server"),
+				env,
+			);
+			const metadata = await response.json();
+			expect(metadata.jwks_uri).toBe(
+				`https://${env.PDS_HOSTNAME}/oauth/jwks`,
+			);
+		});
+
+		it("should serve an empty JWKS at the advertised URL", async () => {
+			const response = await worker.fetch(
+				new Request("http://pds.test/oauth/jwks"),
+				env,
+			);
+			expect(response.status).toBe(200);
+			expect(response.headers.get("Content-Type")).toContain(
+				"application/json",
+			);
+
+			const jwks = await response.json();
+			expect(jwks).toEqual({ keys: [] });
+		});
+
 		it("should return protected resource metadata", async () => {
 			const response = await worker.fetch(
 				new Request("http://pds.test/.well-known/oauth-protected-resource"),


### PR DESCRIPTION
## Summary

- Add `jwks_uri` (RFC 8414 RECOMMENDED) to the OAuth 2.1 authorization-server metadata at `/.well-known/oauth-authorization-server`, pointing at `/oauth/jwks` on the issuer.
- Serve an empty JWKS (`{"keys": []}`) at `/oauth/jwks` via a new `handleJwks()` method on the provider, wired through the PDS Hono app alongside the existing OAuth routes.
- Add unit tests in the oauth-provider package and integration tests in the PDS package.

The JWKS is intentionally empty: Cirrus signs access tokens with HS256 (symmetric `JWT_SECRET`), so there are no public keys to publish for token verification. The endpoint exists for ecosystem compatibility — OAuth clients commonly probe `jwks_uri` during discovery, and the reference atproto PDS publishes the same empty document.

ES256 keys used for `private_key_jwt` client authentication and DPoP are client-side keys, not server keys, so they don't belong in the server JWKS either.

## Test plan

- [x] `pnpm --filter @getcirrus/oauth-provider test` — 116 passed
- [x] `pnpm --filter @getcirrus/oauth-provider check` — publint + attw clean
- [x] `pnpm --filter @getcirrus/pds test` — 303 unit + 84 CLI passed
- [ ] After deploy: `curl https://pds.mk.gg/.well-known/oauth-authorization-server | jq .jwks_uri` returns the URL
- [ ] After deploy: `curl https://pds.mk.gg/oauth/jwks` returns `{"keys":[]}` with `Content-Type: application/json`