### PR TITLE
fix(create-pds): Autocopy `allowBuilds` when using PNPM

### DIFF
--- a/packages/create-pds/src/index.ts
+++ b/packages/create-pds/src/index.ts
@@ -78,13 +78,20 @@ function runCommand(
 	});
 }
 
-async function copyTemplateDir(src: string, dest: string): Promise<void> {
+async function copyTemplateDir(
+	src: string,
+	dest: string,
+	pm: PackageManager,
+): Promise<void> {
 	await mkdir(dest, { recursive: true });
 	const entries = await readdir(src, { withFileTypes: true });
 
 	for (const entry of entries) {
 		const srcPath = join(src, entry.name);
 		let destName = entry.name;
+
+		// Skip pnpm-specific files if not using pnpm
+		if (destName === "pnpm-workspace.yaml" && pm !== "pnpm") continue;
 
 		// Rename dotfiles (npm strips them from packages)
 		if (destName === "gitignore") destName = ".gitignore";
@@ -95,7 +102,7 @@ async function copyTemplateDir(src: string, dest: string): Promise<void> {
 		const destPath = join(dest, destName);
 
 		if (entry.isDirectory()) {
-			await copyTemplateDir(srcPath, destPath);
+			await copyTemplateDir(srcPath, destPath, pm);
 		} else {
 			await cp(srcPath, destPath);
 		}
@@ -266,7 +273,7 @@ const main = defineCommand({
 		spinner.start("Copying template...");
 
 		const templateDir = join(__dirname, "..", "templates", "pds-worker");
-		await copyTemplateDir(templateDir, targetDir);
+		await copyTemplateDir(templateDir, targetDir, pm);
 
 		// Replace placeholders in package.json
 		await replaceInFile(join(targetDir, "package.json"), {

--- a/packages/create-pds/templates/pds-worker/pnpm-workspace.yaml
+++ b/packages/create-pds/templates/pds-worker/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: true
+  sharp: false
+  workerd: true


### PR DESCRIPTION
Hit this small papercut myself.

Per [Block risky postinstall scripts](https://pnpm.io/supply-chain-security#block-risky-postinstall-scripts), `pnpm` now doesn't run `postinstall` scripts automatically. This change adds the config required to ensure `workerd` and `esbuild` have their postinstall scripts run, and only performs this work when applicable(i.e., when using `pnpm`).