### PR TITLE
fix(pds): match reference PDS RecordNotFound message string

### DIFF
--- a/.changeset/match-record-not-found-message.md
+++ b/.changeset/match-record-not-found-message.md
@@ -1,0 +1,5 @@
+---
+"@getcirrus/pds": patch
+---
+
+Match the reference @atproto PDS's exact `RecordNotFound` error message (`Could not locate record: <at-uri>`). The Bluesky social-app's quote-detach flow string-matches this phrase to decide whether to create a new `app.bsky.feed.postgate` record vs. update an existing one; the previous message caused it to rethrow instead of falling through to the create path.

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ pnpm-debug.log*
 
 # Signing key backups (created by pds init)
 signing-key-backup-*.txt
+
+.claude

--- a/apps/check/src/checks/repo-read.ts
+++ b/apps/check/src/checks/repo-read.ts
@@ -569,7 +569,7 @@ const getRecordMissing: Check = {
 	category: "repo-read",
 	label: "getRecord returns 400 RecordNotFound for missing record",
 	description:
-		"Matches the reference @atproto PDS, which raises InvalidRequestError (HTTP 400) with error 'RecordNotFound' rather than returning a 404. Clients that probe a record before writing it (for example detaching a quote, which checks app.bsky.feed.postgate first) rely on this.",
+		"Matches the reference @atproto PDS, which raises InvalidRequestError (HTTP 400) with error 'RecordNotFound' rather than returning a 404, and includes the phrase 'Could not locate record:' in the message. Clients probe a record before writing it (for example detaching a quote, which checks app.bsky.feed.postgate first), and the Bluesky social-app does a literal substring match on that phrase to decide whether to create vs. update.",
 	requires: ["pds", "did"],
 	run: async (ctx): Promise<CheckOutcome> => {
 		const pds = ctx.pds!;
@@ -617,9 +617,29 @@ const getRecordMissing: Check = {
 					},
 				};
 			}
+			const message =
+				body && typeof body === "object" && "message" in body
+					? (body as { message: unknown }).message
+					: undefined;
+			if (
+				typeof message !== "string" ||
+				!message.includes("Could not locate record:")
+			) {
+				return {
+					status: "fail",
+					message:
+						"Expected message to include 'Could not locate record:' (Bluesky social-app substring-matches this phrase when detaching a quote)",
+					evidence: {
+						request: { method: "GET", url },
+						response: { status: res.status, body },
+						expected: "Could not locate record: <at-uri>",
+						actual: message,
+					},
+				};
+			}
 			return {
 				status: "pass",
-				message: "400 RecordNotFound",
+				message: "400 RecordNotFound with social-app-compatible message",
 				evidence: {
 					request: { method: "GET", url },
 					response: { status: res.status, body },

--- a/packages/pds/src/xrpc/repo.ts
+++ b/packages/pds/src/xrpc/repo.ts
@@ -192,7 +192,7 @@ export async function getRecord(
 		return c.json(
 			{
 				error: "RecordNotFound",
-				message: `Record not found: ${collection}/${rkey}`,
+				message: `Could not locate record: at://${repo}/${collection}/${rkey}`,
 			},
 			400,
 		);


### PR DESCRIPTION
## Summary

Follow-up to #189. The HTTP status code is now correct (400), but the Bluesky social-app's quote-detach flow does a string match on the response message:

\`\`\`ts
// src/state/queries/postgate/index.ts (social-app)
if (e.message.includes(\`Could not locate record:\`)) {
  return undefined  // → fall through to createPostgateRecord
}
\`\`\`

Our PDS was returning `Record not found: <collection>/<rkey>`, so the social-app rethrew the error instead of creating the postgate. Match the reference @atproto PDS's exact phrasing — `Could not locate record: at://<did>/<collection>/<rkey>`.

## Test plan

- [ ] Detach a quote in the Bluesky app against a Cirrus PDS — should succeed (creates the postgate record on first detach).