### PR TITLE
feat(oauth-provider): parse and grant space: scopes behind a flag

### DIFF
--- a/packages/oauth-provider/package.json
+++ b/packages/oauth-provider/package.json
@@ -24,7 +24,7 @@
 		"@atcute/identity-resolver": "^1.1.3",
 		"@atcute/lexicon-resolver": "^0.1.6",
 		"@atcute/lexicons": "^1.2.6",
-		"@atproto/oauth-scopes": "^0.3.2",
+		"@atproto/oauth-scopes": "0.0.0-spaces-alpha-20260818163953",
 		"@atproto/oauth-types": "^0.6.3",
 		"@atproto/syntax": "^0.4.2",
 		"jose": "^6.1.3"

--- a/packages/oauth-provider/src/index.ts
+++ b/packages/oauth-provider/src/index.ts
@@ -89,15 +89,23 @@ export {
 	ScopePermissionsTransition,
 	ScopesSet,
 	expandScope,
+	finalizeSpaceScopes,
 	parseScope,
+	parseSpaceScope,
 	permissionsFor,
 } from "./scopes.js";
-export type { ParseScopeOptions } from "./scopes.js";
+export type {
+	FinalizeSpaceScopesOptions,
+	ParseScopeOptions,
+	SpacePermissionType,
+} from "./scopes.js";
+export type { SpaceScopeInfo } from "./ui.js";
 
 // Permission sets
 export { createAtcutePermissionSetResolver } from "./permission-sets.js";
 export type {
 	CreateAtcutePermissionSetResolverOptions,
 	LexiconPermissionSet,
+	LexiconSpace,
 	PermissionSetResolver,
 } from "./permission-sets.js";

--- a/packages/oauth-provider/src/par.ts
+++ b/packages/oauth-provider/src/par.ts
@@ -64,6 +64,7 @@ export class PARHandler {
 	private issuer: string;
 	private expiresIn: number;
 	private permissionSetResolver?: PermissionSetResolver;
+	private allowSpaceScopes: boolean;
 
 	/**
 	 * Create a PAR handler
@@ -85,12 +86,14 @@ export class PARHandler {
 		issuer: string,
 		expiresIn: number = DEFAULT_EXPIRES_IN,
 		permissionSetResolver?: PermissionSetResolver,
+		options?: { allowSpaceScopes?: boolean },
 	) {
 		this.storage = storage;
 		this.clientResolver = clientResolver;
 		this.issuer = issuer;
 		this.expiresIn = expiresIn;
 		this.permissionSetResolver = permissionSetResolver;
+		this.allowSpaceScopes = options?.allowSpaceScopes ?? false;
 	}
 
 	/**
@@ -187,7 +190,10 @@ export class PARHandler {
 		params.scope = scope;
 		const allowIncludes = !!this.permissionSetResolver;
 		try {
-			parseScope(scope, { allowIncludes });
+			parseScope(scope, {
+				allowIncludes,
+				allowSpaceScopes: this.allowSpaceScopes,
+			});
 			// Eagerly resolve every `include:<nsid>` against the lexicon so a
 			// nonexistent permission set fails fast with invalid_scope here
 			// rather than dead-ending at the consent UI. Matches reference

--- a/packages/oauth-provider/src/permission-sets.ts
+++ b/packages/oauth-provider/src/permission-sets.ts
@@ -23,6 +23,19 @@ import type { LexiconPermissionSet } from "@atproto/oauth-scopes";
 
 export type { LexiconPermissionSet };
 
+/**
+ * A lexicon space type declaration (`type: 'space'`), per the permissioned
+ * data proposal. Mirrors `@atproto/oauth-scopes`'s internal `LexiconSpace`
+ * type, which the alpha build does not re-export from its entry point.
+ */
+export type LexiconSpace = {
+	readonly type: "space";
+	readonly name: string;
+	readonly "name:lang"?: Readonly<Record<string, string>>;
+	readonly collections: readonly string[];
+	readonly description?: string;
+};
+
 export interface PermissionSetResolver {
 	/**
 	 * Resolve an NSID to its permission-set lexicon definition. Returns null
@@ -30,6 +43,14 @@ export interface PermissionSetResolver {
 	 * when resolution itself fails (network, signature, etc.).
 	 */
 	resolve(nsid: Nsid): Promise<LexiconPermissionSet | null>;
+	/**
+	 * Resolve an NSID to its lexicon space declaration (`type: 'space'`).
+	 * Returns null when the lexicon exists but is not a space declaration,
+	 * and throws when resolution itself fails. Used by the consent UI to
+	 * show a space type's human name, and at grant time to default a space
+	 * scope's write collections. Optional for backwards compatibility.
+	 */
+	resolveSpaceDeclaration?(nsid: Nsid): Promise<LexiconSpace | null>;
 }
 
 export interface CreateAtcutePermissionSetResolverOptions {
@@ -68,14 +89,23 @@ export function createAtcutePermissionSetResolver(
 		fetch: opts.fetch,
 	});
 
+	const resolveMain = async (nsid: Nsid) => {
+		const did = await authority.resolve(nsid);
+		const resolved = await schema.resolve(did, nsid);
+		return (resolved.schema as { defs?: Record<string, unknown> }).defs
+			?.main as { type?: string } | undefined;
+	};
+
 	return {
 		async resolve(nsid) {
-			const did = await authority.resolve(nsid);
-			const resolved = await schema.resolve(did, nsid);
-			const main = (resolved.schema as { defs?: Record<string, unknown> })
-				.defs?.main as { type?: string } | undefined;
+			const main = await resolveMain(nsid);
 			if (!main || main.type !== "permission-set") return null;
 			return main as unknown as LexiconPermissionSet;
+		},
+		async resolveSpaceDeclaration(nsid) {
+			const main = await resolveMain(nsid);
+			if (!main || main.type !== "space") return null;
+			return main as unknown as LexiconSpace;
 		},
 	};
 }

