### PR TITLE
fix(pds): session auth + lexicon polish

### DIFF
--- a/.changeset/session-auth-polish.md
+++ b/.changeset/session-auth-polish.md
@@ -1,0 +1,9 @@
+---
+"@getcirrus/pds": patch
+---
+
+Fix three conformance issues found by pdscheck:
+
+- `com.atproto.server.getSession` now accepts OAuth access tokens presented with the `DPoP` scheme (RFC 9449), not just `Bearer`. OAuth clients can now read session info without first being rejected with 401.
+- `com.atproto.server.listAppPasswords` returns `createdAt` as an RFC 3339 datetime (e.g. `2026-03-29T15:30:17.000Z`) instead of the SQLite `"YYYY-MM-DD HH:MM:SS"` form that violated the lexicon.
+- `com.atproto.server.getAccountInviteCodes` is now implemented and returns `{ codes: [] }` for authenticated callers (Cirrus has `inviteCodeRequired: false`, so there are no invite codes to list). Previously it fell through to the AppView proxy and returned 501.

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -296,6 +296,11 @@ app.get("/xrpc/com.atproto.repo.listMissingBlobs", requireAuth, (c) =>
 
 // Server identity
 app.get("/xrpc/com.atproto.server.describeServer", server.describeServer);
+app.get(
+	"/xrpc/com.atproto.server.getAccountInviteCodes",
+	requireAuth,
+	server.getAccountInviteCodes,
+);
 
 // Handle resolution - return our DID for our handle, let others fall through to proxy
 app.use("/xrpc/com.atproto.identity.resolveHandle", async (c, next) => {

--- a/packages/pds/src/storage.ts
+++ b/packages/pds/src/storage.ts
@@ -3,6 +3,20 @@ import { BlockMap, type CommitData } from "@atproto/repo";
 import { ReadableBlockstore, type RepoStorage } from "@atproto/repo";
 
 /**
+ * Convert SQLite's `datetime('now')` output ("YYYY-MM-DD HH:MM:SS" in UTC) to
+ * an RFC 3339 / ISO 8601 string for lexicon-compliant API responses. Returns
+ * the input unchanged when it already parses as a date (e.g. ISO strings
+ * written by application code).
+ */
+function sqliteDatetimeToIso(value: string): string {
+	if (value.includes("T")) return value;
+	const iso = value.replace(" ", "T") + "Z";
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) return value;
+	return date.toISOString();
+}
+
+/**
  * SQLite-backed repository storage for Cloudflare Durable Objects.
  *
  * Implements the RepoStorage interface from @atproto/repo, storing blocks
@@ -718,7 +732,7 @@ export class SqliteRepoStorage
 
 		return rows.map((row) => ({
 			name: row.name as string,
-			createdAt: row.created_at as string,
+			createdAt: sqliteDatetimeToIso(row.created_at as string),
 		}));
 	}
 

--- a/packages/pds/src/xrpc/server.ts
+++ b/packages/pds/src/xrpc/server.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import { hash as bcryptHash } from "bcryptjs";
 import type { AccountDurableObject } from "../account-do";
 import { createServiceJwt, getSigningKeypair } from "../service-auth";
+import { getProvider } from "../oauth";
 import {
 	createAccessToken,
 	createRefreshToken,
@@ -238,7 +239,49 @@ export async function getSession(
 ): Promise<Response> {
 	const authHeader = c.req.header("Authorization");
 
-	if (!authHeader?.startsWith("Bearer ")) {
+	if (!authHeader) {
+		return c.json(
+			{
+				error: "AuthenticationRequired",
+				message: "Access token required",
+			},
+			401,
+		);
+	}
+
+	const buildResponse = async () => {
+		const { email: storedEmail } = await accountDO.rpcGetEmail();
+		const email = storedEmail || c.env.EMAIL;
+		return c.json({
+			handle: c.env.HANDLE,
+			did: c.env.DID,
+			...(email ? { email } : {}),
+			emailConfirmed: true,
+			active: true,
+		});
+	};
+
+	// OAuth DPoP-bound access tokens (RFC 9449)
+	if (authHeader.startsWith("DPoP ")) {
+		const provider = getProvider(c.env);
+		const tokenData = await provider.verifyAccessToken(c.req.raw);
+		if (!tokenData || tokenData.sub !== c.env.DID) {
+			return c.json(
+				{
+					error: "InvalidToken",
+					message: "Invalid access token",
+				},
+				401,
+				{
+					"WWW-Authenticate":
+						'DPoP error="invalid_token", error_description="Invalid access token"',
+				},
+			);
+		}
+		return buildResponse();
+	}
+
+	if (!authHeader.startsWith("Bearer ")) {
 		return c.json(
 			{
 				error: "AuthenticationRequired",
@@ -251,20 +294,10 @@ export async function getSession(
 	const token = authHeader.slice(7);
 	const serviceDid = `did:web:${c.env.PDS_HOSTNAME}`;
 
-	// First try static token
 	if (token === c.env.AUTH_TOKEN) {
-		const { email: storedEmail } = await accountDO.rpcGetEmail();
-		const email = storedEmail || c.env.EMAIL;
-		return c.json({
-			handle: c.env.HANDLE,
-			did: c.env.DID,
-			...(email ? { email } : {}),
-			emailConfirmed: true,
-			active: true,
-		});
+		return buildResponse();
 	}
 
-	// Try JWT
 	try {
 		const payload = await verifyAccessToken(
 			token,
@@ -282,15 +315,7 @@ export async function getSession(
 			);
 		}
 
-		const { email: storedEmail } = await accountDO.rpcGetEmail();
-		const email = storedEmail || c.env.EMAIL;
-		return c.json({
-			handle: c.env.HANDLE,
-			did: c.env.DID,
-			...(email ? { email } : {}),
-			emailConfirmed: true,
-			active: true,
-		});
+		return buildResponse();
 	} catch (err) {
 		// Match official PDS: expired tokens return 400 with 'ExpiredToken'
 		// This is required for clients to trigger automatic token refresh
@@ -590,6 +615,19 @@ export async function listAppPasswords(
 			createdAt: p.createdAt,
 		})),
 	});
+}
+
+/**
+ * List invite codes for the account.
+ * com.atproto.server.getAccountInviteCodes
+ *
+ * Cirrus is single-user with `inviteCodeRequired: false` in describeServer,
+ * so there are no invite codes to list.
+ */
+export async function getAccountInviteCodes(
+	c: Context<AuthedAppEnv>,
+): Promise<Response> {
+	return c.json({ codes: [] });
 }
 
 /**

--- a/packages/pds/test/app-passwords.test.ts
+++ b/packages/pds/test/app-passwords.test.ts
@@ -165,6 +165,32 @@ describe("App Passwords", () => {
 			expect(found!.createdAt).toBeDefined();
 		});
 
+		it("returns createdAt as an RFC 3339 datetime", async () => {
+			const token = await getAccessToken();
+			await createAppPassword(token, "iso-datetime-test");
+
+			const res = await worker.fetch(
+				new Request(
+					"http://pds.test/xrpc/com.atproto.server.listAppPasswords",
+					{
+						headers: { Authorization: `Bearer ${token}` },
+					},
+				),
+				env,
+			);
+			const body = (await res.json()) as {
+				passwords: Array<{ name: string; createdAt: string }>;
+			};
+			const found = body.passwords.find((p) => p.name === "iso-datetime-test");
+			expect(found).toBeDefined();
+			// Must match the atproto datetime lexicon (RFC 3339), not the
+			// "YYYY-MM-DD HH:MM:SS" form that SQLite's datetime('now') returns.
+			expect(found!.createdAt).toMatch(
+				/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/,
+			);
+			expect(new Date(found!.createdAt).toISOString()).toBe(found!.createdAt);
+		});
+
 		it("never exposes password hashes", async () => {
 			const token = await getAccessToken();
 			await createAppPassword(token, "hash-check");

--- a/packages/pds/test/session.test.ts
+++ b/packages/pds/test/session.test.ts
@@ -155,6 +155,47 @@ describe("Session Authentication", () => {
 
 			expect(response.status).toBe(401);
 		});
+
+		it("accepts OAuth tokens presented with the DPoP scheme", async () => {
+			// pdscheck found getSession rejecting `Authorization: DPoP <jwt>`
+			// with 401 because the handler only accepted Bearer. Real OAuth
+			// clients present DPoP-bound tokens per RFC 9449.
+			const accessToken = `oauth-test-${crypto.randomUUID()}`;
+			const refreshToken = `refresh-test-${crypto.randomUUID()}`;
+			const stub = env.ACCOUNT.get(env.ACCOUNT.idFromName("account"));
+			await stub.rpcSaveTokens({
+				accessToken,
+				refreshToken,
+				clientId: "https://example.com/client-metadata.json",
+				sub: env.DID,
+				scope: "atproto",
+				issuedAt: Date.now(),
+				accessExpiresAt: Date.now() + 60_000,
+				refreshExpiresAt: Date.now() + 3_600_000,
+			});
+
+			const response = await worker.fetch(
+				new Request("http://pds.test/xrpc/com.atproto.server.getSession", {
+					headers: { Authorization: `DPoP ${accessToken}` },
+				}),
+				env,
+			);
+
+			expect(response.status).toBe(200);
+			const body = (await response.json()) as Record<string, unknown>;
+			expect(body.did).toBe(env.DID);
+			expect(body.handle).toBe(env.HANDLE);
+		});
+
+		it("rejects DPoP scheme with an unknown token", async () => {
+			const response = await worker.fetch(
+				new Request("http://pds.test/xrpc/com.atproto.server.getSession", {
+					headers: { Authorization: "DPoP not-a-real-token" },
+				}),
+				env,
+			);
+			expect(response.status).toBe(401);
+		});
 	});
 
 	describe("refreshSession", () => {

--- a/packages/pds/test/xrpc.test.ts
+++ b/packages/pds/test/xrpc.test.ts
@@ -282,6 +282,31 @@ describe("XRPC Endpoints", () => {
 			});
 		});
 
+		it("should return empty invite codes when authenticated", async () => {
+			const response = await worker.fetch(
+				new Request(
+					"http://pds.test/xrpc/com.atproto.server.getAccountInviteCodes",
+					{
+						headers: { Authorization: `Bearer ${env.AUTH_TOKEN}` },
+					},
+				),
+				env,
+			);
+			expect(response.status).toBe(200);
+			const data = (await response.json()) as { codes: unknown[] };
+			expect(data).toEqual({ codes: [] });
+		});
+
+		it("should require auth for getAccountInviteCodes", async () => {
+			const response = await worker.fetch(
+				new Request(
+					"http://pds.test/xrpc/com.atproto.server.getAccountInviteCodes",
+				),
+				env,
+			);
+			expect(response.status).toBe(401);
+		});
+
 		it("should resolve handle", async () => {
 			const response = await worker.fetch(
 				new Request(


### PR DESCRIPTION
## Summary

Three small conformance fixes found by pdscheck running against a live Cirrus deployment.

- **`getSession` accepts DPoP-bound tokens.** The handler hard-coded `if (!authHeader?.startsWith("Bearer ")) → 401`, so OAuth clients presenting `Authorization: DPoP <jwt>` (RFC 9449) could never read their own session. It now tries `provider.verifyAccessToken(c.req.raw)` first — the same path `middleware/auth.ts` already uses — and falls through to the static `AUTH_TOKEN` and JWT-secret paths.
- **`listAppPasswords` returns RFC 3339 datetimes.** The column is populated by SQLite's `datetime('now')`, which produces `"2026-03-29 15:30:17"` — not a valid lexicon datetime. Fixed at the storage boundary so the application code keeps getting an ISO string regardless of how the value was written.
- **`getAccountInviteCodes` returns `{codes: []}`.** The endpoint wasn't registered, so unknown XRPC methods fell through to the AppView proxy and returned 501. Cirrus has `inviteCodeRequired: false`, so an empty list is the correct, lexicon-conformant response. Endpoint requires auth like the other authenticated server.* routes.

## Test plan

- [x] `pnpm --filter @getcirrus/pds test` (297 unit + 84 CLI tests pass, including 3 new tests covering the fixes)
- [x] `pnpm --filter @getcirrus/pds check` passes
- [x] New test: DPoP-scheme `getSession` returns 200 for a stored OAuth access token
- [x] New test: `listAppPasswords.createdAt` parses as an ISO timestamp
- [x] New tests: `getAccountInviteCodes` returns 200 + `{codes: []}` when authed, 401 when not