### PR TITLE
fix(check): preserve pre-redirect step results across OAuth redirect

### DIFF
--- a/apps/check/src/lib/oauth-flow.ts
+++ b/apps/check/src/lib/oauth-flow.ts
@@ -64,6 +64,7 @@ interface PersistedState {
 	stateNonce: string;
 	expectedIss: string;
 	scope: string;
+	preRedirectSteps?: FlowStep[];
 }
 
 // Scope is chosen at runtime based on the auth server's advertised scopes:
@@ -1136,6 +1137,7 @@ export function startPreRedirectFlow(target: string): FlowRun {
 				evidence: { request: { method: "GET", url: authUrl.toString() } },
 			}));
 
+			const preRedirectSet = new Set<string>(PRE_REDIRECT_STEPS);
 			await persistState({
 				target,
 				handle: resolved.handle,
@@ -1146,6 +1148,9 @@ export function startPreRedirectFlow(target: string): FlowRun {
 				stateNonce,
 				expectedIss: (state.authServer!.issuer as string) ?? "",
 				scope: activeScope,
+				preRedirectSteps: state.steps
+					.filter((s) => preRedirectSet.has(s.id))
+					.map((s) => ({ ...s })),
 			});
 
 			setState(
@@ -1199,10 +1204,23 @@ export async function runPostCallback(): Promise<CallbackRun> {
 	if (persisted?.scope) activeScope = persisted.scope;
 
 	const initial = createFlowState(persisted?.target ?? "");
-	// Mark pre-redirect steps complete
+	// Restore the pre-redirect step results captured before the redirect. If
+	// we don't have them (older persisted state, or none at all), fall back
+	// to marking the steps "skip" rather than fabricating a "pass" — the
+	// alternative was to lie about what actually happened pre-redirect.
+	const persistedById = new Map<string, FlowStep>(
+		(persisted?.preRedirectSteps ?? []).map((s) => [s.id, s]),
+	);
 	for (const id of PRE_REDIRECT_STEPS) {
 		const idx = initial.steps.findIndex((s) => s.id === id);
-		if (idx >= 0) initial.steps[idx]!.status = "pass";
+		if (idx < 0) continue;
+		const prior = persistedById.get(id);
+		if (prior) {
+			initial.steps[idx] = { ...initial.steps[idx]!, ...prior };
+		} else {
+			initial.steps[idx]!.status = "skip";
+			initial.steps[idx]!.message = "no persisted result";
+		}
 	}
 	initial.phase = "post-callback";
 	initial.handle = persisted?.handle;


### PR DESCRIPTION
## Summary

`runPostCallback` in `apps/check/src/lib/oauth-flow.ts` was iterating `PRE_REDIRECT_STEPS` and marking every step `status: 'pass'` after the user returned from the auth server, regardless of what actually happened pre-redirect. PAR boundary tests, scope selection, metadata validation — anything that failed before the redirect — would silently flip green once authentication completed.

## Fix

- Add `preRedirectSteps?: FlowStep[]` to `PersistedState`.
- Snapshot each pre-redirect step's full state (status, message, evidence, timings) into `sessionStorage` alongside the existing `codeVerifier`/`stateNonce` payload right before redirect.
- In `runPostCallback`, restore those into the initial flow state. If no persisted result is present (older session, or none at all), the step renders as `skip` with a "no persisted result" message rather than a fabricated pass.

## Test plan
- [x] Typecheck clean.
- [ ] Manual: open OAuth flow against a target with a known pre-redirect failure (e.g. unregistered redirect_uri test against a non-compliant AS), complete login, confirm the pre-redirect failure still shows as fail/warn in the post-callback view.