### PR TITLE
feat(pds): stage blob uploads until referenced by a record

### DIFF
--- a/packages/create-pds/templates/pds-worker/wrangler.jsonc
+++ b/packages/create-pds/templates/pds-worker/wrangler.jsonc
@@ -26,6 +26,9 @@
 		}
 	],
 	// R2 bucket for blob storage (optional - create via Cloudflare dashboard)
+	// Uploads are staged under `<did>/staged/` until a record references
+	// them. Add a lifecycle rule to expire abandoned uploads, e.g.:
+	//   wrangler r2 bucket lifecycle add pds-blobs --prefix "<did>/staged/" --expire-days 7
 	"r2_buckets": [
 		{
 			"binding": "BLOBS",

--- a/packages/pds/src/account-do.ts
+++ b/packages/pds/src/account-do.ts
@@ -1056,9 +1056,14 @@ export class AccountDurableObject extends DurableObject<PDSEnv> {
 		cid: string,
 		size: number,
 		mimeType: string,
-	): Promise<void> {
+	): Promise<{ referenced: boolean }> {
 		const storage = await this.getStorage();
 		storage.trackImportedBlob(cid, size, mimeType);
+		// Report whether an existing record already references this CID so
+		// the Worker can promote the staged upload immediately (migration
+		// uploads arrive after their referencing records were imported, so
+		// no later record write will do it).
+		return { referenced: storage.isBlobReferenced(cid) };
 	}
 
 	/**

--- a/packages/pds/src/blobs.ts
+++ b/packages/pds/src/blobs.ts
@@ -12,6 +12,74 @@ export interface BlobRef {
 }
 
 /**
+ * R2 key layout for blobs:
+ *
+ *   `${did}/staged/${cid}` – uploaded, not yet referenced by any record.
+ *     Served by nothing; expired by an R2 lifecycle rule after seven days.
+ *   `${did}/${cid}`        – referenced by at least one public record.
+ *     Served by com.atproto.sync.getBlob.
+ *
+ * Uploads land in `staged/` and are promoted (copied) to their destination
+ * key when a record write first references them. The copy completes before
+ * the commit is applied, so anything reacting to the commit never sees a
+ * 404. Keys never move back: promotion is idempotent and `staged/` copies
+ * are left for the lifecycle rule to reap.
+ */
+export function stagedBlobKey(did: string, cid: string): string {
+	return `${did}/staged/${cid}`;
+}
+
+export function publicBlobKey(did: string, cid: string): string {
+	return `${did}/${cid}`;
+}
+
+/**
+ * Extract blob CIDs from a record in JSON form (as received from clients),
+ * recursively searching for blob references. Handles both the current
+ * `{ $type: "blob", ref: { $link }, mimeType, size }` shape and the legacy
+ * untyped `{ cid, mimeType }` shape.
+ */
+export function extractJsonBlobCids(value: unknown): string[] {
+	const cids = new Set<string>();
+	walkForBlobRefs(value, cids);
+	return Array.from(cids);
+}
+
+function walkForBlobRefs(value: unknown, out: Set<string>): void {
+	if (Array.isArray(value)) {
+		for (const item of value) walkForBlobRefs(item, out);
+		return;
+	}
+	if (value === null || typeof value !== "object") return;
+
+	const obj = value as Record<string, unknown>;
+
+	if (
+		obj.$type === "blob" &&
+		typeof obj.ref === "object" &&
+		obj.ref !== null &&
+		typeof (obj.ref as Record<string, unknown>).$link === "string"
+	) {
+		out.add((obj.ref as { $link: string }).$link);
+		return;
+	}
+
+	// Legacy blob ref: { cid: string, mimeType: string } with no $type
+	if (
+		obj.$type === undefined &&
+		typeof obj.cid === "string" &&
+		typeof obj.mimeType === "string"
+	) {
+		out.add(obj.cid);
+		return;
+	}
+
+	for (const key of Object.keys(obj)) {
+		walkForBlobRefs(obj[key], out);
+	}
+}
+
+/**
  * BlobStore manages blob storage in R2.
  * Blobs are stored with CID-based keys prefixed by the account's DID.
  */
@@ -22,16 +90,17 @@ export class BlobStore {
 	) {}
 
 	/**
-	 * Upload a blob to R2 and return a BlobRef.
+	 * Upload a blob to R2 staging and return a BlobRef.
+	 *
+	 * The blob is not fetchable until a record write references it, which
+	 * promotes it to its serving key.
 	 */
 	async putBlob(bytes: Uint8Array, mimeType: string): Promise<BlobRef> {
 		// Compute CID using SHA-256 (RAW codec)
 		const cidObj = await createCid(CODEC_RAW, bytes);
 		const cidStr = cidToString(cidObj);
 
-		// Store in R2 with DID prefix for isolation
-		const key = `${this.did}/${cidStr}`;
-		await this.r2.put(key, bytes, {
+		await this.r2.put(stagedBlobKey(this.did, cidStr), bytes, {
 			httpMetadata: { contentType: mimeType },
 		});
 
@@ -44,19 +113,51 @@ export class BlobStore {
 	}
 
 	/**
-	 * Retrieve a blob from R2 by CID string.
+	 * Promote a staged blob to a destination key with a streaming copy.
+	 *
+	 * Idempotent: returns early when the destination already exists, so
+	 * concurrent writes referencing the same staged blob are safe. A CID
+	 * that is neither staged nor at the destination is skipped — records
+	 * may reference blobs from before this layout existed, and reference
+	 * checking is not this method's job.
 	 */
-	async getBlob(cid: string): Promise<R2ObjectBody | null> {
-		const key = `${this.did}/${cid}`;
-		return this.r2.get(key);
+	private async promoteTo(cid: string, destKey: string): Promise<void> {
+		if (await this.r2.head(destKey)) return;
+
+		const staged = await this.r2.get(stagedBlobKey(this.did, cid));
+		if (!staged) return;
+
+		await this.r2.put(destKey, staged.body, {
+			httpMetadata: staged.httpMetadata,
+		});
 	}
 
 	/**
-	 * Check if a blob exists in R2.
+	 * Promote a staged blob to the public serving key.
+	 */
+	async promoteBlob(cid: string): Promise<void> {
+		await this.promoteTo(cid, publicBlobKey(this.did, cid));
+	}
+
+	/**
+	 * Promote several staged blobs to the public serving key.
+	 */
+	async promoteBlobs(cids: string[]): Promise<void> {
+		await Promise.all(cids.map((cid) => this.promoteBlob(cid)));
+	}
+
+	/**
+	 * Retrieve a public blob from R2 by CID string.
+	 */
+	async getBlob(cid: string): Promise<R2ObjectBody | null> {
+		return this.r2.get(publicBlobKey(this.did, cid));
+	}
+
+	/**
+	 * Check if a blob exists at the public serving key.
 	 */
 	async hasBlob(cid: string): Promise<boolean> {
-		const key = `${this.did}/${cid}`;
-		const head = await this.r2.head(key);
+		const head = await this.r2.head(publicBlobKey(this.did, cid));
 		return head !== null;
 	}
 }

--- a/packages/pds/src/blobs.ts
+++ b/packages/pds/src/blobs.ts
@@ -25,11 +25,11 @@ export interface BlobRef {
  * 404. Keys never move back: promotion is idempotent and `staged/` copies
  * are left for the lifecycle rule to reap.
  */
-export function stagedBlobKey(did: string, cid: string): string {
+function stagedBlobKey(did: string, cid: string): string {
 	return `${did}/staged/${cid}`;
 }
 
-export function publicBlobKey(did: string, cid: string): string {
+function publicBlobKey(did: string, cid: string): string {
 	return `${did}/${cid}`;
 }
 

--- a/packages/pds/src/storage.ts
+++ b/packages/pds/src/storage.ts
@@ -455,6 +455,16 @@ export class SqliteRepoStorage
 	}
 
 	/**
+	 * Check if any record references a blob CID.
+	 */
+	isBlobReferenced(cid: string): boolean {
+		const rows = this.sql
+			.exec("SELECT 1 FROM record_blob WHERE blobCid = ? LIMIT 1", cid)
+			.toArray();
+		return rows.length > 0;
+	}
+
+	/**
 	 * Check if a blob has been imported.
 	 */
 	isBlobImported(cid: string): boolean {

--- a/packages/pds/src/xrpc/repo.ts
+++ b/packages/pds/src/xrpc/repo.ts
@@ -10,8 +10,30 @@ import {
 	type ValidationStatus,
 } from "../validation.js";
 import { detectContentType } from "../format.js";
-import { BlobStore } from "../blobs.js";
+import { BlobStore, extractJsonBlobCids } from "../blobs.js";
 import { buildScopeChecker, requireScope } from "../middleware/auth.js";
+
+/**
+ * Promote any staged blobs referenced by the given records to their public
+ * serving key. Runs in the Worker before the DO applies the commit, so a
+ * relay or AppView reacting to the commit never sees a 404 for a
+ * just-referenced blob. Idempotent per CID; unknown CIDs are skipped.
+ */
+async function promoteRecordBlobs(
+	c: Context<AuthedAppEnv>,
+	records: unknown[],
+): Promise<void> {
+	if (!c.env.BLOBS) return;
+	const cids = new Set<string>();
+	for (const record of records) {
+		for (const cid of extractJsonBlobCids(record)) {
+			cids.add(cid);
+		}
+	}
+	if (cids.size === 0) return;
+	const blobStore = new BlobStore(c.env.BLOBS, c.env.DID);
+	await blobStore.promoteBlobs(Array.from(cids));
+}
 
 function invalidRecordError(
 	c: Context<AuthedAppEnv>,
@@ -319,6 +341,8 @@ export async function createRecord(
 		throw err;
 	}
 
+	await promoteRecordBlobs(c, [validated.record]);
+
 	try {
 		const result = await accountDO.rpcCreateRecord(
 			collection,
@@ -431,6 +455,8 @@ export async function putRecord(
 		if (err instanceof InvalidRecordError) return invalidRecordError(c, err);
 		throw err;
 	}
+
+	await promoteRecordBlobs(c, [validated.record]);
 
 	try {
 		const result = await accountDO.rpcPutRecord(
@@ -589,6 +615,11 @@ export async function applyWrites(
 		}
 	}
 
+	await promoteRecordBlobs(
+		c,
+		preparedWrites.filter((w) => w.value !== undefined).map((w) => w.value),
+	);
+
 	try {
 		const result = await accountDO.rpcApplyWrites(preparedWrites);
 		return c.json(result);
@@ -669,13 +700,21 @@ export async function uploadBlob(
 	// input gate, and Cloudflare resets the object when a storage op times
 	// out, dropping the firehose and desyncing the relay. The DO only
 	// records the tracking metadata. This mirrors sync.getBlob.
+	//
+	// Uploads land in `staged/` and are promoted when a record write
+	// references them. During migration the referencing records were already
+	// imported, so no later write will promote — rpcTrackBlob reports
+	// whether the CID is referenced and we promote here in that case.
 	const blobStore = new BlobStore(c.env.BLOBS, c.env.DID);
 	const blobRef = await blobStore.putBlob(bytes, contentType);
-	await accountDO.rpcTrackBlob(
+	const { referenced } = await accountDO.rpcTrackBlob(
 		blobRef.ref.$link,
 		blobRef.size,
 		blobRef.mimeType,
 	);
+	if (referenced) {
+		await blobStore.promoteBlob(blobRef.ref.$link);
+	}
 	return c.json({ blob: blobRef });
 }
 

--- a/packages/pds/src/xrpc/sync.ts
+++ b/packages/pds/src/xrpc/sync.ts
@@ -206,13 +206,16 @@ export async function listBlobs(
 		return c.json({ cids: [] });
 	}
 
-	// List blobs from R2 with prefix
+	// List blobs from R2 with prefix. The delimiter keeps nested key
+	// namespaces (`${did}/staged/`, `${did}/space/…`) out of the public
+	// listing — only promoted blobs at `${did}/${cid}` are enumerable.
 	const prefix = `${did}/`;
 	const cursor = c.req.query("cursor");
 	const limit = Math.min(Number(c.req.query("limit")) || 500, 1000);
 
 	const listed = await c.env.BLOBS.list({
 		prefix,
+		delimiter: "/",
 		limit,
 		cursor: cursor || undefined,
 	});

--- a/packages/pds/test/blobs.test.ts
+++ b/packages/pds/test/blobs.test.ts
@@ -1,5 +1,62 @@
 import { describe, it, expect } from "vitest";
 import { env, worker } from "./helpers";
+import { extractJsonBlobCids } from "../src/blobs";
+
+/**
+ * Reference a blob from a record so it gets promoted from staging to its
+ * public serving key. Uses an unknown collection (validation is optimistic
+ * for unloaded lexicons) so the record shape doesn't matter.
+ */
+async function referenceBlob(blob: unknown): Promise<void> {
+	const res = await worker.fetch(
+		new Request("http://pds.test/xrpc/com.atproto.repo.createRecord", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${env.AUTH_TOKEN}`,
+			},
+			body: JSON.stringify({
+				repo: env.DID,
+				collection: "test.cirrus.blobRef",
+				record: { $type: "test.cirrus.blobRef", file: blob },
+			}),
+		}),
+		env,
+	);
+	expect(res.status).toBe(200);
+}
+
+async function uploadBlob(
+	bytes: Uint8Array,
+	contentType: string,
+): Promise<{
+	$type: string;
+	ref: { $link: string };
+	mimeType: string;
+	size: number;
+}> {
+	const response = await worker.fetch(
+		new Request("http://pds.test/xrpc/com.atproto.repo.uploadBlob", {
+			method: "POST",
+			headers: {
+				"Content-Type": contentType,
+				Authorization: `Bearer ${env.AUTH_TOKEN}`,
+			},
+			body: bytes,
+		}),
+		env,
+	);
+	expect(response.status).toBe(200);
+	const data = (await response.json()) as {
+		blob: {
+			$type: string;
+			ref: { $link: string };
+			mimeType: string;
+			size: number;
+		};
+	};
+	return data.blob;
+}
 
 describe("Blob Storage", () => {
 	describe("uploadBlob", () => {
@@ -97,32 +154,14 @@ describe("Blob Storage", () => {
 	});
 
 	describe("getBlob", () => {
-		it("should retrieve uploaded blob", async () => {
-			// First upload a blob
+		it("should retrieve uploaded blob once referenced", async () => {
 			const testData = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
-			const uploadResponse = await worker.fetch(
-				new Request("http://pds.test/xrpc/com.atproto.repo.uploadBlob", {
-					method: "POST",
-					headers: {
-						"Content-Type": "application/octet-stream",
-						Authorization: `Bearer ${env.AUTH_TOKEN}`,
-					},
-					body: testData,
-				}),
-				env,
-			);
+			const blob = await uploadBlob(testData, "application/octet-stream");
+			await referenceBlob(blob);
 
-			expect(uploadResponse.status).toBe(200);
-
-			const uploadData = (await uploadResponse.json()) as {
-				blob: { ref: { $link: string } };
-			};
-			const cid = uploadData.blob.ref.$link;
-
-			// Then retrieve it
 			const getResponse = await worker.fetch(
 				new Request(
-					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${cid}`,
+					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${blob.ref.$link}`,
 				),
 				env,
 			);
@@ -193,29 +232,14 @@ describe("Blob Storage", () => {
 		});
 
 		it("should preserve content type", async () => {
-			// Upload a blob with specific content type
 			const testData = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
-			const uploadResponse = await worker.fetch(
-				new Request("http://pds.test/xrpc/com.atproto.repo.uploadBlob", {
-					method: "POST",
-					headers: {
-						"Content-Type": "image/png",
-						Authorization: `Bearer ${env.AUTH_TOKEN}`,
-					},
-					body: testData,
-				}),
-				env,
-			);
-
-			const uploadData = (await uploadResponse.json()) as {
-				blob: { ref: { $link: string } };
-			};
-			const cid = uploadData.blob.ref.$link;
+			const blob = await uploadBlob(testData, "image/png");
+			await referenceBlob(blob);
 
 			// Retrieve and check content type
 			const getResponse = await worker.fetch(
 				new Request(
-					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${cid}`,
+					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${blob.ref.$link}`,
 				),
 				env,
 			);
@@ -252,29 +276,13 @@ describe("Blob Storage", () => {
 			]);
 
 			// Upload with wildcard content type (simulating the bug)
-			const uploadResponse = await worker.fetch(
-				new Request("http://pds.test/xrpc/com.atproto.repo.uploadBlob", {
-					method: "POST",
-					headers: {
-						"Content-Type": "*/*",
-						Authorization: `Bearer ${env.AUTH_TOKEN}`,
-					},
-					body: mp4Header,
-				}),
-				env,
-			);
-
-			expect(uploadResponse.status).toBe(200);
-
-			const uploadData = (await uploadResponse.json()) as {
-				blob: { ref: { $link: string } };
-			};
-			const cid = uploadData.blob.ref.$link;
+			const blob = await uploadBlob(mp4Header, "*/*");
+			await referenceBlob(blob);
 
 			// Retrieve - should detect video/mp4 from magic bytes
 			const getResponse = await worker.fetch(
 				new Request(
-					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${cid}`,
+					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${blob.ref.$link}`,
 				),
 				env,
 			);
@@ -289,26 +297,12 @@ describe("Blob Storage", () => {
 				0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
 			]);
 
-			const uploadResponse = await worker.fetch(
-				new Request("http://pds.test/xrpc/com.atproto.repo.uploadBlob", {
-					method: "POST",
-					headers: {
-						"Content-Type": "*/*",
-						Authorization: `Bearer ${env.AUTH_TOKEN}`,
-					},
-					body: jpegData,
-				}),
-				env,
-			);
-
-			const uploadData = (await uploadResponse.json()) as {
-				blob: { ref: { $link: string } };
-			};
-			const cid = uploadData.blob.ref.$link;
+			const blob = await uploadBlob(jpegData, "*/*");
+			await referenceBlob(blob);
 
 			const getResponse = await worker.fetch(
 				new Request(
-					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${cid}`,
+					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${blob.ref.$link}`,
 				),
 				env,
 			);
@@ -323,26 +317,12 @@ describe("Blob Storage", () => {
 				0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
 			]);
 
-			const uploadResponse = await worker.fetch(
-				new Request("http://pds.test/xrpc/com.atproto.repo.uploadBlob", {
-					method: "POST",
-					headers: {
-						"Content-Type": "*/*",
-						Authorization: `Bearer ${env.AUTH_TOKEN}`,
-					},
-					body: pngData,
-				}),
-				env,
-			);
-
-			const uploadData = (await uploadResponse.json()) as {
-				blob: { ref: { $link: string } };
-			};
-			const cid = uploadData.blob.ref.$link;
+			const blob = await uploadBlob(pngData, "*/*");
+			await referenceBlob(blob);
 
 			const getResponse = await worker.fetch(
 				new Request(
-					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${cid}`,
+					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${blob.ref.$link}`,
 				),
 				env,
 			);
@@ -357,26 +337,12 @@ describe("Blob Storage", () => {
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
 			]);
 
-			const uploadResponse = await worker.fetch(
-				new Request("http://pds.test/xrpc/com.atproto.repo.uploadBlob", {
-					method: "POST",
-					headers: {
-						"Content-Type": "*/*",
-						Authorization: `Bearer ${env.AUTH_TOKEN}`,
-					},
-					body: unknownData,
-				}),
-				env,
-			);
-
-			const uploadData = (await uploadResponse.json()) as {
-				blob: { ref: { $link: string } };
-			};
-			const cid = uploadData.blob.ref.$link;
+			const blob = await uploadBlob(unknownData, "*/*");
+			await referenceBlob(blob);
 
 			const getResponse = await worker.fetch(
 				new Request(
-					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${cid}`,
+					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${blob.ref.$link}`,
 				),
 				env,
 			);
@@ -389,39 +355,19 @@ describe("Blob Storage", () => {
 	});
 
 	describe("Integration", () => {
-		it("should handle upload and retrieval flow", async () => {
+		it("should handle upload, reference and retrieval flow", async () => {
 			// Create test data
 			const testData = new Uint8Array([
 				255, 216, 255, 224, 0, 16, 74, 70, 73, 70,
 			]); // JPEG header
 
-			// Upload
-			const uploadResponse = await worker.fetch(
-				new Request("http://pds.test/xrpc/com.atproto.repo.uploadBlob", {
-					method: "POST",
-					headers: {
-						"Content-Type": "image/jpeg",
-						Authorization: `Bearer ${env.AUTH_TOKEN}`,
-					},
-					body: testData,
-				}),
-				env,
-			);
-
-			expect(uploadResponse.status).toBe(200);
-
-			const { blob } = (await uploadResponse.json()) as {
-				blob: {
-					$type: string;
-					ref: { $link: string };
-					mimeType: string;
-					size: number;
-				};
-			};
+			const blob = await uploadBlob(testData, "image/jpeg");
 			expect(blob.$type).toBe("blob");
 			expect(blob.ref.$link).toBeTruthy();
 			expect(blob.mimeType).toBe("image/jpeg");
 			expect(blob.size).toBe(testData.length);
+
+			await referenceBlob(blob);
 
 			// Retrieve
 			const getResponse = await worker.fetch(
@@ -439,6 +385,169 @@ describe("Blob Storage", () => {
 			expect(getResponse.headers.get("Content-Length")).toBe(
 				testData.length.toString(),
 			);
+		});
+	});
+
+	describe("Blob staging", () => {
+		it("does not serve an uploaded blob until a record references it", async () => {
+			const bytes = new Uint8Array([0x53, 0x54, 0x41, 0x47, 0x45, 0x44, 0x21]);
+			const blob = await uploadBlob(bytes, "application/octet-stream");
+
+			// Not fetchable while staged
+			const before = await worker.fetch(
+				new Request(
+					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${blob.ref.$link}`,
+				),
+				env,
+			);
+			expect(before.status).toBe(404);
+
+			await referenceBlob(blob);
+
+			// Promoted and fetchable after the record write
+			const after = await worker.fetch(
+				new Request(
+					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${blob.ref.$link}`,
+				),
+				env,
+			);
+			expect(after.status).toBe(200);
+			expect(new Uint8Array(await after.arrayBuffer())).toEqual(bytes);
+		});
+
+		it("promotes blobs referenced via putRecord", async () => {
+			const bytes = new Uint8Array([0x50, 0x55, 0x54, 0x52, 0x45, 0x43]);
+			const blob = await uploadBlob(bytes, "application/octet-stream");
+
+			const res = await worker.fetch(
+				new Request("http://pds.test/xrpc/com.atproto.repo.putRecord", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: `Bearer ${env.AUTH_TOKEN}`,
+					},
+					body: JSON.stringify({
+						repo: env.DID,
+						collection: "test.cirrus.blobRef",
+						rkey: "putrecord-blob",
+						record: { $type: "test.cirrus.blobRef", file: blob },
+					}),
+				}),
+				env,
+			);
+			expect(res.status).toBe(200);
+
+			const get = await worker.fetch(
+				new Request(
+					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${blob.ref.$link}`,
+				),
+				env,
+			);
+			expect(get.status).toBe(200);
+		});
+
+		it("promotes blobs referenced via applyWrites", async () => {
+			const bytes = new Uint8Array([0x41, 0x50, 0x50, 0x4c, 0x59, 0x57]);
+			const blob = await uploadBlob(bytes, "application/octet-stream");
+
+			const res = await worker.fetch(
+				new Request("http://pds.test/xrpc/com.atproto.repo.applyWrites", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: `Bearer ${env.AUTH_TOKEN}`,
+					},
+					body: JSON.stringify({
+						repo: env.DID,
+						writes: [
+							{
+								$type: "com.atproto.repo.applyWrites#create",
+								collection: "test.cirrus.blobRef",
+								value: { $type: "test.cirrus.blobRef", file: blob },
+							},
+						],
+					}),
+				}),
+				env,
+			);
+			expect(res.status).toBe(200);
+
+			const get = await worker.fetch(
+				new Request(
+					`http://pds.test/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${blob.ref.$link}`,
+				),
+				env,
+			);
+			expect(get.status).toBe(200);
+		});
+
+		it("excludes staged uploads from listBlobs", async () => {
+			const stagedBytes = new Uint8Array([0x4e, 0x4f, 0x4c, 0x49, 0x53, 0x54]);
+			const servedBytes = new Uint8Array([0x59, 0x45, 0x53, 0x4c, 0x49, 0x53]);
+			const stagedBlob = await uploadBlob(
+				stagedBytes,
+				"application/octet-stream",
+			);
+			const servedBlob = await uploadBlob(
+				servedBytes,
+				"application/octet-stream",
+			);
+			await referenceBlob(servedBlob);
+
+			const res = await worker.fetch(
+				new Request(
+					`http://pds.test/xrpc/com.atproto.sync.listBlobs?did=${env.DID}&limit=1000`,
+				),
+				env,
+			);
+			expect(res.status).toBe(200);
+			const data = (await res.json()) as { cids: string[] };
+			expect(data.cids).toContain(servedBlob.ref.$link);
+			expect(data.cids).not.toContain(stagedBlob.ref.$link);
+		});
+	});
+
+	describe("extractJsonBlobCids", () => {
+		const ref = (cid: string) => ({
+			$type: "blob",
+			ref: { $link: cid },
+			mimeType: "image/png",
+			size: 1,
+		});
+
+		it("finds typed blob refs at any depth", () => {
+			const record = {
+				$type: "app.bsky.feed.post",
+				embed: {
+					$type: "app.bsky.embed.images",
+					images: [
+						{ image: ref("bafone"), alt: "" },
+						{ image: ref("baftwo"), alt: "" },
+					],
+				},
+			};
+			expect(extractJsonBlobCids(record).sort()).toEqual([
+				"bafone",
+				"baftwo",
+			]);
+		});
+
+		it("finds legacy untyped blob refs", () => {
+			const record = {
+				avatar: { cid: "baflegacy", mimeType: "image/jpeg" },
+			};
+			expect(extractJsonBlobCids(record)).toEqual(["baflegacy"]);
+		});
+
+		it("deduplicates repeated refs", () => {
+			const record = { a: ref("bafsame"), b: ref("bafsame") };
+			expect(extractJsonBlobCids(record)).toEqual(["bafsame"]);
+		});
+
+		it("returns nothing for records without blobs", () => {
+			expect(
+				extractJsonBlobCids({ $type: "app.bsky.feed.post", text: "hi" }),
+			).toEqual([]);
 		});
 	});
 });

--- a/packages/pds/vitest.config.ts
+++ b/packages/pds/vitest.config.ts
@@ -32,6 +32,9 @@ export default defineConfig({
 	},
 	test: {
 		globals: true,
+		// Several proxy tests hit the live AppView; its latency regularly
+		// pushes past vitest's 5s default and flakes CI.
+		testTimeout: 15000,
 		// Vitest 4: singleWorker is now maxWorkers: 1, isolate: false
 		maxWorkers: 1,
 		isolate: false,


### PR DESCRIPTION
Uploads now land at ${did}/staged/${cid} in R2 and are only copied to
the public serving key ${did}/${cid} when a record write references
them. This closes the gap where any blob was fetchable by CID via
sync.getBlob the moment it was uploaded, and lays the key-layout
groundwork for credential-gated space blobs.

- uploadBlob writes to staged/; promotion happens in the Worker before
  the DO commit is applied, so relays never see a 404 for a
  just-referenced blob
- rpcTrackBlob reports whether the CID is already referenced so
  migration uploads (records imported first) promote immediately
- sync.listBlobs lists with a delimiter so staged/ and future nested
  namespaces never leak into the public listing
- staged/ is expired by an R2 lifecycle rule (documented in the
  wrangler template)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>