### PR TITLE
fix(oauth-provider): PAR rejects unregistered redirect_uri

### DIFF
--- a/.changeset/par-validate-redirect-uri.md
+++ b/.changeset/par-validate-redirect-uri.md
@@ -1,0 +1,5 @@
+---
+"@getcirrus/oauth-provider": patch
+---
+
+PAR (`/oauth/par`) now validates `redirect_uri` against the client's registered redirect_uris at push time. Previously the check only ran at the authorize step, which let a malicious caller obtain a `request_uri` for an unregistered redirect even though the subsequent authorize would have rejected it. Reject early per RFC 6749 §3.1.2.4.

--- a/apps/check/src/lib/oauth-flow.ts
+++ b/apps/check/src/lib/oauth-flow.ts
@@ -64,6 +64,7 @@ interface PersistedState {
 	stateNonce: string;
 	expectedIss: string;
 	scope: string;
+	preRedirectSteps?: FlowStep[];
 }
 
 // Scope is chosen at runtime based on the auth server's advertised scopes:
@@ -1136,6 +1137,7 @@ export function startPreRedirectFlow(target: string): FlowRun {
 				evidence: { request: { method: "GET", url: authUrl.toString() } },
 			}));
 
+			const preRedirectSet = new Set<string>(PRE_REDIRECT_STEPS);
 			await persistState({
 				target,
 				handle: resolved.handle,
@@ -1146,6 +1148,9 @@ export function startPreRedirectFlow(target: string): FlowRun {
 				stateNonce,
 				expectedIss: (state.authServer!.issuer as string) ?? "",
 				scope: activeScope,
+				preRedirectSteps: state.steps
+					.filter((s) => preRedirectSet.has(s.id))
+					.map((s) => ({ ...s })),
 			});
 
 			setState(
@@ -1199,10 +1204,23 @@ export async function runPostCallback(): Promise<CallbackRun> {
 	if (persisted?.scope) activeScope = persisted.scope;
 
 	const initial = createFlowState(persisted?.target ?? "");
-	// Mark pre-redirect steps complete
+	// Restore the pre-redirect step results captured before the redirect. If
+	// we don't have them (older persisted state, or none at all), fall back
+	// to marking the steps "skip" rather than fabricating a "pass" — the
+	// alternative was to lie about what actually happened pre-redirect.
+	const persistedById = new Map<string, FlowStep>(
+		(persisted?.preRedirectSteps ?? []).map((s) => [s.id, s]),
+	);
 	for (const id of PRE_REDIRECT_STEPS) {
 		const idx = initial.steps.findIndex((s) => s.id === id);
-		if (idx >= 0) initial.steps[idx]!.status = "pass";
+		if (idx < 0) continue;
+		const prior = persistedById.get(id);
+		if (prior) {
+			initial.steps[idx] = { ...initial.steps[idx]!, ...prior };
+		} else {
+			initial.steps[idx]!.status = "skip";
+			initial.steps[idx]!.message = "no persisted result";
+		}
 	}
 	initial.phase = "post-callback";
 	initial.handle = persisted?.handle;

--- a/packages/oauth-provider/src/par.ts
+++ b/packages/oauth-provider/src/par.ts
@@ -4,6 +4,7 @@
  */
 
 import type { OAuthParResponse } from "@atproto/oauth-types";
+import type { ClientResolver } from "./client-resolver.js";
 import type { OAuthStorage, PARData } from "./storage.js";
 import { randomString } from "./encoding.js";
 import { parseRequestBody } from "./provider.js";
@@ -53,6 +54,7 @@ const REQUIRED_PARAMS = [
  */
 export class PARHandler {
 	private storage: OAuthStorage;
+	private clientResolver: ClientResolver;
 	private issuer: string;
 	private expiresIn: number;
 	private allowIncludes: boolean;
@@ -60,6 +62,9 @@ export class PARHandler {
 	/**
 	 * Create a PAR handler
 	 * @param storage OAuth storage implementation
+	 * @param clientResolver Client metadata resolver. Used to validate
+	 *   redirect_uri against the registered list at push time per
+	 *   RFC 6749 §3.1.2.4.
 	 * @param issuer The OAuth issuer URL
 	 * @param expiresIn PAR expiration time in seconds (default: 90)
 	 * @param allowIncludes Whether `include:` (permission set) scopes are
@@ -69,11 +74,13 @@ export class PARHandler {
 	 */
 	constructor(
 		storage: OAuthStorage,
+		clientResolver: ClientResolver,
 		issuer: string,
 		expiresIn: number = DEFAULT_EXPIRES_IN,
 		allowIncludes: boolean = false,
 	) {
 		this.storage = storage;
+		this.clientResolver = clientResolver;
 		this.issuer = issuer;
 		this.expiresIn = expiresIn;
 		this.allowIncludes = allowIncludes;
@@ -145,6 +152,28 @@ export class PARHandler {
 			new URL(params.redirect_uri!);
 		} catch {
 			return this.errorResponse("invalid_request", "Invalid redirect_uri", 400);
+		}
+
+		// RFC 6749 §3.1.2.4: the AS MUST reject any redirect_uri that wasn't
+		// registered in the client metadata. Authorize re-validates, but PAR
+		// must also reject here — otherwise a request_uri gets issued for a
+		// redirect the client never registered.
+		let client;
+		try {
+			client = await this.clientResolver.resolveClient(clientId);
+		} catch (e) {
+			return this.errorResponse(
+				"invalid_client",
+				`Failed to resolve client: ${e instanceof Error ? e.message : String(e)}`,
+				400,
+			);
+		}
+		if (!client.redirectUris.includes(params.redirect_uri!)) {
+			return this.errorResponse(
+				"invalid_request",
+				"redirect_uri is not registered for this client",
+				400,
+			);
 		}
 
 		const scope = params.scope ?? ATPROTO_SCOPE;

--- a/packages/oauth-provider/src/provider.ts
+++ b/packages/oauth-provider/src/provider.ts
@@ -215,14 +215,15 @@ export class ATProtoOAuthProvider {
 		this.issuer = config.issuer;
 		this.dpopRequired = config.dpopRequired ?? true;
 		this.enablePAR = config.enablePAR ?? true;
+		this.clientResolver =
+			config.clientResolver ?? new ClientResolver({ storage: config.storage });
 		this.parHandler = new PARHandler(
 			config.storage,
+			this.clientResolver,
 			config.issuer,
 			undefined,
 			!!config.permissionSetResolver,
 		);
-		this.clientResolver =
-			config.clientResolver ?? new ClientResolver({ storage: config.storage });
 		this.verifyUser = config.verifyUser;
 		this.getCurrentUser = config.getCurrentUser;
 		this.getPasskeyOptions = config.getPasskeyOptions;

--- a/packages/oauth-provider/test/par.test.ts
+++ b/packages/oauth-provider/test/par.test.ts
@@ -1,15 +1,44 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { ClientResolver } from "../src/client-resolver.js";
 import { PARHandler } from "../src/par.js";
 import { InMemoryOAuthStorage } from "../src/storage.js";
+import type { ClientMetadata } from "../src/storage.js";
 import { generateCodeChallenge, generateCodeVerifier } from "./helpers.js";
+
+/**
+ * Stub resolver for PAR tests: returns metadata with a fixed registered
+ * redirect_uri so PAR's RFC 6749 §3.1.2.4 check passes for the canonical
+ * fixture. Tests that probe rejection pass a different redirect_uri.
+ */
+class StubResolver extends ClientResolver {
+	private fixed: ClientMetadata;
+	constructor(redirectUri: string) {
+		super();
+		this.fixed = {
+			clientId: "did:web:client.example.com",
+			clientName: "Test Client",
+			redirectUris: [redirectUri],
+			tokenEndpointAuthMethod: "none",
+			cachedAt: Date.now(),
+		};
+	}
+	override async resolveClient(): Promise<ClientMetadata> {
+		return this.fixed;
+	}
+}
 
 describe("PAR Handler", () => {
 	let storage: InMemoryOAuthStorage;
 	let handler: PARHandler;
+	const REGISTERED_REDIRECT = "https://client.example.com/callback";
 
 	beforeEach(() => {
 		storage = new InMemoryOAuthStorage();
-		handler = new PARHandler(storage, "https://example.com");
+		handler = new PARHandler(
+			storage,
+			new StubResolver(REGISTERED_REDIRECT),
+			"https://example.com",
+		);
 	});
 
 	function createPARRequest(params: Record<string, string>): Request {
@@ -77,6 +106,31 @@ describe("PAR Handler", () => {
 
 			const json = (await response.json()) as { error: string };
 			expect(json.error).toBe("invalid_request");
+		});
+
+		it("rejects redirect_uri not registered in client metadata (RFC 6749 §3.1.2.4)", async () => {
+			const verifier = generateCodeVerifier();
+			const challenge = await generateCodeChallenge(verifier);
+
+			const request = createPARRequest({
+				client_id: "did:web:client.example.com",
+				redirect_uri: "https://attacker.invalid/steal-code",
+				response_type: "code",
+				code_challenge: challenge,
+				code_challenge_method: "S256",
+				state: "random-state",
+				scope: "atproto",
+			});
+
+			const response = await handler.handlePushRequest(request);
+			expect(response.status).toBe(400);
+
+			const json = (await response.json()) as {
+				error: string;
+				error_description: string;
+			};
+			expect(json.error).toBe("invalid_request");
+			expect(json.error_description).toMatch(/not registered/i);
 		});
 
 		it("rejects unsupported response_type", async () => {


### PR DESCRIPTION
## Summary

pdscheck's \`flow.par-rejects-unregistered-redirect-uri\` step caught a defense-in-depth gap: Cirrus's PAR endpoint accepted any \`redirect_uri\` whose URL parsed cleanly, regardless of whether it was registered in the client metadata. RFC 6749 §3.1.2.4 requires rejection at this point. The subsequent \`/oauth/authorize\` step does re-validate (\`provider.ts:370\`), so the practical exploitability was limited — but issuing a \`request_uri\` for an unregistered redirect is itself a spec violation and a footgun if any code path elsewhere ever trusted the PAR-stored \`redirect_uri\` without re-checking.

## Fix

- Plumb the existing \`ClientResolver\` into \`PARHandler\`.
- After URL-validating \`redirect_uri\`, resolve the client and reject with \`invalid_request\` if the URI isn't in \`client.redirectUris\`.
- Provider constructor reordered so \`clientResolver\` is built before \`parHandler\` consumes it.
- New regression test in \`packages/oauth-provider/test/par.test.ts\` covering the rejection.
- Existing tests use a new \`StubResolver\` (extends \`ClientResolver\`) that returns a fixed registered redirect so they still pass the new check.

## Test plan
- [x] \`pnpm --filter @getcirrus/oauth-provider test\` — 117 passing (12 in par.test.ts incl. the new one).
- [x] \`pnpm --filter @getcirrus/oauth-provider check\` — clean.
- [x] \`pnpm --filter @getcirrus/pds test\` — 313 unit + 84 CLI passing.
- [ ] Re-run pdscheck OAuth flow against the deployed PDS once this lands: expect \`flow.par-rejects-unregistered-redirect-uri\` to pass.