### PR TITLE
fix(check): keep last row aligned with the rest of the list

### DIFF
--- a/apps/check/src/components/CheckRow.tsx
+++ b/apps/check/src/components/CheckRow.tsx
@@ -58,7 +58,7 @@ export function CheckRow(props: { result: CheckResult }) {
 	};
 
 	return (
-		<li class={`border-b border-line/60 last:border-0 ${rowAccent()}`}>
+		<li class={`border-b border-line/60 last:border-b-0 ${rowAccent()}`}>
 			<div
 				role="button"
 				tabindex={0}


### PR DESCRIPTION
Each check row carries a 4px transparent left border (`border-l-4 border-l-transparent`) so every row has identical indentation regardless of status. `last:border-0` was zeroing every border on the final row — including that left accent — causing the last row's content to shift 4px to the left.

Switching to `last:border-b-0` removes only the bottom border, preserving the left indentation.

## Test plan
- [x] Diff is a single-character change.
- [ ] Confirm visually in the deployed app that the bottom row aligns with the others.