### PR TITLE
fix(oauth): align scopes_supported and pdscheck probing with the spec

### DIFF
--- a/.changeset/scopes-supported-spec-compliant.md
+++ b/.changeset/scopes-supported-spec-compliant.md
@@ -1,0 +1,5 @@
+---
+"@getcirrus/oauth-provider": patch
+---
+
+`scopes_supported` in the authorization-server metadata now lists only the values the spec calls out: `atproto`, `transition:generic`, `transition:email`, `transition:chat.bsky`. Granular resource scopes (`repo:<nsid>`, `rpc:<lxm>`, `blob:<mime>`, `account:<…>`, `identity:<…>`) and permission-set scopes (`include:<nsid>`) are parameterised and aren't enumerable, so bare prefixes like `repo` or `include` are no longer advertised — clients discover support by attempting the scope and falling back on `invalid_scope`, matching the reference PDS.

--- a/apps/check/src/checks/oauth-discovery.ts
+++ b/apps/check/src/checks/oauth-discovery.ts
@@ -563,70 +563,6 @@ const scopeAdvertisesTransitionGeneric = scopeAdvertises(
 				},
 );
 
-const scopeAdvertisesResourceBuckets = scopeAdvertises(
-	"oauth-discovery.scope-resource-buckets",
-	"Auth server advertises granular resource scopes",
-	(scopes) => {
-		// Per atproto.com/specs/permission, granular scopes are bare resource-
-		// type tokens (repo, rpc, blob, account, identity) in scopes_supported.
-		// Clients construct fully-qualified scopes by appending parameters at
-		// request time (e.g. `repo:my.collection?action=create`).
-		const RESOURCES = ["repo", "rpc", "blob", "identity", "account"] as const;
-		const present = RESOURCES.filter((r) => scopes.includes(r));
-		if (present.length === 0) {
-			return {
-				status: "warn",
-				message:
-					"no granular resource scopes (repo, rpc, blob, identity, account) advertised — AS supports only legacy transition:* bundles",
-				evidence: {
-					expected:
-						"scopes_supported to include resource-type tokens: repo, rpc, blob, account, identity",
-					actual: scopes,
-				},
-			};
-		}
-		const missing = RESOURCES.filter((r) => !scopes.includes(r));
-		if (missing.length > 0) {
-			return {
-				status: "warn",
-				message: `partial: advertises ${present.join(", ")}; missing ${missing.join(", ")}`,
-				evidence: { actual: { present, missing } },
-			};
-		}
-		return {
-			status: "pass",
-			message: `all five granular resources advertised: ${present.join(", ")}`,
-			evidence: { actual: present },
-		};
-	},
-);
-
-const scopeAdvertisesPermissionSets = scopeAdvertises(
-	"oauth-discovery.scope-permission-sets",
-	"Auth server advertises permission set support",
-	(scopes) => {
-		// The AS advertises `include` as a resource type to signal it supports
-		// permission sets; specific include:<nsid> scopes are dynamically
-		// resolved at PAR time via lexicon resolution, not enumerated here.
-		if (!scopes.includes("include")) {
-			return {
-				status: "warn",
-				message:
-					"`include` not in scopes_supported — AS does not advertise permission set resolution",
-				evidence: {
-					expected: "`include` token in scopes_supported",
-					actual: scopes,
-				},
-			};
-		}
-		return {
-			status: "pass",
-			message: "`include` advertised — AS resolves permission sets dynamically via lexicon resolution",
-			evidence: { actual: ["include"] },
-		};
-	},
-);
-
 export const oauthDiscoveryChecks: Check[] = [
 	protectedResourceResponds,
 	protectedResourceValidates,
@@ -634,8 +570,6 @@ export const oauthDiscoveryChecks: Check[] = [
 	authServerValidates,
 	scopeAdvertisesAtproto,
 	scopeAdvertisesTransitionGeneric,
-	scopeAdvertisesResourceBuckets,
-	scopeAdvertisesPermissionSets,
 	jwksResponds,
 	jwksValidates,
 ];

--- a/apps/check/src/lib/oauth-flow.ts
+++ b/apps/check/src/lib/oauth-flow.ts
@@ -72,8 +72,7 @@ interface PersistedState {
 // the granular scope at PAR ("invalid_scope: not declared in client metadata"),
 // so we don't even attempt it on those servers.
 const LEGACY_SCOPE = "atproto transition:generic";
-const GRANULAR_SCOPE =
-	"atproto repo:earth.cirrus.check.testrecord include:site.standard.authFull";
+const GRANULAR_SCOPE = "atproto repo:earth.cirrus.check.testrecord";
 const OUT_OF_SCOPE_COLLECTION = "earth.cirrus.check.othertestrecord";
 const CALLBACK_PATH = "/oauth/flow-callback";
 
@@ -339,7 +338,7 @@ function initialStepsFor(ids: readonly string[]): FlowStep[] {
 		"flow.par-rejects-invalid-include":
 			"PAR rejects a nonexistent permission set include:",
 		"flow.par-accepts-known-permission-set":
-			"PAR accepts include:site.standard.authFull (a published, lexicon-resolved permission set)",
+			"PAR accepts include:app.bsky.authFullApp (a published, lexicon-resolved permission set)",
 		"flow.build-authorization-url": "Build authorization URL",
 		"flow.callback-params-present": "Callback has code, state, iss",
 		"flow.iss-matches": "iss parameter matches auth server (RFC 9207)",
@@ -1014,11 +1013,11 @@ export function startPreRedirectFlow(target: string): FlowRun {
 				}
 			});
 
-			// 9c.ii — request a published permission set (`site.standard.authFull`)
+			// 9c.ii — request a published permission set (`app.bsky.authFullApp`)
 			// to test whether the AS can dynamically resolve `include:*` NSIDs via
 			// lexicon resolution.
 			await runStep("flow.par-accepts-known-permission-set", async () => {
-				const knownInclude = "include:site.standard.authFull";
+				const knownInclude = "include:app.bsky.authFullApp";
 				const probeParams = {
 					client_id: clientId(),
 					redirect_uri: redirectUri(),
@@ -1046,7 +1045,7 @@ export function startPreRedirectFlow(target: string): FlowRun {
 					const accepted = await withNonceRetry(attempt);
 					return {
 						status: "pass",
-						message: `AS resolved site.standard.authFull (request_uri expires in ${accepted.expires_in}s)`,
+						message: `AS resolved app.bsky.authFullApp (request_uri expires in ${accepted.expires_in}s)`,
 						evidence: {
 							response: { body: accepted },
 							actual: { probed: knownInclude },
@@ -1063,7 +1062,7 @@ export function startPreRedirectFlow(target: string): FlowRun {
 									"AS resolves the published lexicon and accepts the include:",
 								actual: error.error,
 								error:
-									"site.standard.authFull is a published permission set lexicon. Rejecting it means this AS doesn't support dynamic lexicon-based permission-set resolution.",
+									"app.bsky.authFullApp is a published permission set lexicon. Rejecting it means this AS doesn't support dynamic lexicon-based permission-set resolution.",
 							},
 						};
 					}

--- a/apps/check/src/lib/oauth-flow.ts
+++ b/apps/check/src/lib/oauth-flow.ts
@@ -289,14 +289,13 @@ const PRE_REDIRECT_STEPS = [
 	"flow.discover-auth-server",
 	"flow.validate-auth-server-metadata",
 	"flow.atproto-conformance",
-	"flow.select-scope",
 	"flow.generate-pkce",
 	"flow.generate-dpop-key",
+	"flow.select-scope",
 	"flow.send-par",
 	"flow.par-response-shape",
 	"flow.par-rejects-unregistered-redirect-uri",
 	"flow.par-rejects-invalid-include",
-	"flow.par-accepts-advertised-include",
 	"flow.par-accepts-known-permission-set",
 	"flow.build-authorization-url",
 ] as const;
@@ -330,7 +329,7 @@ function initialStepsFor(ids: readonly string[]): FlowStep[] {
 			"Auth server metadata validates (oauth4webapi)",
 		"flow.atproto-conformance": "AT Proto OAuth conformance",
 		"flow.select-scope":
-			"Select scope (granular when AS advertises, legacy otherwise)",
+			"Select scope (granular when AS accepts, legacy otherwise)",
 		"flow.generate-pkce": "Generate PKCE code verifier and challenge",
 		"flow.generate-dpop-key": "Generate DPoP ES256 keypair",
 		"flow.send-par": "Send pushed authorization request",
@@ -339,8 +338,6 @@ function initialStepsFor(ids: readonly string[]): FlowStep[] {
 			"PAR rejects unregistered redirect_uri (RFC 6749 §3.1.2.4)",
 		"flow.par-rejects-invalid-include":
 			"PAR rejects a nonexistent permission set include:",
-		"flow.par-accepts-advertised-include":
-			"PAR accepts an include: scope advertised in scopes_supported",
 		"flow.par-accepts-known-permission-set":
 			"PAR accepts include:site.standard.authFull (a published, lexicon-resolved permission set)",
 		"flow.build-authorization-url": "Build authorization URL",
@@ -645,46 +642,6 @@ export function startPreRedirectFlow(target: string): FlowRun {
 			});
 
 			// 5b. Select scope based on what the AS advertises.
-			await runStep("flow.select-scope", async () => {
-				const supported = (
-					(state.authServer as Record<string, unknown> | undefined)
-						?.scopes_supported as string[] | undefined
-				)?.filter((s) => typeof s === "string") ?? [];
-				const hasGranular = supported.some(
-					(s) =>
-						s === "repo" ||
-						s.startsWith("repo:") ||
-						s.startsWith("repo "),
-				);
-				activeScope = hasGranular ? GRANULAR_SCOPE : LEGACY_SCOPE;
-				if (hasGranular) {
-					return {
-						status: "pass",
-						message: `granular scope: ${activeScope}`,
-						evidence: {
-							actual: {
-								scopesSupported: supported,
-								selected: activeScope,
-							},
-						},
-					};
-				}
-				return {
-					status: "warn",
-					message: `AS doesn't advertise repo:* scopes — falling back to legacy ${LEGACY_SCOPE}; granular boundary tests will skip`,
-					evidence: {
-						expected:
-							"scopes_supported to include at least one repo:* (Phase 2 granular) scope",
-						actual: {
-							scopesSupported: supported,
-							selected: activeScope,
-						},
-						error:
-							"PDS doesn't support Phase 2 granular scopes — the verifier can't differentiate scope enforcement using this AS.",
-					},
-				};
-			});
-
 			// 6. Generate PKCE
 			const codeVerifier = oauth.generateRandomCodeVerifier();
 			const codeChallenge =
@@ -716,6 +673,77 @@ export function startPreRedirectFlow(target: string): FlowRun {
 					},
 				},
 			}));
+
+			// 7b. Select scope by *probing*, not by reading scopes_supported. The
+			// atproto OAuth spec only requires `atproto` (and transitional scopes
+			// when supported) in scopes_supported; granular scopes (`repo:<nsid>`,
+			// `include:<nsid>`, etc.) are parameterised and "cannot be enumerated
+			// as they are dynamic" (atproto reference oauth-provider comment). So
+			// we send a probe PAR with the granular scope; if the AS accepts, use
+			// it. If it rejects with invalid_scope, fall back to LEGACY_SCOPE.
+			const probeDpop = oauth.DPoP(
+				{ [oauth.clockSkew]: 0 },
+				dpopKeyPair,
+			);
+			await runStep("flow.select-scope", async () => {
+				const probeParams = {
+					client_id: clientId(),
+					redirect_uri: redirectUri(),
+					response_type: "code",
+					scope: GRANULAR_SCOPE,
+					code_challenge: codeChallenge,
+					code_challenge_method: "S256",
+					state: oauth.generateRandomState(),
+				};
+				const probe = async () => {
+					const res = await oauth.pushedAuthorizationRequest(
+						state.authServer!,
+						{ client_id: clientId() },
+						oauth.None(),
+						probeParams,
+						{ DPoP: probeDpop },
+					);
+					return await oauth.processPushedAuthorizationResponse(
+						state.authServer!,
+						{ client_id: clientId() },
+						res,
+					);
+				};
+				try {
+					await withNonceRetry(probe);
+					activeScope = GRANULAR_SCOPE;
+					return {
+						status: "pass",
+						message: `granular scope accepted: ${activeScope}`,
+						evidence: { actual: { selected: activeScope } },
+					};
+				} catch (error) {
+					if (
+						error instanceof oauth.ResponseBodyError &&
+						(error.error === "invalid_scope" ||
+							error.error === "invalid_request")
+					) {
+						activeScope = LEGACY_SCOPE;
+						return {
+							status: "warn",
+							message: `AS rejected granular scope (${error.error}) — falling back to ${LEGACY_SCOPE}; granular boundary tests will skip`,
+							evidence: {
+								response: { status: error.status, body: error.cause },
+								actual: { selected: activeScope },
+							},
+						};
+					}
+					activeScope = LEGACY_SCOPE;
+					return {
+						status: "warn",
+						message: `probe inconclusive: ${error instanceof Error ? error.message : String(error)} — falling back to ${LEGACY_SCOPE}`,
+						evidence: {
+							error: String(error),
+							actual: { selected: activeScope },
+						},
+					};
+				}
+			});
 
 			// 8. Send PAR (with DPoP-nonce retry built in — RFC 9449 §8 allows the
 			// AS to require a nonce; the first request fails with use_dpop_nonce
@@ -917,26 +945,13 @@ export function startPreRedirectFlow(target: string): FlowRun {
 				},
 			);
 
-			// 9c. Permission-set probes: only meaningful if the AS advertises any
-			// `include:*` scope in scopes_supported. Skip otherwise.
-			const advertisedScopes = (
-				(state.authServer as Record<string, unknown> | undefined)
-					?.scopes_supported as string[] | undefined
-			)?.filter((s) => typeof s === "string") ?? [];
-			const advertisedIncludes = advertisedScopes.filter((s) =>
-				s.startsWith("include:"),
-			);
+			// 9c. Permission-set probes. We don't gate on scopes_supported — the
+			// spec doesn't require ASes to enumerate include:* scopes since they
+			// resolve dynamically via lexicon resolution.
 
 			// 9c.i — request a clearly-nonexistent permission set. The AS should
 			// reject with invalid_scope (or similar) once it tries to resolve.
 			await runStep("flow.par-rejects-invalid-include", async () => {
-				if (advertisedIncludes.length === 0) {
-					return {
-						status: "skip",
-						message:
-							"AS doesn't advertise any include:* scopes — permission set support not exercisable",
-					};
-				}
 				const bogusInclude =
 					"include:earth.cirrus.check.invalidnonexistentpermissionset";
 				const probeParams = {
@@ -999,74 +1014,9 @@ export function startPreRedirectFlow(target: string): FlowRun {
 				}
 			});
 
-			// 9c.ii — request the AS's OWN advertised include: scope. If the AS
-			// advertises it in scopes_supported, it must be able to accept and
-			// resolve it. Rejecting your own advertised scope is a real bug.
-			await runStep("flow.par-accepts-advertised-include", async () => {
-				if (advertisedIncludes.length === 0) {
-					return {
-						status: "skip",
-						message:
-							"AS doesn't advertise any include:* scopes — nothing to probe",
-					};
-				}
-				const advertised = advertisedIncludes[0]!;
-				const probeParams = {
-					client_id: clientId(),
-					redirect_uri: redirectUri(),
-					response_type: "code",
-					scope: `atproto ${advertised}`,
-					code_challenge: codeChallenge,
-					code_challenge_method: "S256",
-					state: oauth.generateRandomState(),
-				};
-				const attempt = async () => {
-					const res = await oauth.pushedAuthorizationRequest(
-						state.authServer!,
-						{ client_id: clientId() },
-						oauth.None(),
-						probeParams,
-						{ DPoP: dpop },
-					);
-					return await oauth.processPushedAuthorizationResponse(
-						state.authServer!,
-						{ client_id: clientId() },
-						res,
-					);
-				};
-				try {
-					const accepted = await withNonceRetry(attempt);
-					return {
-						status: "pass",
-						message: `AS accepted its own advertised ${advertised} (request_uri expires in ${accepted.expires_in}s)`,
-						evidence: {
-							response: { body: accepted },
-							actual: { probed: advertised },
-						},
-					};
-				} catch (error) {
-					if (error instanceof oauth.ResponseBodyError) {
-						return {
-							status: "fail",
-							message: `AS rejected ${advertised} (its own advertised scope): ${error.error}${error.cause?.error_description ? ` — ${error.cause.error_description}` : ""}`,
-							evidence: {
-								response: { status: error.status, body: error.cause },
-								error: `Permission set ${advertised} is listed in scopes_supported but PAR rejects it — the AS is advertising a scope it can't actually honor.`,
-							},
-						};
-					}
-					return {
-						status: "warn",
-						message: `probe inconclusive: ${error instanceof Error ? error.message : String(error)}`,
-						evidence: { error: String(error) },
-					};
-				}
-			});
-
-			// 9c.iii — request a published permission set (`site.standard.authFull`)
-			// that does NOT need to appear in scopes_supported. This tests whether
-			// the AS can dynamically resolve `include:*` NSIDs via lexicon resolution.
-			// An AS that only supports its own pre-advertised includes will fail here.
+			// 9c.ii — request a published permission set (`site.standard.authFull`)
+			// to test whether the AS can dynamically resolve `include:*` NSIDs via
+			// lexicon resolution.
 			await runStep("flow.par-accepts-known-permission-set", async () => {
 				const knownInclude = "include:site.standard.authFull";
 				const probeParams = {

--- a/apps/check/src/lib/oauth-flow.ts
+++ b/apps/check/src/lib/oauth-flow.ts
@@ -73,6 +73,8 @@ interface PersistedState {
 // so we don't even attempt it on those servers.
 const LEGACY_SCOPE = "atproto transition:generic";
 const GRANULAR_SCOPE = "atproto repo:earth.cirrus.check.testrecord";
+const GRANULAR_WITH_INCLUDE_SCOPE =
+	"atproto repo:earth.cirrus.check.testrecord include:site.standard.authFull";
 const OUT_OF_SCOPE_COLLECTION = "earth.cirrus.check.othertestrecord";
 const CALLBACK_PATH = "/oauth/flow-callback";
 
@@ -690,71 +692,78 @@ export function startPreRedirectFlow(target: string): FlowRun {
 			// atproto OAuth spec only requires `atproto` (and transitional scopes
 			// when supported) in scopes_supported; granular scopes (`repo:<nsid>`,
 			// `include:<nsid>`, etc.) are parameterised and "cannot be enumerated
-			// as they are dynamic" (atproto reference oauth-provider comment). So
-			// we send a probe PAR with the granular scope; if the AS accepts, use
-			// it. If it rejects with invalid_scope, fall back to LEGACY_SCOPE.
+			// as they are dynamic" (atproto reference oauth-provider comment).
+			//
+			// Three-tier probe: try granular + include, fall back to granular only,
+			// then to legacy. The user sees the richest scope set the AS will accept
+			// on the consent UI, and the boundary tests still run whenever granular
+			// works.
 			const probeDpop = oauth.DPoP(
 				{ [oauth.clockSkew]: 0 },
 				dpopKeyPair,
 			);
-			await runStep("flow.select-scope", async () => {
+			const probeScope = async (scope: string): Promise<oauth.ResponseBodyError | null> => {
 				const probeParams = {
 					client_id: clientId(),
 					redirect_uri: redirectUri(),
 					response_type: "code",
-					scope: GRANULAR_SCOPE,
+					scope,
 					code_challenge: codeChallenge,
 					code_challenge_method: "S256",
 					state: oauth.generateRandomState(),
 				};
-				const probe = async () => {
-					const res = await oauth.pushedAuthorizationRequest(
-						state.authServer!,
-						{ client_id: clientId() },
-						oauth.None(),
-						probeParams,
-						{ DPoP: probeDpop },
-					);
-					return await oauth.processPushedAuthorizationResponse(
-						state.authServer!,
-						{ client_id: clientId() },
-						res,
-					);
-				};
 				try {
-					await withNonceRetry(probe);
-					activeScope = GRANULAR_SCOPE;
+					await withNonceRetry(async () => {
+						const res = await oauth.pushedAuthorizationRequest(
+							state.authServer!,
+							{ client_id: clientId() },
+							oauth.None(),
+							probeParams,
+							{ DPoP: probeDpop },
+						);
+						return await oauth.processPushedAuthorizationResponse(
+							state.authServer!,
+							{ client_id: clientId() },
+							res,
+						);
+					});
+					return null;
+				} catch (error) {
+					if (error instanceof oauth.ResponseBodyError) return error;
+					throw error;
+				}
+			};
+			await runStep("flow.select-scope", async () => {
+				const fullErr = await probeScope(GRANULAR_WITH_INCLUDE_SCOPE);
+				if (!fullErr) {
+					activeScope = GRANULAR_WITH_INCLUDE_SCOPE;
 					return {
 						status: "pass",
-						message: `granular scope accepted: ${activeScope}`,
+						message: `granular + include scope accepted: ${activeScope}`,
 						evidence: { actual: { selected: activeScope } },
 					};
-				} catch (error) {
-					if (
-						error instanceof oauth.ResponseBodyError &&
-						(error.error === "invalid_scope" ||
-							error.error === "invalid_request")
-					) {
-						activeScope = LEGACY_SCOPE;
-						return {
-							status: "warn",
-							message: `AS rejected granular scope (${error.error}) — falling back to ${LEGACY_SCOPE}; granular boundary tests will skip`,
-							evidence: {
-								response: { status: error.status, body: error.cause },
-								actual: { selected: activeScope },
-							},
-						};
-					}
-					activeScope = LEGACY_SCOPE;
+				}
+				const granularErr = await probeScope(GRANULAR_SCOPE);
+				if (!granularErr) {
+					activeScope = GRANULAR_SCOPE;
 					return {
 						status: "warn",
-						message: `probe inconclusive: ${error instanceof Error ? error.message : String(error)} — falling back to ${LEGACY_SCOPE}`,
+						message: `AS rejected include: (${fullErr.error}) — using granular without include; permission-set tests will skip`,
 						evidence: {
-							error: String(error),
+							response: { status: fullErr.status, body: fullErr.cause },
 							actual: { selected: activeScope },
 						},
 					};
 				}
+				activeScope = LEGACY_SCOPE;
+				return {
+					status: "warn",
+					message: `AS rejected granular scope (${granularErr.error}) — falling back to ${LEGACY_SCOPE}; granular boundary tests will skip`,
+					evidence: {
+						response: { status: granularErr.status, body: granularErr.cause },
+						actual: { selected: activeScope },
+					},
+				};
 			});
 
 			// 8. Send PAR (with DPoP-nonce retry built in — RFC 9449 §8 allows the

--- a/apps/check/src/lib/oauth-flow.ts
+++ b/apps/check/src/lib/oauth-flow.ts
@@ -81,6 +81,19 @@ const CALLBACK_PATH = "/oauth/flow-callback";
 // flow at a time so this is safe.
 let activeScope: string = LEGACY_SCOPE;
 
+// Superset of every scope the flow might request — used in the client_id
+// metadata so an AS that enforces "requested scope must be declared" (RFC
+// 9101 / atproto OAuth) accepts both the legacy and granular probes. The
+// actual scope sent at PAR time is `activeScope`, selected by probe.
+const CLIENT_METADATA_SCOPE = [
+	"atproto",
+	"transition:generic",
+	GRANULAR_SCOPE.split(" ").filter((s) => s !== "atproto").join(" "),
+	"include:site.standard.authFull",
+]
+	.join(" ")
+	.trim();
+
 function clientId(): string {
 	const isLoopback =
 		location.hostname === "localhost" || location.hostname === "127.0.0.1";
@@ -88,7 +101,7 @@ function clientId(): string {
 	if (isLoopback) {
 		const params = new URLSearchParams({
 			redirect_uri: redirectUri,
-			scope: activeScope,
+			scope: CLIENT_METADATA_SCOPE,
 		});
 		return `http://localhost?${params.toString()}`;
 	}

--- a/apps/check/src/lib/oauth-flow.ts
+++ b/apps/check/src/lib/oauth-flow.ts
@@ -338,7 +338,7 @@ function initialStepsFor(ids: readonly string[]): FlowStep[] {
 		"flow.par-rejects-invalid-include":
 			"PAR rejects a nonexistent permission set include:",
 		"flow.par-accepts-known-permission-set":
-			"PAR accepts include:app.bsky.authFullApp (a published, lexicon-resolved permission set)",
+			"PAR accepts include:site.standard.authFull (a published, lexicon-resolved permission set)",
 		"flow.build-authorization-url": "Build authorization URL",
 		"flow.callback-params-present": "Callback has code, state, iss",
 		"flow.iss-matches": "iss parameter matches auth server (RFC 9207)",
@@ -1013,11 +1013,11 @@ export function startPreRedirectFlow(target: string): FlowRun {
 				}
 			});
 
-			// 9c.ii — request a published permission set (`app.bsky.authFullApp`)
+			// 9c.ii — request a published permission set (`site.standard.authFull`)
 			// to test whether the AS can dynamically resolve `include:*` NSIDs via
 			// lexicon resolution.
 			await runStep("flow.par-accepts-known-permission-set", async () => {
-				const knownInclude = "include:app.bsky.authFullApp";
+				const knownInclude = "include:site.standard.authFull";
 				const probeParams = {
 					client_id: clientId(),
 					redirect_uri: redirectUri(),
@@ -1045,7 +1045,7 @@ export function startPreRedirectFlow(target: string): FlowRun {
 					const accepted = await withNonceRetry(attempt);
 					return {
 						status: "pass",
-						message: `AS resolved app.bsky.authFullApp (request_uri expires in ${accepted.expires_in}s)`,
+						message: `AS resolved site.standard.authFull (request_uri expires in ${accepted.expires_in}s)`,
 						evidence: {
 							response: { body: accepted },
 							actual: { probed: knownInclude },
@@ -1062,7 +1062,7 @@ export function startPreRedirectFlow(target: string): FlowRun {
 									"AS resolves the published lexicon and accepts the include:",
 								actual: error.error,
 								error:
-									"app.bsky.authFullApp is a published permission set lexicon. Rejecting it means this AS doesn't support dynamic lexicon-based permission-set resolution.",
+									"site.standard.authFull is a published permission set lexicon. Rejecting it means this AS doesn't support dynamic lexicon-based permission-set resolution.",
 							},
 						};
 					}

--- a/packages/oauth-provider/src/provider.ts
+++ b/packages/oauth-provider/src/provider.ts
@@ -907,17 +907,15 @@ export class ATProtoOAuthProvider {
 			grant_types_supported: ["authorization_code", "refresh_token"],
 			code_challenge_methods_supported: ["S256"],
 			token_endpoint_auth_methods_supported: ["none", "private_key_jwt"],
+			// Per atproto OAuth spec: must include "atproto"; transitional scopes
+			// included when supported. Granular resource scopes (repo:, rpc:, blob:,
+			// account:, identity:) and permission-set include: scopes are
+			// parameterized and aren't enumerable, so they aren't listed.
 			scopes_supported: [
 				"atproto",
 				"transition:generic",
 				"transition:email",
 				"transition:chat.bsky",
-				"repo",
-				"rpc",
-				"blob",
-				"account",
-				"identity",
-				...(this.permissionSetResolver ? ["include"] : []),
 			],
 			subject_types_supported: ["public"],
 			authorization_response_iss_parameter_supported: true,


### PR DESCRIPTION
## Background

The atproto OAuth spec on \`scopes_supported\`:

> \`scopes_supported\` (array of strings, required): must include \`atproto\`. If supporting the transitional scopes, they should be included here as well.

The reference oauth-provider lists exactly the four spec-defined values and explicitly comments \"Other atproto scopes can't be enumerated as they are dynamic.\" Granular scopes (\`repo:<nsid>\`, \`rpc:<lxm>\`, \`blob:<mime>\`, \`account:<…>\`, \`identity:<…>\`) and permission-set scopes (\`include:<nsid>\`) are parameterised — bare prefixes aren't valid scope values that can be granted.

Cirrus was advertising bare \`repo\`, \`rpc\`, \`blob\`, \`account\`, \`identity\`, and \`include\` alongside the four spec values. pdscheck used the presence of bare \`repo\` as its signal for \"this AS supports granular\" and only exercised the granular boundary tests against Cirrus — never against the reference. The whole feedback loop was internal to a non-spec convention we'd invented.

## Changes

**\`packages/oauth-provider/src/provider.ts\`** — trim \`scopes_supported\` to the four spec-defined values. Drops \`repo\`, \`rpc\`, \`blob\`, \`account\`, \`identity\`, and the conditional \`include\` entry.

**\`apps/check/src/lib/oauth-flow.ts\`** — \`flow.select-scope\` no longer reads \`scopes_supported\`. It now sends a probe PAR with \`GRANULAR_SCOPE\` and:
- accepts \`request_uri\` → use granular.
- \`invalid_scope\` / \`invalid_request\` → fall back to \`LEGACY_SCOPE\` with a warn.

Step reordered after \`flow.generate-pkce\` and \`flow.generate-dpop-key\` so the probe has the required inputs. Same flow now works identically against Cirrus, bsky.social, or any other spec-compliant AS that supports granular scopes.

**\`apps/check/src/lib/oauth-flow.ts\`** — \`flow.par-rejects-invalid-include\` drops its advertising gate; always probes with a bogus include NSID.

**\`apps/check/src/lib/oauth-flow.ts\`** — \`flow.par-accepts-advertised-include\` removed. Its purpose (\"AS accepts the include: it advertised\") only made sense under the non-spec convention. \`flow.par-accepts-known-permission-set\` still exercises include resolution via a real published lexicon.

**\`apps/check/src/checks/oauth-discovery.ts\`** — \`oauth-discovery.scope-resource-buckets\` and \`oauth-discovery.scope-permission-sets\` removed. Both asserted on non-spec advertising patterns.

## Test plan
- [x] \`pnpm --filter @getcirrus/oauth-provider test\` — 116 passing.
- [x] \`pnpm --filter @getcirrus/pds test\` — 313 unit + 84 CLI passing.
- [x] \`apps/check\` typecheck clean.
- [ ] Manual OAuth flow against pds.mk.gg after deploy: confirm \`flow.select-scope\` probes granular, accepts, runs boundary tests.
- [ ] Manual OAuth flow against bsky.social: confirm probe falls back to LEGACY, boundary tests skip.