### PR TITLE
feat(pds): implement PDS-side identity endpoints

### DIFF
--- a/.changeset/pds-identity-endpoints.md
+++ b/.changeset/pds-identity-endpoints.md
@@ -1,0 +1,11 @@
+---
+"@getcirrus/pds": minor
+---
+
+Implement three PDS-side identity endpoints that previously fell through to the AppView proxy and returned 501:
+
+- `com.atproto.identity.resolveDid` returns the DID document for the local account.
+- `com.atproto.identity.resolveIdentity` returns `{did, handle, didDoc}` for the local handle or DID.
+- `com.atproto.identity.getRecommendedDidCredentials` (authenticated) returns the rotation keys, `alsoKnownAs`, verification methods, and PDS service entry that a migrating account should advertise.
+
+Requests for foreign DIDs or handles continue to fall through to the AppView proxy unchanged.

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -107,31 +107,7 @@ function getAccountDO(env: PDSEnv) {
 
 // DID document for did:web resolution
 app.get("/.well-known/did.json", (c) => {
-	const didDocument = {
-		"@context": [
-			"https://www.w3.org/ns/did/v1",
-			"https://w3id.org/security/multikey/v1",
-			"https://w3id.org/security/suites/secp256k1-2019/v1",
-		],
-		id: c.env.DID,
-		alsoKnownAs: [`at://${c.env.HANDLE}`],
-		verificationMethod: [
-			{
-				id: `${c.env.DID}#atproto`,
-				type: "Multikey",
-				controller: c.env.DID,
-				publicKeyMultibase: c.env.SIGNING_KEY_PUBLIC,
-			},
-		],
-		service: [
-			{
-				id: "#atproto_pds",
-				type: "AtprotoPersonalDataServer",
-				serviceEndpoint: `https://${c.env.PDS_HOSTNAME}`,
-			},
-		],
-	};
-	return c.json(didDocument);
+	return c.json(identity.buildDidDocument(c.env));
 });
 
 // Handle verification for AT Protocol
@@ -305,6 +281,22 @@ app.use("/xrpc/com.atproto.identity.resolveHandle", async (c, next) => {
 	}
 	await next();
 });
+
+// DID resolution - serve our DID doc for our DID, others fall through to proxy
+app.use("/xrpc/com.atproto.identity.resolveDid", identity.resolveDid);
+
+// Identity resolution - serve our identity for our DID/handle, others fall through
+app.use(
+	"/xrpc/com.atproto.identity.resolveIdentity",
+	identity.resolveIdentity,
+);
+
+// Recommended PLC credentials for inbound migration
+app.get(
+	"/xrpc/com.atproto.identity.getRecommendedDidCredentials",
+	requireAuth,
+	identity.getRecommendedDidCredentials,
+);
 
 // Identity management for outbound migration
 // These endpoints allow migrating FROM Cirrus to another PDS

--- a/packages/pds/src/xrpc/identity.ts
+++ b/packages/pds/src/xrpc/identity.ts
@@ -16,13 +16,130 @@ import type { Context } from "hono";
 import { Secp256k1Keypair } from "@atproto/crypto";
 import { encode } from "@atcute/cbor";
 import { base64url } from "jose";
-import type { AuthedAppEnv } from "../types";
+import type { AppEnv, AuthedAppEnv, PDSEnv } from "../types";
 import {
 	createMigrationToken,
 	validateMigrationToken,
 } from "../migration-token";
 
 const PLC_DIRECTORY = "https://plc.directory";
