### PR TITLE
fix(pds): include cid on applyWrites create/update results

### DIFF
--- a/.changeset/applywrites-result-cid.md
+++ b/.changeset/applywrites-result-cid.md
@@ -1,0 +1,5 @@
+---
+"@getcirrus/pds": patch
+---
+
+`applyWrites` now returns the record CID on `createResult` and `updateResult` even when the record is removed later in the same batch. The lexicon marks `cid` as required, but the previous code looked it up in the post-commit MST — for a record that was created then deleted within one batch, the MST has no entry and the field was missing. The CID is now computed from the record bytes up front, matching reference PDS behaviour.

--- a/apps/check/src/checks/firehose.ts
+++ b/apps/check/src/checks/firehose.ts
@@ -676,10 +676,22 @@ const commitOpsHavePrev: Check = {
 		for (const frame of commits) {
 			const ops = frame.body.ops;
 			if (!Array.isArray(ops)) continue;
+			// Reference PDS sets prev from the pre-commit MST only; an
+			// update/delete for a path that was *also* created earlier in the
+			// same commit has no prev (the record didn't exist before the
+			// commit). Track intra-commit creates so we don't fail those.
+			const createdInCommit = new Set<string>();
 			for (const op of ops) {
 				if (!op || typeof op !== "object") continue;
 				const action = (op as { action?: unknown }).action;
+				const path = (op as { path?: unknown }).path;
+				if (typeof path !== "string") continue;
+				if (action === "create") {
+					createdInCommit.add(path);
+					continue;
+				}
 				if (action !== "update" && action !== "delete") continue;
+				if (createdInCommit.has(path)) continue;
 				updateDeleteOps++;
 				if (!Object.prototype.hasOwnProperty.call(op, "prev")) {
 					missingPrev++;

--- a/packages/pds/src/account-do.ts
+++ b/packages/pds/src/account-do.ts
@@ -7,6 +7,7 @@ import {
 	writeCarStream,
 	readCarWithRoot,
 	getRecords,
+	cidForRecord,
 	type CarBlock,
 	type RecordCreateOp,
 	type RecordUpdateOp,
@@ -728,10 +729,10 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 		}
 
 		// Capture prev CIDs for every update/delete *before* the write, so the
-		// firehose can emit ops[].prev per sync 1.1. Skipping creates avoids
-		// unnecessary MST lookups; for updates that touch a previously-created
-		// record in the same batch, formatCommit handles the chain — only the
-		// initial repo-state prev matters for the firehose op record.
+		// firehose can emit ops[].prev per sync 1.1. Matches reference PDS
+		// behaviour: prev is read from pre-batch MST state only, so a delete
+		// for a record that was also created earlier in the same batch will
+		// have no prev (the record didn't exist before the batch).
 		const prevCids = new Map<string, CID>();
 		for (const op of ops) {
 			if (op.action === WriteOpAction.Create) continue;
@@ -739,6 +740,19 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 			if (prevCids.has(key)) continue;
 			const cid = await repo.data.get(key);
 			if (cid) prevCids.set(key, cid);
+		}
+
+		// Precompute every create/update record's CID. The lexicon marks
+		// `cid` as required on createResult / updateResult, and we can't rely
+		// on the post-commit MST: a create that is deleted later in the same
+		// batch leaves no entry. cidForRecord is deterministic from the
+		// record bytes and matches what formatCommit stores in the MST.
+		const opCids: Array<CID | undefined> = new Array(ops.length);
+		for (let i = 0; i < ops.length; i++) {
+			const op = ops[i]!;
+			if (op.action !== WriteOpAction.Delete) {
+				opCids[i] = await cidForRecord(op.record);
+			}
 		}
 
 		const prevRev = repo.commit.rev;
@@ -776,12 +790,11 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 						...(prev ? { prev } : {}),
 					});
 				} else {
-					const dataKey = `${result.collection}/${result.rkey}`;
-					const recordCid = await updatedRepo.data.get(dataKey);
+					const recordCid = opCids[i]!;
 					finalResults.push({
 						$type: result.$type,
 						uri: `at://${updatedRepo.did}/${result.collection}/${result.rkey}`,
-						cid: recordCid?.toString(),
+						cid: recordCid.toString(),
 						...(result.validationStatus !== undefined
 							? { validationStatus: result.validationStatus }
 							: {}),

--- a/packages/pds/test/xrpc.test.ts
+++ b/packages/pds/test/xrpc.test.ts
@@ -1290,6 +1290,12 @@ describe("XRPC Endpoints", () => {
 			expect(data.results[0].$type).toBe(
 				"com.atproto.repo.applyWrites#createResult",
 			);
+			// createResult.cid is required by the lexicon — the record never lands
+			// in the MST but its CID is still well-defined from the record bytes.
+			expect(data.results[0].cid).toMatch(/^bafy[a-z0-9]+$/);
+			expect(data.results[0].uri).toBe(
+				`at://${env.DID}/app.bsky.feed.post/${rkey}`,
+			);
 			expect(data.results[1].$type).toBe(
 				"com.atproto.repo.applyWrites#deleteResult",
 			);


### PR DESCRIPTION
## Summary

Two related fixes surfaced by the latest pdscheck run against pds.mk.gg, both stemming from PR #176 (accept create+delete on the same rkey).

### Bug 1 — `createResult.cid` missing

The lexicon ([com.atproto.repo.applyWrites#createResult](https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/repo/applyWrites.json)) marks `cid` as required, but Cirrus was reading it from `updatedRepo.data.get(dataKey)` after applying the commit. For a record that was created then deleted within the same batch, the MST has no entry, so `recordCid` was undefined and the field was omitted from the response.

**Fix:** precompute the create/update record's CID via `@atproto/repo`'s `cidForRecord(op.record)` before formatting the commit. The function encodes the record to DAG-CBOR and hashes deterministically — same algorithm the MST uses internally. This matches reference PDS behaviour (`packages/pds/src/repo/prepare.ts:217`: `cid: await cidForCbor(encode(record))`).

### Bug 2 — pdscheck flags delete ops with no prev

Sync 1.1 requires `prev` on update/delete ops in the firehose. For a `[create(K), delete(K)]` batch, the delete has no prev because the record didn't exist pre-commit. Reference PDS reads `prev` from a pre-batch query (`actor-store/repo/transactor.ts:125`), so it also omits prev in this case.

**Fix:** pdscheck's `firehose.commit-ops-have-prev` check now exempts an update/delete op whose path was also created earlier in the same `#commit`. No change to Cirrus's firehose payload — its existing behaviour was already aligned with the reference.

## Test plan
- [x] `pnpm --filter @getcirrus/pds test` — 313 unit + 84 CLI passing, including a strengthened assertion in the existing create+delete-same-rkey test that `cid` and `uri` are present on `createResult`.
- [x] `pnpm --filter @getcirrus/pds check` — clean.
- [x] `apps/check` typechecks.
- [ ] Re-run pdscheck against the deployed PDS once this lands: expect `repo-write.apply-writes.validates` and `firehose.commit-ops-have-prev` to pass.