### PR TITLE
feat(pds): Remove `bucket_name` from R2 Binding

### DIFF
--- a/packages/create-pds/templates/pds-worker/wrangler.jsonc
+++ b/packages/create-pds/templates/pds-worker/wrangler.jsonc
@@ -25,11 +25,10 @@
 			]
 		}
 	],
-	// R2 bucket for blob storage (optional - create via Cloudflare dashboard)
+	// R2 bucket for blob storage (optional - auto-created on first deploy)
 	"r2_buckets": [
 		{
-			"binding": "BLOBS",
-			"bucket_name": "pds-blobs"
+			"binding": "BLOBS"
 		}
 	],
 	// Environment variables (public config)


### PR DESCRIPTION
Closes #107.

When going through the creation flow for a new PDS, `wrangler` will now auto-create a bucket using `wrangler`'s [Automatic Provisioning](https://developers.cloudflare.com/workers/wrangler/configuration/#automatic-provisioning) feature, which should prevent collisions between multiple PDSses, as you cannot have two Workers on an account with the same name.

 
Example output from the deploy flow:
```
Experimental: The following bindings need to be provisioned:
Binding           Resource
env.BLOBS         R2 Bucket


Provisioning BLOBS (R2 Bucket)...
🌀 Creating new R2 Bucket "my-pds-pds-blobs"...
✨ BLOBS provisioned 🎉
```