+
+/**
+ * Build the DID document for the local account.
+ *
+ * Shared between /.well-known/did.json and the
+ * com.atproto.identity.resolveDid / resolveIdentity endpoints.
+ */
+export function buildDidDocument(env: PDSEnv) {
+	return {
+		"@context": [
+			"https://www.w3.org/ns/did/v1",
+			"https://w3id.org/security/multikey/v1",
+			"https://w3id.org/security/suites/secp256k1-2019/v1",
+		],
+		id: env.DID,
+		alsoKnownAs: [`at://${env.HANDLE}`],
+		verificationMethod: [
+			{
+				id: `${env.DID}#atproto`,
+				type: "Multikey",
+				controller: env.DID,
+				publicKeyMultibase: env.SIGNING_KEY_PUBLIC,
+			},
+		],
+		service: [
+			{
+				id: "#atproto_pds",
+				type: "AtprotoPersonalDataServer",
+				serviceEndpoint: `https://${env.PDS_HOSTNAME}`,
+			},
+		],
+	};
+}
+
+/**
+ * Resolve a DID to its DID document.
+ *
+ * For our local DID we serve the document directly. Any other DID is
+ * passed through to the next handler (the AppView proxy).
+ *
+ * Endpoint: GET com.atproto.identity.resolveDid
+ */
+export async function resolveDid(
+	c: Context<AppEnv>,
+	next: () => Promise<void>,
+): Promise<Response | void> {
+	const did = c.req.query("did");
+	if (!did) {
+		return c.json(
+			{ error: "InvalidRequest", message: "Missing required parameter: did" },
+			400,
+		);
+	}
+	if (did === c.env.DID) {
+		return c.json({ didDoc: buildDidDocument(c.env) });
+	}
+	await next();
+}
+
+/**
+ * Resolve an identifier (handle or DID) to its full identity.
+ *
+ * For our local handle or DID we serve the response directly. Anything
+ * else falls through to the AppView proxy.
+ *
+ * Endpoint: GET com.atproto.identity.resolveIdentity
+ */
+export async function resolveIdentity(
+	c: Context<AppEnv>,
+	next: () => Promise<void>,
+): Promise<Response | void> {
+	const identifier = c.req.query("identifier");
+	if (!identifier) {
+		return c.json(
+			{
+				error: "InvalidRequest",
+				message: "Missing required parameter: identifier",
+			},
+			400,
+		);
+	}
+	if (identifier === c.env.DID || identifier === c.env.HANDLE) {
+		return c.json({
+			did: c.env.DID,
+			handle: c.env.HANDLE,
+			didDoc: buildDidDocument(c.env),
+		});
+	}
+	await next();
+}
+
+/**
+ * Return recommended PLC credentials for the current account.
+ *
+ * Used by other PDSes during an inbound migration to discover the
+ * keys / services they should attach to a new PLC operation.
+ *
+ * Endpoint: GET com.atproto.identity.getRecommendedDidCredentials
+ */
+export async function getRecommendedDidCredentials(
+	c: Context<AuthedAppEnv>,
+): Promise<Response> {
+	const keypair = await Secp256k1Keypair.import(c.env.SIGNING_KEY);
+	const signingKey = keypair.did();
+
+	return c.json({
+		rotationKeys: [signingKey],
+		alsoKnownAs: [`at://${c.env.HANDLE}`],
+		verificationMethods: { atproto: signingKey },
+		services: {
+			atproto_pds: {
+				type: "AtprotoPersonalDataServer",
+				endpoint: `https://${c.env.PDS_HOSTNAME}`,
+			},
+		},
+	});
+}
 
 /**
  * PLC operation structure

--- a/packages/pds/test/identity.test.ts
+++ b/packages/pds/test/identity.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { Secp256k1Keypair } from "@atproto/crypto";
+import { env, worker } from "./helpers";
+
+describe("Identity Endpoints", () => {
+	describe("com.atproto.identity.resolveDid", () => {
+		it("returns the DID document for our DID", async () => {
+			const response = await worker.fetch(
+				new Request(
+					`http://pds.test/xrpc/com.atproto.identity.resolveDid?did=${env.DID}`,
+				),
+				env,
+			);
+			expect(response.status).toBe(200);
+
+			const data = (await response.json()) as { didDoc: Record<string, unknown> };
+			expect(data.didDoc).toBeDefined();
+			expect(data.didDoc.id).toBe(env.DID);
+			expect(data.didDoc.alsoKnownAs).toEqual([`at://${env.HANDLE}`]);
+			expect(Array.isArray(data.didDoc.verificationMethod)).toBe(true);
+			expect(Array.isArray(data.didDoc.service)).toBe(true);
+			const services = data.didDoc.service as Array<{
+				id: string;
+				type: string;
+				serviceEndpoint: string;
+			}>;
+			expect(services[0]).toMatchObject({
+				id: "#atproto_pds",
+				type: "AtprotoPersonalDataServer",
+				serviceEndpoint: `https://${env.PDS_HOSTNAME}`,
+			});
+		});
+
+		it("returns 400 when did param is missing", async () => {
+			const response = await worker.fetch(
+				new Request("http://pds.test/xrpc/com.atproto.identity.resolveDid"),
+				env,
+			);
+			expect(response.status).toBe(400);
+			const data = (await response.json()) as { error: string };
+			expect(data.error).toBe("InvalidRequest");
+		});
+
+		it("falls through to the AppView proxy for foreign DIDs", async () => {
+			const response = await worker.fetch(
+				new Request(
+					"http://pds.test/xrpc/com.atproto.identity.resolveDid?did=did:web:other.example",
+				),
+				env,
+			);
+			expect(response.status).not.toBe(404);
+		});
+	});
+
+	describe("com.atproto.identity.resolveIdentity", () => {
+		it("returns identity info for our DID", async () => {
+			const response = await worker.fetch(
+				new Request(
+					`http://pds.test/xrpc/com.atproto.identity.resolveIdentity?identifier=${env.DID}`,
+				),
+				env,
+			);
+			expect(response.status).toBe(200);
+
+			const data = (await response.json()) as {
+				did: string;
+				handle: string;
+				didDoc: { id: string };
+			};
+			expect(data.did).toBe(env.DID);
+			expect(data.handle).toBe(env.HANDLE);
+			expect(data.didDoc.id).toBe(env.DID);
+		});
+
+		it("returns identity info for our handle", async () => {
+			const response = await worker.fetch(
+				new Request(
+					`http://pds.test/xrpc/com.atproto.identity.resolveIdentity?identifier=${env.HANDLE}`,
+				),
+				env,
+			);
+			expect(response.status).toBe(200);
+
+			const data = (await response.json()) as {
+				did: string;
+				handle: string;
+				didDoc: { id: string };
+			};
+			expect(data.did).toBe(env.DID);
+			expect(data.handle).toBe(env.HANDLE);
+			expect(data.didDoc.id).toBe(env.DID);
+		});
+
+		it("returns 400 when identifier param is missing", async () => {
+			const response = await worker.fetch(
+				new Request(
+					"http://pds.test/xrpc/com.atproto.identity.resolveIdentity",
+				),
+				env,
+			);
+			expect(response.status).toBe(400);
+			const data = (await response.json()) as { error: string };
+			expect(data.error).toBe("InvalidRequest");
+		});
+
+		it("falls through to the AppView proxy for foreign identifiers", async () => {
+			const response = await worker.fetch(
+				new Request(
+					"http://pds.test/xrpc/com.atproto.identity.resolveIdentity?identifier=bob.test",
+				),
+				env,
+			);
+			expect(response.status).not.toBe(404);
+		});
+	});
+
+	describe("com.atproto.identity.getRecommendedDidCredentials", () => {
+		it("requires authentication", async () => {
+			const response = await worker.fetch(
+				new Request(
+					"http://pds.test/xrpc/com.atproto.identity.getRecommendedDidCredentials",
+				),
+				env,
+			);
+			expect(response.status).toBe(401);
+		});
+
+		it("returns recommended credentials for the current account", async () => {
+			const response = await worker.fetch(
+				new Request(
+					"http://pds.test/xrpc/com.atproto.identity.getRecommendedDidCredentials",
+					{
+						headers: { Authorization: `Bearer ${env.AUTH_TOKEN}` },
+					},
+				),
+				env,
+			);
+			expect(response.status).toBe(200);
+
+			const data = (await response.json()) as {
+				rotationKeys: string[];
+				alsoKnownAs: string[];
+				verificationMethods: { atproto: string };
+				services: {
+					atproto_pds: { type: string; endpoint: string };
+				};
+			};
+
+			const expectedSigningKey = (
+				await Secp256k1Keypair.import(env.SIGNING_KEY)
+			).did();
+
+			expect(data.rotationKeys).toEqual([expectedSigningKey]);
+			expect(data.alsoKnownAs).toEqual([`at://${env.HANDLE}`]);
+			expect(data.verificationMethods).toEqual({ atproto: expectedSigningKey });
+			expect(data.services).toEqual({
+				atproto_pds: {
+					type: "AtprotoPersonalDataServer",
+					endpoint: `https://${env.PDS_HOSTNAME}`,
+				},
+			});
+			expect(expectedSigningKey.startsWith("did:key:")).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Implements three PDS-side `com.atproto.identity.*` endpoints that previously fell through to the AppView proxy and returned 501. Each follows the existing `resolveHandle` pattern: serve the local account directly, fall through to the proxy for foreign identities.

- **`resolveDid`** — returns `{didDoc}` for our local DID; foreign DIDs fall through to the AppView proxy.
- **`resolveIdentity`** — returns `{did, handle, didDoc}` for our local handle or DID; foreign identifiers fall through.
- **`getRecommendedDidCredentials`** (authenticated) — returns `rotationKeys`, `alsoKnownAs`, `verificationMethods`, and the `atproto_pds` service entry, used by other PDSes during inbound migration. The signing key is derived from `SIGNING_KEY` via `Secp256k1Keypair.import().did()`.

Also extracts the DID document construction (previously inlined in `/.well-known/did.json`) into a shared `buildDidDocument(env)` helper so the well-known route and the new XRPC routes return identical documents.

## Test plan

- [x] `pnpm --filter @getcirrus/pds test` — 303 unit + 84 CLI tests pass, including 9 new tests in `test/identity.test.ts` covering each endpoint's happy path, missing-param 400s, fall-through for foreign identifiers, and auth enforcement on `getRecommendedDidCredentials`.
- [x] `pnpm --filter @getcirrus/pds check` — publint + attw clean.