--- a/packages/oauth-provider/src/provider.ts
+++ b/packages/oauth-provider/src/provider.ts
@@ -28,7 +28,7 @@ import {
 	renderErrorPage,
 	getConsentUiCsp,
 } from "./ui.js";
-import type { PermissionSetBundle } from "./ui.js";
+import type { PermissionSetBundle, SpaceScopeInfo } from "./ui.js";
 import { IncludeScope } from "@atproto/oauth-scopes";
 import { authenticateClient, ClientAuthError } from "./client-auth.js";
 import {
@@ -36,7 +36,9 @@ import {
 	ScopeMissingError,
 	ScopeParseError,
 	expandScope,
+	finalizeSpaceScopes,
 	parseScope,
+	parseSpaceScope,
 	permissionsFor,
 } from "./scopes.js";
 import type { ScopePermissionsTransition } from "./scopes.js";
@@ -75,6 +77,12 @@ export interface OAuthProviderConfig {
 	 * are rejected with `invalid_scope`.
 	 */
 	permissionSetResolver?: PermissionSetResolver;
+	/**
+	 * Whether `space:` scopes are accepted (atproto spaces, alpha). When
+	 * false (default), any request carrying a `space:` scope fails at
+	 * authorization with `invalid_scope`.
+	 */
+	spacesEnabled?: boolean;
 }
 
 /**
@@ -167,6 +175,7 @@ export class ATProtoOAuthProvider {
 		challenge: string,
 	) => Promise<{ sub: string; handle: string } | null>;
 	private permissionSetResolver?: PermissionSetResolver;
+	private spacesEnabled: boolean;
 
 	/**
 	 * Resolve metadata for any `include:` scopes in the given scope string so
@@ -210,6 +219,82 @@ export class ATProtoOAuthProvider {
 		return bundles;
 	}
 
+	/**
+	 * Resolve display metadata for any `space:` scopes so the consent UI can
+	 * show the space type's human name and flag wildcards. Resolution
+	 * failures fall back to the raw NSID with a warning rather than blocking
+	 * consent — unlike permission sets, the scope's meaning is fully carried
+	 * by the scope string itself.
+	 */
+	private async resolveSpaceMetadata(
+		scope: string,
+	): Promise<SpaceScopeInfo[]> {
+		if (!this.spacesEnabled) return [];
+		const spaces: SpaceScopeInfo[] = [];
+		for (const token of scope.split(" ")) {
+			const perm = parseSpaceScope(token);
+			if (!perm) continue;
+			const info: SpaceScopeInfo = {
+				type: perm.type,
+				authority: perm.authority,
+			};
+			if (
+				perm.type !== "*" &&
+				this.permissionSetResolver?.resolveSpaceDeclaration
+			) {
+				try {
+					const decl =
+						await this.permissionSetResolver.resolveSpaceDeclaration(
+							perm.type as Parameters<
+								NonNullable<
+									PermissionSetResolver["resolveSpaceDeclaration"]
+								>
+							>[0],
+						);
+					if (decl?.name) {
+						info.name = decl.name;
+					} else {
+						info.error = "Space type declaration was not found";
+					}
+				} catch (e) {
+					info.error =
+						e instanceof Error ? e.message : "Resolution failed";
+				}
+			}
+			spaces.push(info);
+		}
+		return spaces;
+	}
+
+	/**
+	 * Rewrite the scope string into its stored (grant) form: resolve
+	 * `authority=self` on space scopes to the authenticated user's DID and
+	 * default their write collections from the space type declaration. No-op
+	 * when spaces are disabled (space scopes were already rejected).
+	 */
+	private async finalizeScopeForGrant(
+		scope: string,
+		userDid: string,
+	): Promise<string> {
+		if (!this.spacesEnabled) return scope;
+		const resolver = this.permissionSetResolver;
+		return finalizeSpaceScopes(scope, {
+			userDid,
+			resolveSpaceCollections: resolver?.resolveSpaceDeclaration
+				? async (nsid) => {
+						const decl = await resolver.resolveSpaceDeclaration!(
+							nsid as Parameters<
+								NonNullable<
+									PermissionSetResolver["resolveSpaceDeclaration"]
+								>
+							>[0],
+						);
+						return decl?.collections ?? null;
+					}
+				: undefined,
+		});
+	}
+
 	constructor(config: OAuthProviderConfig) {
 		this.storage = config.storage;
 		this.issuer = config.issuer;
@@ -217,12 +302,14 @@ export class ATProtoOAuthProvider {
 		this.enablePAR = config.enablePAR ?? true;
 		this.clientResolver =
 			config.clientResolver ?? new ClientResolver({ storage: config.storage });
+		this.spacesEnabled = config.spacesEnabled ?? false;
 		this.parHandler = new PARHandler(
 			config.storage,
 			this.clientResolver,
 			config.issuer,
 			undefined,
 			config.permissionSetResolver,
+			{ allowSpaceScopes: this.spacesEnabled },
 		);
 		this.verifyUser = config.verifyUser;
 		this.getCurrentUser = config.getCurrentUser;
@@ -382,8 +469,9 @@ export class ATProtoOAuthProvider {
 		const scope = params.scope ?? ATPROTO_SCOPE;
 		params.scope = scope;
 		const allowIncludes = !!this.permissionSetResolver;
+		const allowSpaceScopes = this.spacesEnabled;
 		try {
-			parseScope(scope, { allowIncludes });
+			parseScope(scope, { allowIncludes, allowSpaceScopes });
 		} catch (e) {
 			if (e instanceof ScopeParseError) {
 				return await this.renderError("invalid_scope", e.message);
@@ -410,6 +498,7 @@ export class ATProtoOAuthProvider {
 
 		const passkeyAvailable = !user && !!passkeyOptions;
 		const bundles = await this.resolveBundleMetadata(scope);
+		const spaces = await this.resolveSpaceMetadata(scope);
 		const html = renderConsentUI({
 			client,
 			scope,
@@ -421,6 +510,7 @@ export class ATProtoOAuthProvider {
 			passkeyAvailable,
 			passkeyOptions: passkeyOptions ?? undefined,
 			bundles,
+			spaces,
 		});
 
 		const csp = await getConsentUiCsp(passkeyAvailable);
@@ -529,7 +619,7 @@ export class ATProtoOAuthProvider {
 		) {
 			try {
 				scope = await expandScope(requestedScope, this.permissionSetResolver);
-				parseScope(scope);
+				parseScope(scope, { allowSpaceScopes: this.spacesEnabled });
 			} catch (e) {
 				if (e instanceof ScopeParseError) {
 					const errorUrl = new URL(redirectUri);
@@ -551,6 +641,7 @@ export class ATProtoOAuthProvider {
 				throw e;
 			}
 		}
+		scope = await this.finalizeScopeForGrant(scope, user.sub);
 		const code = generateAuthCode();
 
 		const authCodeData: AuthCodeData = {
@@ -1123,10 +1214,13 @@ export class ATProtoOAuthProvider {
 		const allowIncludes = !!this.permissionSetResolver;
 		let scope = requestedScope;
 		try {
-			parseScope(requestedScope, { allowIncludes });
+			parseScope(requestedScope, {
+				allowIncludes,
+				allowSpaceScopes: this.spacesEnabled,
+			});
 			if (allowIncludes && requestedScope.includes("include:")) {
 				scope = await expandScope(requestedScope, this.permissionSetResolver);
-				parseScope(scope);
+				parseScope(scope, { allowSpaceScopes: this.spacesEnabled });
 			}
 		} catch (e) {
 			if (e instanceof ScopeParseError) {
@@ -1137,6 +1231,8 @@ export class ATProtoOAuthProvider {
 			}
 			throw e;
 		}
+
+		scope = await this.finalizeScopeForGrant(scope, user.sub);
 
 		const authCodeData: AuthCodeData = {
 			clientId: oauthParams.client_id!,

--- a/packages/oauth-provider/src/scopes.ts
+++ b/packages/oauth-provider/src/scopes.ts
@@ -20,9 +20,24 @@ import {
 	ScopePermissionsTransition,
 	ScopesSet,
 } from "@atproto/oauth-scopes";
+import * as oauthScopes from "@atproto/oauth-scopes";
 import type { PermissionSetResolver } from "./permission-sets.js";
 
 export { IncludeScope, ScopeMissingError, ScopePermissionsTransition, ScopesSet };
+
+/**
+ * `SpacePermission` is only present in the `spaces-alpha` builds of
+ * `@atproto/oauth-scopes`. Accessed via the namespace so a build without it
+ * rejects `space:` scopes outright instead of accepting an approximation.
+ */
+const SpacePermission = (
+	oauthScopes as {
+		SpacePermission?: typeof import("@atproto/oauth-scopes").SpacePermission;
+	}
+).SpacePermission;
+
+export type SpacePermissionType =
+	import("@atproto/oauth-scopes").SpacePermission;
 
 /**
  * Resources known to the spec. Used in OAuth metadata advertisement and to
@@ -34,6 +49,7 @@ export const GRANULAR_RESOURCES = [
 	"blob",
 	"account",
 	"identity",
+	"space",
 ] as const;
 
 /**
@@ -73,6 +89,7 @@ const STRUCTURAL_PARSERS: Record<
 	blob: (s) => BlobPermission.fromString(s),
 	account: (s) => AccountPermission.fromString(s),
 	identity: (s) => IdentityPermission.fromString(s),
+	space: (s) => (SpacePermission ? SpacePermission.fromString(s) : null),
 };
 
 export interface ParseScopeOptions {
@@ -87,6 +104,12 @@ export interface ParseScopeOptions {
 	 * stored token's scope).
 	 */
 	allowIncludes?: boolean;
+	/**
+	 * When true, `space:` scopes are accepted (structurally validated with
+	 * `SpacePermission`). When false (default), any `space:` scope throws a
+	 * ScopeParseError — the host has not enabled atproto spaces.
+	 */
+	allowSpaceScopes?: boolean;
 }
 
 /**
@@ -95,7 +118,7 @@ export interface ParseScopeOptions {
  */
 export function parseScope(
 	input: string | undefined | null,
-	{ allowIncludes = false }: ParseScopeOptions = {},
+	{ allowIncludes = false, allowSpaceScopes = false }: ParseScopeOptions = {},
 ): ScopesSet {
 	const set = ScopesSet.fromString(input ?? "");
 
@@ -128,6 +151,12 @@ export function parseScope(
 		const end =
 			colon === -1 ? question : question === -1 ? colon : Math.min(colon, question);
 		const resource = end === -1 ? scope : scope.slice(0, end);
+		if (resource === "space" && !allowSpaceScopes) {
+			throw new ScopeParseError(
+				`Space scopes are not enabled on this server: ${scope}`,
+				scope,
+			);
+		}
 		const parser =
 			STRUCTURAL_PARSERS[
 				resource as (typeof GRANULAR_RESOURCES)[number]
@@ -204,6 +233,96 @@ export async function expandScope(
 	}
 
 	return Array.from(out).join(" ");
+}
+
+/**
+ * Parse a scope token as a space permission. Returns null for non-space
+ * tokens, malformed space scopes, or builds of `@atproto/oauth-scopes`
+ * without `SpacePermission`.
+ */
+export function parseSpaceScope(token: string): SpacePermissionType | null {
+	if (
+		token !== "space" &&
+		!token.startsWith("space:") &&
+		!token.startsWith("space?")
+	) {
+		return null;
+	}
+	return SpacePermission ? SpacePermission.fromString(token) : null;
+}
+
+export interface FinalizeSpaceScopesOptions {
+	/** The authenticated user's DID; replaces `authority=self`. */
+	userDid: string;
+	/**
+	 * Resolve a space type NSID to its lexicon space declaration's
+	 * `collections` list, used as the default write collections when the
+	 * grant names none. Absent or failing resolution leaves the scope
+	 * without default collections (reads unaffected, writes constrained to
+	 * the explicitly requested collections).
+	 */
+	resolveSpaceCollections?: (
+		nsid: string,
+	) => Promise<readonly string[] | null>;
+}
+
+/**
+ * Rewrite the `space:` tokens of an expanded scope string into their stored
+ * form, per the proposal's grant-time requirements:
+ *
+ * - `authority=self` is resolved to the authenticated user's DID, so a
+ *   stored grant never contains `self`.
+ * - A grant with no explicit collections inherits the space type
+ *   declaration's `collections` as its default write set.
+ *
+ * Call at code-issuance time, after `include:` expansion and before the
+ * scope is stored.
+ */
+export async function finalizeSpaceScopes(
+	scope: string,
+	{ userDid, resolveSpaceCollections }: FinalizeSpaceScopesOptions,
+): Promise<string> {
+	const tokens = scope.split(" ").filter(Boolean);
+	const out: string[] = [];
+
+	for (const token of tokens) {
+		let perm = parseSpaceScope(token);
+		if (!perm) {
+			out.push(token);
+			continue;
+		}
+
+		if (perm.isSelfAuthority) {
+			perm = perm.withResolvedAuthority(
+				userDid as `did:${string}:${string}`,
+			);
+		}
+
+		if (
+			!perm.hasCollections &&
+			perm.type !== "*" &&
+			resolveSpaceCollections
+		) {
+			try {
+				const collections = await resolveSpaceCollections(perm.type);
+				if (collections && collections.length > 0) {
+					perm = perm.withDefaultCollections(
+						collections as readonly (
+							| "*"
+							| `${string}.${string}.${string}`
+						)[],
+					);
+				}
+			} catch {
+				// Leave the scope without default collections; the grant still
+				// covers reads and any explicitly requested collections.
+			}
+		}
+
+		out.push(perm.toString());
+	}
+
+	return out.join(" ");
 }
 
 /**

--- a/packages/oauth-provider/src/ui.ts
+++ b/packages/oauth-provider/src/ui.ts
@@ -12,7 +12,8 @@ import {
 	RpcPermission,
 } from "@atproto/oauth-scopes";
 import type { ClientMetadata } from "./storage.js";
-import { ATPROTO_SCOPE, ScopesSet } from "./scopes.js";
+import { ATPROTO_SCOPE, ScopesSet, parseSpaceScope } from "./scopes.js";
+import type { SpacePermissionType } from "./scopes.js";
 
 /**
  * The passkey authentication script (static, can be hashed).
@@ -222,6 +223,23 @@ export interface PermissionSetBundle {
 }
 
 /**
+ * Display metadata for a `space:` scope in the consent UI. The space type's
+ * lexicon declaration supplies the human `name`; a failed resolution falls
+ * back to the raw NSID with a warning (unlike permission-set bundles, the
+ * scope string itself fully describes the grant, so consent stays possible).
+ */
+export interface SpaceScopeInfo {
+	/** The space type NSID, or `*` for a wildcard grant. */
+	type: string;
+	/** The authority parameter: `self`, a DID, or `*`. */
+	authority: string;
+	/** Human-readable name from the space type's lexicon declaration. */
+	name?: string;
+	/** Set when the space type declaration could not be resolved. */
+	error?: string;
+}
+
+/**
  * A consent-UI permission line. Either a single string or a "summary +
  * collapsible items" pair. The latter renders as a `<details>` disclosure so
  * apps requesting many granular scopes (e.g. tangled.org with 21 `repo:` and
@@ -266,9 +284,66 @@ function commonNsidPrefix(nsids: readonly string[]): string | null {
  * `bundles`, when supplied, lets us render `include:` scopes as the bundle's
  * human title rather than just its NSID.
  */
+/**
+ * Describe one `space:` permission for the consent UI. Wildcards on the
+ * space type or authority get a prominent warning per the proposal, and an
+ * unresolved space type falls back to the raw NSID with a warning.
+ */
+function describeSpaceScope(
+	p: SpacePermissionType,
+	info: SpaceScopeInfo | undefined,
+): string[] {
+	const out: string[] = [];
+
+	const typeLabel =
+		p.type === "*"
+			? "spaces of ANY type"
+			: info?.name
+				? `"${info.name}" spaces (${p.type})`
+				: `${p.type} spaces`;
+
+	const authorityLabel =
+		p.authority === "self"
+			? "your own"
+			: p.authority === "*"
+				? "ANY account's"
+				: `${p.authority}'s`;
+
+	const canRead = p.action.includes("read") || p.action.includes("read_self");
+	const canWrite =
+		p.action.includes("create") ||
+		p.action.includes("update") ||
+		p.action.includes("delete");
+	const verb =
+		canRead && canWrite ? "Read and write" : canWrite ? "Write" : "Read";
+	const skeySuffix = p.skey === "*" ? "" : ` (space "${p.skey}")`;
+
+	let line = `${verb} private data in ${authorityLabel} ${typeLabel}${skeySuffix}`;
+	if (p.type === "*" || p.authority === "*") {
+		line = `⚠️ ${line}`;
+	}
+	out.push(line);
+
+	if (p.manage.length > 0) {
+		const ops = p.manage.join(", ");
+		out.push(
+			`Manage (${ops}) ${authorityLabel} ${typeLabel}, including membership`,
+		);
+	}
+
+	if (info?.error) {
+		out.push(
+			`⚠️ ${p.type} — could not resolve space type declaration: ${info.error}`,
+		);
+	}
+
+	return out;
+}
+
 function getScopeDescriptions(
 	scope: string,
 	bundles?: readonly PermissionSetBundle[],
+	spaces?: readonly SpaceScopeInfo[],
 ): ScopeDescription[] {
 	const set = ScopesSet.fromString(scope);
 	const out: ScopeDescription[] = [];
@@ -293,8 +368,16 @@ function getScopeDescriptions(
 	const accounts: AccountPermission[] = [];
 	const identities: IdentityPermission[] = [];
 	const includes: IncludeScope[] = [];
+	const spacePerms: SpacePermissionType[] = [];
 
 	for (const s of set) {
+		// Space scopes may use the `space?type=...` form with no colon, so
+		// they get a dedicated parse ahead of the colon-keyed dispatch.
+		const spacePerm = parseSpaceScope(s);
+		if (spacePerm) {
+			spacePerms.push(spacePerm);
+			continue;
+		}
 		const colon = s.indexOf(":");
 		if (colon === -1) continue;
 		const resource = s.slice(0, colon);
@@ -409,6 +492,12 @@ function getScopeDescriptions(
 	for (const p of identities) {
 		out.push(`Manage your ${p.attr === "*" ? "identity" : p.attr}`);
 	}
+	for (const p of spacePerms) {
+		const info = spaces?.find(
+			(s) => s.type === p.type && s.authority === p.authority,
+		);
+		out.push(...describeSpaceScope(p, info));
+	}
 	for (const inc of includes) {
 		const bundle = bundles?.find((b) => b.nsid === inc.nsid);
 		if (bundle?.error) {
@@ -461,6 +550,12 @@ export interface ConsentUIOptions {
 	 * instead of the bare NSID.
 	 */
 	bundles?: readonly PermissionSetBundle[];
+	/**
+	 * Resolved display metadata for any `space:` scopes in the request. The
+	 * consent UI uses this to show the space type's human name; a failed
+	 * resolution falls back to the raw NSID with a warning.
+	 */
+	spaces?: readonly SpaceScopeInfo[];
 }
 
 /**
@@ -482,7 +577,11 @@ export function renderConsentUI(options: ConsentUIOptions): string {
 	} = options;
 
 	const clientName = escapeHtml(client.clientName);
-	const scopeDescriptions = getScopeDescriptions(scope, options.bundles);
+	const scopeDescriptions = getScopeDescriptions(
+		scope,
+		options.bundles,
+		options.spaces,
+	);
 	const hasResolutionFailure = !!options.bundles?.some((b) => b.error);
 	const logoHtml = client.logoUri
 		? `<img src="${escapeHtml(client.logoUri)}" alt="${clientName} logo" class="app-logo" />`

--- a/packages/oauth-provider/test/space-scopes.test.ts
+++ b/packages/oauth-provider/test/space-scopes.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import {
+	ScopeParseError,
+	finalizeSpaceScopes,
+	parseScope,
+	parseSpaceScope,
+	permissionsFor,
+} from "../src/scopes.js";
+
+describe("parseScope with space scopes", () => {
+	it("rejects space scopes by default", () => {
+		expect(() => parseScope("atproto space:app.bsky.group")).toThrow(
+			ScopeParseError,
+		);
+		expect(() => parseScope("atproto space:app.bsky.group")).toThrow(
+			/not enabled/,
+		);
+	});
+
+	it("rejects the named-param space form by default too", () => {
+		expect(() =>
+			parseScope("atproto space?type=app.bsky.group"),
+		).toThrow(/not enabled/);
+	});
+
+	it("accepts valid space scopes when enabled", () => {
+		const set = parseScope("atproto space:app.bsky.group", {
+			allowSpaceScopes: true,
+		});
+		expect(set.has("space:app.bsky.group")).toBe(true);
+	});
+
+	it("accepts parameterised space scopes when enabled", () => {
+		const set = parseScope(
+			"atproto space:app.bsky.group?authority=did:plc:abc123&skey=3kbcq3p7ad400",
+			{ allowSpaceScopes: true },
+		);
+		expect(set.size).toBe(2);
+	});
+
+	it("rejects malformed space scopes even when enabled", () => {
+		// Positional type is required
+		expect(() => parseScope("atproto space", { allowSpaceScopes: true })).toThrow(
+			ScopeParseError,
+		);
+		expect(() =>
+			parseScope("atproto space:app.bsky.group?bogus=1", {
+				allowSpaceScopes: true,
+			}),
+		).toThrow(ScopeParseError);
+	});
+});
+
+describe("parseSpaceScope", () => {
+	it("parses positional and named-param forms", () => {
+		expect(parseSpaceScope("space:app.bsky.group")?.type).toBe(
+			"app.bsky.group",
+		);
+		expect(parseSpaceScope("space?type=app.bsky.group")?.type).toBe(
+			"app.bsky.group",
+		);
+	});
+
+	it("returns null for non-space tokens", () => {
+		expect(parseSpaceScope("repo:app.bsky.feed.post")).toBeNull();
+		expect(parseSpaceScope("spaces:nope")).toBeNull();
+	});
+});
+
+describe("finalizeSpaceScopes", () => {
+	const did = "did:web:alice.test";
+
+	it("resolves authority=self to the user's DID", async () => {
+		const scope = await finalizeSpaceScopes("atproto space:app.bsky.group", {
+			userDid: did,
+		});
+		expect(scope).toContain(`authority=${did}`);
+		expect(scope).not.toContain("self");
+	});
+
+	it("leaves explicit authorities untouched", async () => {
+		const input =
+			"atproto space:app.bsky.group?authority=did:plc:abc123";
+		const scope = await finalizeSpaceScopes(input, { userDid: did });
+		expect(scope).toContain("authority=did:plc:abc123");
+		expect(scope).not.toContain(did);
+	});
+
+	it("does not touch non-space scopes", async () => {
+		const input = "atproto repo:app.bsky.feed.post blob:image/*";
+		expect(await finalizeSpaceScopes(input, { userDid: did })).toBe(input);
+	});
+
+	it("applies default collections from the space type declaration", async () => {
+		const scope = await finalizeSpaceScopes("atproto space:app.bsky.group", {
+			userDid: did,
+			resolveSpaceCollections: async (nsid) => {
+				expect(nsid).toBe("app.bsky.group");
+				return ["app.bsky.feed.post", "app.bsky.feed.like"];
+			},
+		});
+		expect(scope).toContain("collection=app.bsky.feed.like");
+		expect(scope).toContain("collection=app.bsky.feed.post");
+	});
+
+	it("keeps explicitly requested collections instead of defaults", async () => {
+		const scope = await finalizeSpaceScopes(
+			"atproto space:app.bsky.group?collection=app.bsky.feed.post",
+			{
+				userDid: did,
+				resolveSpaceCollections: async () => ["some.other.collection"],
+			},
+		);
+		expect(scope).toContain("collection=app.bsky.feed.post");
+		expect(scope).not.toContain("some.other.collection");
+	});
+
+	it("survives a failing collection resolver", async () => {
+		const scope = await finalizeSpaceScopes("atproto space:app.bsky.group", {
+			userDid: did,
+			resolveSpaceCollections: async () => {
+				throw new Error("network down");
+			},
+		});
+		expect(scope).toContain(`authority=${did}`);
+	});
+});
+
+describe("space permission checks", () => {
+	it("grants match after self-resolution", async () => {
+		const did = "did:web:alice.test";
+		const stored = await finalizeSpaceScopes(
+			"atproto space:app.bsky.group",
+			{
+				userDid: did,
+				resolveSpaceCollections: async () => ["app.bsky.feed.post"],
+			},
+		);
+		const perms = permissionsFor(stored);
+		expect(
+			perms.allowsSpace({
+				type: "app.bsky.group",
+				authority: did,
+				skey: "3kbcq3p7ad400",
+				action: "read",
+			}),
+		).toBe(true);
+		expect(
+			perms.allowsSpace({
+				type: "app.bsky.group",
+				authority: did,
+				skey: "3kbcq3p7ad400",
+				action: "create",
+				collection: "app.bsky.feed.post",
+			}),
+		).toBe(true);
+		expect(
+			perms.allowsSpace({
+				type: "app.bsky.group",
+				authority: did,
+				skey: "3kbcq3p7ad400",
+				action: "create",
+				collection: "app.bsky.other.collection",
+			}),
+		).toBe(false);
+		expect(
+			perms.allowsSpace({
+				type: "app.bsky.group",
+				authority: "did:plc:someoneelse",
+				skey: "3kbcq3p7ad400",
+				action: "read",
+			}),
+		).toBe(false);
+	});
+
+	it("transition:generic grants nothing on spaces", () => {
+		const perms = permissionsFor("atproto transition:generic");
+		expect(
+			perms.allowsSpace({
+				type: "app.bsky.group",
+				authority: "did:web:alice.test",
+				skey: "*",
+				action: "read",
+			}),
+		).toBe(false);
+	});
+
+	it("manage ops gate on the manage axis", async () => {
+		const did = "did:web:alice.test";
+		const stored = await finalizeSpaceScopes(
+			"atproto space:app.bsky.group?manage=create&manage=delete",
+			{ userDid: did },
+		);
+		const perms = permissionsFor(stored);
+		expect(
+			perms.allowsSpace({
+				type: "app.bsky.group",
+				authority: did,
+				skey: "*",
+				manage: "create",
+			}),
+		).toBe(true);
+		expect(
+			perms.allowsSpace({
+				type: "app.bsky.group",
+				authority: did,
+				skey: "*",
+				manage: "update",
+			}),
+		).toBe(false);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
         specifier: ^1.2.6
         version: 1.3.0
       '@atproto/oauth-scopes':
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: 0.0.0-spaces-alpha-20260818163953
+        version: 0.0.0-spaces-alpha-20260818163953
       '@atproto/oauth-types':
         specifier: ^0.6.3
         version: 0.6.3
@@ -524,6 +524,10 @@ packages:
   '@atproto/did@0.3.0':
     resolution: {integrity: sha512-raUPzUGegtW/6OxwCmM8bhZvuIMzxG5t9oWsth6Tp91Kb5fTnHV2h/KKNF1C82doeA4BdXCErTyg7ISwLbQkzA==}
 
+  '@atproto/did@0.5.4':
+    resolution: {integrity: sha512-BlnwQ+obL+4ZA71KH/EzZ3TY+cpSxnLiUI85mjBJIQwvDF/oN2sQA18wIj9jpduviIt2b/cMtlJuzHjzBkfXvw==}
+    engines: {node: '>=22'}
+
   '@atproto/jwk@0.6.0':
     resolution: {integrity: sha512-bDoJPvt7TrQVi/rBfBrSSpGykhtIriKxeYCYQTiPRKFfyRhbgpElF0wPXADjIswnbzZdOwbY63az4E/CFVT3Tw==}
 
@@ -545,8 +549,9 @@ packages:
   '@atproto/lexicon@0.6.1':
     resolution: {integrity: sha512-/vI1kVlY50Si+5MXpvOucelnYwb0UJ6Qto5mCp+7Q5C+Jtp+SoSykAPVvjVtTnQUH2vrKOFOwpb3C375vSKzXw==}
 
-  '@atproto/oauth-scopes@0.3.2':
-    resolution: {integrity: sha512-88awgvB9asSR86KjEXL31N9nFd1XG+QtbzEJFw5/wwEv41tS4S8c4Prqb/MAzVuFQ4OHOndYo1VDD99vGMpqTA==}
+  '@atproto/oauth-scopes@0.0.0-spaces-alpha-20260818163953':
+    resolution: {integrity: sha512-bQz4BwNk/FAPd8bXGO3EyhlIKu/UJzN5XIgmNeiZXtJbhbe30J78A3WnvBuA+SILiGFw7/M9hfgq9FcJKCzjCw==}
+    engines: {node: '>=22'}
 
   '@atproto/oauth-types@0.6.3':
     resolution: {integrity: sha512-jdKuoPknJuh/WjI+mYk7agSbx9mNVMbS6Dr3k1z2YMY2oRiCQjxYBuo4MLKATbxj05nMQaZRWlHRUazoAu5Cng==}
@@ -555,14 +560,15 @@ packages:
     resolution: {integrity: sha512-QpVTVulgfz5PUiCTELlDBiRvnsnwrFWi+6CfY88VwXzrRHd9NE8GItK7sfxQ6U65vD/idH8ddCgFrlrsn1REPQ==}
     engines: {node: '>=18.7.0'}
 
+  '@atproto/syntax@0.0.0-spaces-alpha-20260818163953':
+    resolution: {integrity: sha512-Xl2fpD/NcfVOWpHR86HKym2XNDYHmgiqThZXoYMwh9XUo+/LgVZYGVpSecfKRBcQ5tNGiRivE1Fvio5YDfJ3lA==}
+    engines: {node: '>=22'}
+
   '@atproto/syntax@0.4.2':
     resolution: {integrity: sha512-X9XSRPinBy/0VQ677j8VXlBsYSsUXaiqxWVpGGxJYsAhugdQRb0jqaVKJFtm6RskeNkV6y9xclSUi9UYG/COrA==}
 
   '@atproto/syntax@0.4.3':
     resolution: {integrity: sha512-YoZUz40YAJr5nPwvCDWgodEOlt5IftZqPJvA0JDWjuZKD8yXddTwSzXSaKQAzGOpuM+/A3uXRtPzJJqlScc+iA==}
-
-  '@atproto/syntax@0.5.4':
-    resolution: {integrity: sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==}
 
   '@atproto/xrpc@0.7.7':
     resolution: {integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==}
@@ -5031,6 +5037,10 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  '@atproto/did@0.5.4':
+    dependencies:
+      zod: 3.25.76
+
   '@atproto/jwk@0.6.0':
     dependencies:
       multiformats: 9.9.0
@@ -5075,10 +5085,10 @@ snapshots:
       multiformats: 9.9.0
       zod: 3.25.76
 
-  '@atproto/oauth-scopes@0.3.2':
+  '@atproto/oauth-scopes@0.0.0-spaces-alpha-20260818163953':
     dependencies:
-      '@atproto/did': 0.3.0
-      '@atproto/syntax': 0.5.4
+      '@atproto/did': 0.5.4
+      '@atproto/syntax': 0.0.0-spaces-alpha-20260818163953
 
   '@atproto/oauth-types@0.6.3':
     dependencies:
@@ -5098,13 +5108,14 @@ snapshots:
       varint: 6.0.0
       zod: 3.25.76
 
+  '@atproto/syntax@0.0.0-spaces-alpha-20260818163953':
+    dependencies:
+      iso-datestring-validator: 2.2.2
+      tslib: 2.8.1
+
   '@atproto/syntax@0.4.2': {}
 
   '@atproto/syntax@0.4.3':
-    dependencies:
-      tslib: 2.8.1
-
-  '@atproto/syntax@0.5.4':
     dependencies:
       tslib: 2.8.1
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,15 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["github>unjs/renovate-config", ":widenPeerDependencies"],
-	"packageRules": []
+	"packageRules": [
+		{
+			"description": "Spaces-alpha packages are pinned to exact alpha builds and re-verified manually against each upstream build before bumping",
+			"matchPackageNames": [
+				"@atproto/oauth-scopes",
+				"@atproto/space",
+				"@atproto/syntax"
+			],
+			"enabled": false
+		}
+	]
 }


### PR DESCRIPTION
Adds the space resource from @atproto/oauth-scopes@alpha (pinned exact,
excluded from Renovate):

- space added to GRANULAR_RESOURCES, parsed with SpacePermission via a
  namespace import so an alpha build without the export rejects space:
  scopes outright instead of approximating
- new spacesEnabled provider option; when off (default), space: scopes
  fail at PAR and authorize with invalid_scope
- authority=self is resolved to the authenticated DID at grant time and
  default write collections are taken from the space type declaration,
  so stored grants never contain self
- consent screen resolves the space type NSID to its lexicon declaration
  and shows its name, falling back to the raw NSID with a warning;
  wildcard type/authority get a prominent warning
- PermissionSetResolver gains optional resolveSpaceDeclaration, wired
  into the existing atcute lexicon resolver

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>