### PR TITLE
feat(spaces): add @getcirrus/spaces engine package

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,10 @@
 			"ignore": ["scripts/**", "test/fixtures/**", "e2e/fixture/**"],
 			"ignoreDependencies": ["tsx", "vite", "@cloudflare/vite-plugin"]
 		},
+		"packages/spaces": {
+			"ignore": ["test/fixtures/**"],
+			"ignoreDependencies": ["wrangler"]
+		},
 		"packages/create-pds": {
 			"ignore": ["templates/**"]
 		}

--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -1,0 +1,55 @@
+{
+	"name": "@getcirrus/spaces",
+	"version": "0.1.0",
+	"description": "Atproto spaces engine (alpha) for Cloudflare Workers \u2013 permissioned repos, space hosting and credentials",
+	"type": "module",
+	"main": "dist/index.js",
+	"files": [
+		"dist"
+	],
+	"exports": {
+		".": "./dist/index.js"
+	},
+	"scripts": {
+		"build": "tsdown",
+		"dev": "tsdown --watch",
+		"test": "vitest run",
+		"check": "publint && attw --pack --ignore-rules=cjs-resolves-to-esm"
+	},
+	"dependencies": {
+		"@atcute/cid": "^2.3.0",
+		"@atproto/crypto": "^0.4.5",
+		"@atproto/lex-cbor": "^0.1.6",
+		"@atproto/lex-data": "^0.1.7",
+		"@atproto/lex-json": "^0.0.11",
+		"@atproto/space": "0.0.0-spaces-alpha-20260818163953",
+		"@atcute/tid": "^1.1.1",
+		"hono": "^4.11.3",
+		"@atcute/lexicons": "^1.2.6"
+	},
+	"devDependencies": {
+		"@arethetypeswrong/cli": "^0.18.2",
+		"@cloudflare/vitest-pool-workers": "^0.16.9",
+		"@cloudflare/workers-types": "^4.20260524.1",
+		"@atproto/jwk-jose": "^0.2.1",
+		"publint": "^0.3.16",
+		"tsdown": "^0.18.3",
+		"typescript": "^5.9.3",
+		"vitest": "4.1.0-beta.1",
+		"wrangler": "^4.93.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/ascorbic/cirrus.git",
+		"directory": "packages/spaces"
+	},
+	"homepage": "https://github.com/ascorbic/cirrus",
+	"keywords": [
+		"atproto",
+		"spaces",
+		"permissioned-data",
+		"cloudflare-workers"
+	],
+	"author": "Matt Kane",
+	"license": "MIT"
+}

--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -17,21 +17,16 @@
 		"check": "publint && attw --pack --ignore-rules=cjs-resolves-to-esm"
 	},
 	"dependencies": {
-		"@atcute/cid": "^2.3.0",
 		"@atproto/crypto": "^0.4.5",
 		"@atproto/lex-cbor": "^0.1.6",
-		"@atproto/lex-data": "^0.1.7",
-		"@atproto/lex-json": "^0.0.11",
 		"@atproto/space": "0.0.0-spaces-alpha-20260818163953",
 		"@atcute/tid": "^1.1.1",
-		"hono": "^4.11.3",
 		"@atcute/lexicons": "^1.2.6"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.18.2",
 		"@cloudflare/vitest-pool-workers": "^0.16.9",
 		"@cloudflare/workers-types": "^4.20260524.1",
-		"@atproto/jwk-jose": "^0.2.1",
 		"publint": "^0.3.16",
 		"tsdown": "^0.18.3",
 		"typescript": "^5.9.3",

--- a/packages/spaces/src/blob-keys.ts
+++ b/packages/spaces/src/blob-keys.ts
@@ -1,0 +1,35 @@
+/**
+ * R2 key layout for space blobs.
+ *
+ * A blob referenced by a record in a space lives at
+ * `${did}/space/${spaceId}/${cid}` and is served only by the
+ * credential-gated `com.atproto.space.getBlob`. The same blob referenced
+ * from two spaces is stored twice: per-space prefixes make space deletion
+ * and full reset a prefix delete with no cross-space reference counting.
+ */
+
+import { spaceId } from "./space-uri.js";
+
+/** Prefix holding every space blob for the account. */
+export function spaceBlobRootPrefix(did: string): string {
+	return `${did}/space/`;
+}
+
+/** Prefix holding one space's blobs. `id` comes from {@link spaceId}. */
+export function spaceBlobPrefix(did: string, id: string): string {
+	return `${did}/space/${id}/`;
+}
+
+/** Key for one blob in one space. */
+export function spaceBlobKey(did: string, id: string, cid: string): string {
+	return `${did}/space/${id}/${cid}`;
+}
+
+/** Convenience: key for a blob given the space URI rather than its id. */
+export async function spaceBlobKeyForUri(
+	did: string,
+	spaceUri: string,
+	cid: string,
+): Promise<string> {
+	return spaceBlobKey(did, await spaceId(spaceUri), cid);
+}

--- a/packages/spaces/src/errors.ts
+++ b/packages/spaces/src/errors.ts
@@ -1,0 +1,105 @@
+/**
+ * Typed errors for the spaces engine.
+ *
+ * Durable Object RPC flattens thrown errors into a wrapper `Error` whose
+ * message is `"${name}: ${message}"`, so every error here encodes its
+ * protocol error name as a message prefix. Worker-side handlers recover the
+ * name with {@link parseSpaceErrorCode} and map it onto the lexicon error
+ * shape.
+ */
+
+/** Protocol error names used across space and simplespace endpoints. */
+export const SPACE_ERROR_CODES = [
+	"SpaceNotFound",
+	"SpaceDeleted",
+	"SpaceAlreadyExists",
+	"RepoNotFound",
+	"RecordNotFound",
+	"RecordAlreadyExists",
+	"BlobNotFound",
+	"UserNotAuthorized",
+	"AppNotAuthorized",
+	"NotAuthorized",
+	"InvalidDelegationToken",
+	"InvalidClientAttestation",
+	"InvalidCredential",
+	"NotSpaceOwner",
+	"UnsupportedPolicy",
+	"UnsupportedAppAccess",
+	"ServiceNotResolvable",
+	"MalformedCursor",
+	"InvalidSpaceUri",
+	"InvalidRequest",
+	"SpacesSchemaOutdated",
+] as const;
+
+export type SpaceErrorCode = (typeof SPACE_ERROR_CODES)[number];
+
+const CODE_SET: ReadonlySet<string> = new Set(SPACE_ERROR_CODES);
+
+/** HTTP status for each error name when it isn't the default 400. */
+const ERROR_STATUS: Partial<Record<SpaceErrorCode, number>> = {
+	SpaceNotFound: 404,
+	RepoNotFound: 404,
+	BlobNotFound: 404,
+	RecordAlreadyExists: 409,
+	SpaceAlreadyExists: 409,
+	UserNotAuthorized: 403,
+	AppNotAuthorized: 403,
+	NotAuthorized: 403,
+	NotSpaceOwner: 403,
+	InvalidDelegationToken: 401,
+	InvalidClientAttestation: 401,
+	InvalidCredential: 401,
+	SpacesSchemaOutdated: 503,
+};
+
+export class SpaceError extends Error {
+	override name = "SpaceError";
+	constructor(
+		readonly code: SpaceErrorCode,
+		message: string,
+	) {
+		// The `${code}: ` prefix survives the DO RPC boundary.
+		super(`${code}: ${message}`);
+	}
+
+	get status(): number {
+		return ERROR_STATUS[this.code] ?? 400;
+	}
+
+	/** The human message without the code prefix. */
+	get detail(): string {
+		return this.message.slice(this.code.length + 2);
+	}
+}
+
+/**
+ * Recover the space error name from an error that may have crossed a DO RPC
+ * boundary. Returns null for errors that aren't space errors.
+ */
+export function parseSpaceErrorCode(
+	err: unknown,
+): { code: SpaceErrorCode; message: string } | null {
+	if (err instanceof SpaceError) {
+		return { code: err.code, message: err.detail };
+	}
+	if (err instanceof Error) {
+		const colon = err.message.indexOf(": ");
+		if (colon > 0) {
+			const code = err.message.slice(0, colon);
+			if (CODE_SET.has(code)) {
+				return {
+					code: code as SpaceErrorCode,
+					message: err.message.slice(colon + 2),
+				};
+			}
+		}
+	}
+	return null;
+}
+
+/** HTTP status for a recovered space error name. */
+export function spaceErrorStatus(code: SpaceErrorCode): number {
+	return ERROR_STATUS[code] ?? 400;
+}

--- a/packages/spaces/src/index-do.ts
+++ b/packages/spaces/src/index-do.ts
@@ -170,12 +170,19 @@ export class SpaceIndexDurableObject<Env = unknown> extends DurableObject<Env> {
 		this.initialized = false;
 	}
 
-	/** Clean up `pending` entries that never activated. */
+	/**
+	 * Tombstone `pending` entries that never activated. They become
+	 * `deleted` rather than being removed: a crash between the space DO's
+	 * initialisation and the index activation leaves real DO storage
+	 * behind, and the index row is the only durable manifest `spaces reset`
+	 * has for finding and destroying it.
+	 */
 	override async alarm(): Promise<void> {
 		await this.ensureInitialized();
 		const cutoff = new Date(Date.now() - PENDING_ENTRY_TTL_MS).toISOString();
 		this.sql.exec(
-			"DELETE FROM space WHERE state = 'pending' AND updated_at < ?",
+			"UPDATE space SET state = 'deleted', updated_at = ? WHERE state = 'pending' AND updated_at < ?",
+			new Date().toISOString(),
 			cutoff,
 		);
 		await this.ctx.storage.setAlarm(Date.now() + ALARM_INTERVAL_MS);

--- a/packages/spaces/src/index-do.ts
+++ b/packages/spaces/src/index-do.ts
@@ -1,0 +1,196 @@
+/**
+ * SpaceIndexDurableObject – singleton registry of space URIs with role
+ * flags, timestamps and lifecycle state, addressed by `idFromName("spaces")`.
+ *
+ * Serves listSpaces, the dashboard, export and reset. Nothing reads it on
+ * the hot path: the space DO id is derived from the URI, so reads never
+ * depend on the index. Creation is a two-step write — the index entry is
+ * written `pending`, the space DO is initialised, then the entry is marked
+ * `active`. A `pending` entry that never activates is cleaned up by this
+ * DO's alarm.
+ */
+
+import { DurableObject } from "cloudflare:workers";
+import { INDEX_DO_SCHEMA, PENDING_ENTRY_TTL_MS, SPACE_SCHEMA_VERSION } from "./schema.js";
+
+export type SpaceIndexState = "pending" | "active" | "deleted";
+
+export interface SpaceIndexEntry {
+	uri: string;
+	authority: string;
+	type: string;
+	skey: string;
+	isAuthority: boolean;
+	state: SpaceIndexState;
+	createdAt: string;
+	updatedAt: string;
+}
+
+const ALARM_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+export class SpaceIndexDurableObject<Env = unknown> extends DurableObject<Env> {
+	private sql: SqlStorage;
+	private initialized = false;
+
+	constructor(ctx: DurableObjectState, env: Env) {
+		super(ctx, env);
+		this.sql = ctx.storage.sql;
+	}
+
+	private async ensureInitialized(): Promise<void> {
+		if (this.initialized) return;
+		await this.ctx.blockConcurrencyWhile(async () => {
+			if (this.initialized) return;
+			this.sql.exec(INDEX_DO_SCHEMA);
+			this.initialized = true;
+			const alarm = await this.ctx.storage.getAlarm();
+			if (alarm === null) {
+				await this.ctx.storage.setAlarm(Date.now() + ALARM_INTERVAL_MS);
+			}
+		});
+	}
+
+	/** Register (or revive) an entry in `pending` state. */
+	async rpcRegister(entry: {
+		uri: string;
+		authority: string;
+		type: string;
+		skey: string;
+		isAuthority: boolean;
+	}): Promise<void> {
+		await this.ensureInitialized();
+		const now = new Date().toISOString();
+		this.sql.exec(
+			`INSERT INTO space (uri, authority, type, skey, is_authority, state, created_at, updated_at, schema_version)
+			 VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+			 ON CONFLICT (uri) DO UPDATE SET
+				state = CASE WHEN space.state = 'active' THEN 'active' ELSE 'pending' END,
+				is_authority = excluded.is_authority,
+				updated_at = excluded.updated_at`,
+			entry.uri,
+			entry.authority,
+			entry.type,
+			entry.skey,
+			entry.isAuthority ? 1 : 0,
+			now,
+			now,
+			SPACE_SCHEMA_VERSION,
+		);
+	}
+
+	async rpcActivate(uri: string): Promise<void> {
+		await this.ensureInitialized();
+		this.sql.exec(
+			"UPDATE space SET state = 'active', updated_at = ? WHERE uri = ?",
+			new Date().toISOString(),
+			uri,
+		);
+	}
+
+	async rpcMarkDeleted(uri: string): Promise<void> {
+		await this.ensureInitialized();
+		this.sql.exec(
+			"UPDATE space SET state = 'deleted', updated_at = ? WHERE uri = ?",
+			new Date().toISOString(),
+			uri,
+		);
+	}
+
+	async rpcGet(uri: string): Promise<SpaceIndexEntry | null> {
+		await this.ensureInitialized();
+		const row = this.sql
+			.exec("SELECT * FROM space WHERE uri = ?", uri)
+			.toArray()[0];
+		return row ? toEntry(row) : null;
+	}
+
+	async rpcList(params: {
+		type?: string;
+		authority?: string;
+		state?: SpaceIndexState;
+		limit: number;
+		afterUri?: string;
+	}): Promise<{ spaces: SpaceIndexEntry[]; hasMore: boolean }> {
+		await this.ensureInitialized();
+		const args: unknown[] = [];
+		let where = "1=1";
+		if (params.type) {
+			where += " AND type = ?";
+			args.push(params.type);
+		}
+		if (params.authority) {
+			where += " AND authority = ?";
+			args.push(params.authority);
+		}
+		if (params.state) {
+			where += " AND state = ?";
+			args.push(params.state);
+		}
+		if (params.afterUri) {
+			where += " AND uri > ?";
+			args.push(params.afterUri);
+		}
+		const rows = this.sql
+			.exec(
+				`SELECT * FROM space WHERE ${where} ORDER BY uri ASC LIMIT ?`,
+				...args,
+				params.limit + 1,
+			)
+			.toArray();
+		const hasMore = rows.length > params.limit;
+		const page = hasMore ? rows.slice(0, params.limit) : rows;
+		return { spaces: page.map(toEntry), hasMore };
+	}
+
+	async rpcStats(): Promise<{
+		total: number;
+		active: number;
+		pending: number;
+		deleted: number;
+		hosted: number;
+	}> {
+		await this.ensureInitialized();
+		const count = (where: string): number =>
+			(this.sql
+				.exec(`SELECT COUNT(*) AS n FROM space WHERE ${where}`)
+				.toArray()[0]?.n as number) ?? 0;
+		return {
+			total: count("1=1"),
+			active: count("state = 'active'"),
+			pending: count("state = 'pending'"),
+			deleted: count("state = 'deleted'"),
+			hosted: count("is_authority = 1 AND state = 'active'"),
+		};
+	}
+
+	/** Wipe the registry (spaces reset). */
+	async rpcDestroy(): Promise<void> {
+		await this.ctx.storage.deleteAlarm();
+		await this.ctx.storage.deleteAll();
+		this.initialized = false;
+	}
+
+	/** Clean up `pending` entries that never activated. */
+	override async alarm(): Promise<void> {
+		await this.ensureInitialized();
+		const cutoff = new Date(Date.now() - PENDING_ENTRY_TTL_MS).toISOString();
+		this.sql.exec(
+			"DELETE FROM space WHERE state = 'pending' AND updated_at < ?",
+			cutoff,
+		);
+		await this.ctx.storage.setAlarm(Date.now() + ALARM_INTERVAL_MS);
+	}
+}
+
+function toEntry(row: Record<string, unknown>): SpaceIndexEntry {
+	return {
+		uri: row.uri as string,
+		authority: row.authority as string,
+		type: row.type as string,
+		skey: row.skey as string,
+		isAuthority: (row.is_authority as number) === 1,
+		state: row.state as SpaceIndexState,
+		createdAt: row.created_at as string,
+		updatedAt: row.updated_at as string,
+	};
+}

--- a/packages/spaces/src/index.ts
+++ b/packages/spaces/src/index.ts
@@ -1,0 +1,61 @@
+/**
+ * @getcirrus/spaces – atproto spaces engine (alpha) for Cloudflare Workers.
+ *
+ * All space state is isolated from the public repository: alpha-era
+ * breaking changes are absorbed by wiping space data (`pds spaces reset`),
+ * never by touching the account's MST, blobs or OAuth state.
+ */
+
+export { SpaceDurableObject } from "./space-do.js";
+export { SpaceIndexDurableObject } from "./index-do.js";
+export type { SpaceIndexEntry, SpaceIndexState } from "./index-do.js";
+
+export {
+	SpaceError,
+	parseSpaceErrorCode,
+	spaceErrorStatus,
+	SPACE_ERROR_CODES,
+} from "./errors.js";
+export type { SpaceErrorCode } from "./errors.js";
+
+export {
+	formatSpaceUri,
+	parseSpaceUri,
+	requireSpaceUri,
+	spaceId,
+	spaceRecordUri,
+} from "./space-uri.js";
+export type { SpaceRef } from "./space-uri.js";
+
+export {
+	spaceBlobKey,
+	spaceBlobKeyForUri,
+	spaceBlobPrefix,
+	spaceBlobRootPrefix,
+} from "./blob-keys.js";
+
+export {
+	SPACE_SCHEMA_VERSION,
+	OPLOG_RETENTION_DAYS,
+	OPLOG_RETENTION_OPS,
+	NOTIFY_REGISTRATION_DAYS,
+} from "./schema.js";
+
+export { createServiceJwt } from "./service-jwt.js";
+export type { ServiceJwtParams } from "./service-jwt.js";
+
+export { nextRev, tidCutoff } from "./tid.js";
+
+export type {
+	ApplyWritesResult,
+	NotifyItem,
+	OplogEntry,
+	PreparedSpaceWrite,
+	RepoState,
+	SpaceAppAccess,
+	SpaceConfig,
+	SpaceHostConfig,
+	SpaceMeta,
+	SpacePolicy,
+	SpaceRecordRow,
+} from "./types.js";

--- a/packages/spaces/src/schema.ts
+++ b/packages/spaces/src/schema.ts
@@ -1,0 +1,132 @@
+/**
+ * SQLite schema for SpaceDurableObject.
+ *
+ * Mirrors the reference PDS's `002-space` migration table for table, minus
+ * the `space` column on every row — one DO per space makes it redundant.
+ *
+ * There is no migration path between alpha schema versions: bumping
+ * {@link SPACE_SCHEMA_VERSION} puts existing DOs into a refusing state until
+ * `pds spaces reset` wipes them. That is the alpha policy, applied honestly.
+ */
+
+/** Bump on any breaking change to the tables below. */
+export const SPACE_SCHEMA_VERSION = 1;
+
+export const SPACE_DO_SCHEMA = `
+	-- One row. schema_version is checked on every open.
+	CREATE TABLE IF NOT EXISTS meta (
+		uri TEXT NOT NULL,
+		authority TEXT NOT NULL,
+		type TEXT NOT NULL,
+		skey TEXT NOT NULL,
+		is_authority INTEGER NOT NULL,
+		created_at TEXT NOT NULL,
+		deleted_at TEXT,
+		schema_version INTEGER NOT NULL
+	);
+
+	-- Operator's permissioned repo in this space.
+	CREATE TABLE IF NOT EXISTS record (
+		collection TEXT NOT NULL,
+		rkey TEXT NOT NULL,
+		cid TEXT NOT NULL,
+		bytes BLOB NOT NULL,
+		rev TEXT NOT NULL,
+		indexed_at TEXT NOT NULL,
+		PRIMARY KEY (collection, rkey)
+	);
+	CREATE INDEX IF NOT EXISTS idx_record_rev ON record(rev);
+
+	CREATE TABLE IF NOT EXISTS record_blob (
+		blob_cid TEXT NOT NULL,
+		collection TEXT NOT NULL,
+		rkey TEXT NOT NULL,
+		PRIMARY KEY (blob_cid, collection, rkey)
+	);
+	CREATE INDEX IF NOT EXISTS idx_record_blob_record ON record_blob(collection, rkey);
+
+	CREATE TABLE IF NOT EXISTS repo_state (
+		id INTEGER PRIMARY KEY CHECK (id = 1),
+		set_hash BLOB NOT NULL,
+		rev TEXT NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS oplog (
+		rev TEXT NOT NULL,
+		idx INTEGER NOT NULL,
+		collection TEXT NOT NULL,
+		rkey TEXT NOT NULL,
+		cid TEXT,
+		prev TEXT,
+		PRIMARY KEY (rev, idx)
+	);
+
+	-- Authority role only.
+	CREATE TABLE IF NOT EXISTS config (
+		id INTEGER PRIMARY KEY CHECK (id = 1),
+		policy TEXT NOT NULL,
+		managing_app TEXT,
+		app_access TEXT NOT NULL,
+		app_allowed TEXT NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS member (did TEXT PRIMARY KEY);
+
+	CREATE TABLE IF NOT EXISTS writer (
+		did TEXT PRIMARY KEY,
+		rev TEXT NOT NULL,
+		hash BLOB NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS notify_registration (
+		service TEXT PRIMARY KEY,
+		endpoint TEXT NOT NULL,
+		expires_at TEXT NOT NULL
+	);
+
+	CREATE TABLE IF NOT EXISTS notify_queue (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		service TEXT NOT NULL,
+		body TEXT NOT NULL,
+		attempts INTEGER NOT NULL DEFAULT 0,
+		next_at INTEGER NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_notify_queue_next ON notify_queue(next_at);
+
+	-- Replay protection, both roles.
+	CREATE TABLE IF NOT EXISTS replay (
+		kind TEXT NOT NULL,
+		key TEXT NOT NULL,
+		expires_at INTEGER NOT NULL,
+		PRIMARY KEY (kind, key)
+	);
+`;
+
+/** Retain oplog entries for at most this many days. */
+export const OPLOG_RETENTION_DAYS = 30;
+/** Retain at most this many oplog entries. */
+export const OPLOG_RETENTION_OPS = 10_000;
+/** Notify registrations expire after this many days. */
+export const NOTIFY_REGISTRATION_DAYS = 7;
+/** Give up delivering a notification after this many attempts. */
+export const NOTIFY_MAX_ATTEMPTS = 5;
+/** Base delay for notification retry backoff, in milliseconds. */
+export const NOTIFY_BACKOFF_BASE_MS = 30_000;
+
+export const INDEX_DO_SCHEMA = `
+	CREATE TABLE IF NOT EXISTS space (
+		uri TEXT PRIMARY KEY,
+		authority TEXT NOT NULL,
+		type TEXT NOT NULL,
+		skey TEXT NOT NULL,
+		is_authority INTEGER NOT NULL,
+		state TEXT NOT NULL,             -- 'pending' | 'active' | 'deleted'
+		created_at TEXT NOT NULL,
+		updated_at TEXT NOT NULL,
+		schema_version INTEGER NOT NULL
+	);
+	CREATE INDEX IF NOT EXISTS idx_space_state ON space(state);
+`;
+
+/** Remove `pending` index entries that never activated after this long. */
+export const PENDING_ENTRY_TTL_MS = 24 * 60 * 60 * 1000;

--- a/packages/spaces/src/service-jwt.ts
+++ b/packages/spaces/src/service-jwt.ts
@@ -1,0 +1,46 @@
+/**
+ * Minimal atproto service-auth JWT creation, used for outbound
+ * `com.atproto.space.notifyWrite` / `notifySpaceDeleted` calls. Matches the
+ * shape `verifyServiceJwt` implementations expect: `{iss, aud, lxm?, jti,
+ * iat, exp}` signed with the account signing key (alg from the keypair).
+ */
+
+import type { Keypair } from "@atproto/crypto";
+
+const encoder = new TextEncoder();
+
+function base64url(bytes: Uint8Array): string {
+	let bin = "";
+	for (const b of bytes) bin += String.fromCharCode(b);
+	return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export interface ServiceJwtParams {
+	iss: string;
+	aud: string;
+	lxm?: string;
+	/** Lifetime in seconds (default 60). */
+	expiresInSec?: number;
+}
+
+export async function createServiceJwt(
+	params: ServiceJwtParams,
+	keypair: Keypair,
+): Promise<string> {
+	const iat = Math.floor(Date.now() / 1000);
+	const header = { typ: "JWT", alg: keypair.jwtAlg };
+	const payload: Record<string, unknown> = {
+		iat,
+		iss: params.iss,
+		aud: params.aud,
+		exp: iat + (params.expiresInSec ?? 60),
+		jti: crypto.randomUUID(),
+	};
+	if (params.lxm) payload.lxm = params.lxm;
+
+	const signingInput = `${base64url(encoder.encode(JSON.stringify(header)))}.${base64url(
+		encoder.encode(JSON.stringify(payload)),
+	)}`;
+	const sig = await keypair.sign(encoder.encode(signingInput));
+	return `${signingInput}.${base64url(sig)}`;
+}

--- a/packages/spaces/src/space-do.ts
+++ b/packages/spaces/src/space-do.ts
@@ -390,6 +390,10 @@ export abstract class SpaceDurableObject<Env = unknown> extends DurableObject<En
 	 * List records ordered by (collection, rkey) — equivalent to record-URI
 	 * order since every record shares the space and repo prefix. Descending
 	 * by default, matching the reference; `reverse` flips to ascending.
+	 *
+	 * `rev` is the repo revision the page was read at — the page and the
+	 * revision are one snapshot (synchronous reads, single-threaded DO), so
+	 * a paged reader can fence against concurrent writes.
 	 */
 	async rpcListRecords(params: {
 		collection?: string;
@@ -397,9 +401,17 @@ export abstract class SpaceDurableObject<Env = unknown> extends DurableObject<En
 		after?: { collection: string; rkey: string };
 		reverse?: boolean;
 		excludeValues?: boolean;
-	}): Promise<{ records: SpaceRecordRow[]; hasMore: boolean }> {
+	}): Promise<{
+		records: SpaceRecordRow[];
+		hasMore: boolean;
+		rev: string | null;
+	}> {
 		await this.ensureOpen();
 		this.requireLiveMeta();
+		const stateRow = this.sql
+			.exec("SELECT rev FROM repo_state WHERE id = 1")
+			.toArray()[0];
+		const rev = stateRow ? (stateRow.rev as string) : null;
 		const asc = params.reverse === true;
 		const op = asc ? ">" : "<";
 		const order = asc ? "ASC" : "DESC";
@@ -435,6 +447,7 @@ export abstract class SpaceDurableObject<Env = unknown> extends DurableObject<En
 					: { bytes: new Uint8Array(row.bytes as ArrayBuffer) }),
 			})),
 			hasMore,
+			rev,
 		};
 	}
 
@@ -713,21 +726,28 @@ export abstract class SpaceDurableObject<Env = unknown> extends DurableObject<En
 		return { dids: page.map((r) => r.did as string), hasMore };
 	}
 
-	/** Record a writer's latest (rev, hash), from notifyWrite or own writes. */
+	/**
+	 * Record a writer's latest (rev, hash), from notifyWrite or own writes.
+	 * Monotonic per writer: a delayed or replayed notification with an older
+	 * rev never rolls the writer set backwards. Returns whether the write
+	 * advanced state, so callers can skip fan-out for stale notifications.
+	 */
 	async rpcRecordWriter(
 		did: string,
 		rev: string,
 		hash: Uint8Array,
-	): Promise<void> {
+	): Promise<{ advanced: boolean }> {
 		await this.ensureOpen();
 		this.requireLiveMeta();
-		this.sql.exec(
+		const result = this.sql.exec(
 			`INSERT INTO writer (did, rev, hash) VALUES (?, ?, ?)
-			 ON CONFLICT (did) DO UPDATE SET rev = excluded.rev, hash = excluded.hash`,
+			 ON CONFLICT (did) DO UPDATE SET rev = excluded.rev, hash = excluded.hash
+			 WHERE excluded.rev > writer.rev`,
 			did,
 			rev,
 			hash,
 		);
+		return { advanced: result.rowsWritten > 0 };
 	}
 
 	async rpcListWriters(params: {

--- a/packages/spaces/src/space-do.ts
+++ b/packages/spaces/src/space-do.ts
@@ -1,0 +1,1059 @@
+/**
+ * SpaceDurableObject – one instance per space, addressed by
+ * `idFromName(spaceUri)`.
+ *
+ * Holds everything Cirrus knows about that space: the operator's
+ * permissioned repo (records, oplog, LtHash state, blob references) and,
+ * when the operator is the authority, the simplespace config, member list,
+ * writer set, notification registrations and the outbound notification
+ * queue. Also the replay tables for DPoP proofs and delegation tokens
+ * presented against the space.
+ *
+ * Constraints inherited from the Cirrus architecture:
+ * - No R2 I/O in here, ever. Blobs are the Worker's job.
+ * - Commits are never signed here; the signing key never enters this class
+ *   except through {@link SpaceHostConfig.getKeypair}, which is used only
+ *   for outbound notification service JWTs from the alarm.
+ * - The host supplies its identity via {@link getHostConfig}; this class
+ *   must not read `env.DID`. If it ever contains a branch on which host is
+ *   running it, the boundary has failed.
+ */
+
+import { DurableObject } from "cloudflare:workers";
+import { RepoCommit } from "@atproto/space";
+import { SpaceError } from "./errors.js";
+import {
+	NOTIFY_BACKOFF_BASE_MS,
+	NOTIFY_MAX_ATTEMPTS,
+	NOTIFY_REGISTRATION_DAYS,
+	OPLOG_RETENTION_DAYS,
+	OPLOG_RETENTION_OPS,
+	SPACE_DO_SCHEMA,
+	SPACE_SCHEMA_VERSION,
+} from "./schema.js";
+import { nextRev, tidCutoff } from "./tid.js";
+import { createServiceJwt } from "./service-jwt.js";
+import type {
+	ApplyWritesResult,
+	NotifyItem,
+	OplogEntry,
+	PreparedSpaceWrite,
+	RepoState,
+	SpaceAppAccess,
+	SpaceConfig,
+	SpaceHostConfig,
+	SpaceMeta,
+	SpacePolicy,
+	SpaceRecordRow,
+} from "./types.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+/** Interval between maintenance passes (compaction, replay cleanup). */
+const MAINTENANCE_INTERVAL_MS = DAY_MS;
+/** How many queued notifications to attempt per alarm invocation. */
+const NOTIFY_BATCH = 20;
+
+interface QueueRow {
+	id: number;
+	service: string;
+	body: string;
+	attempts: number;
+	next_at: number;
+}
+
+export abstract class SpaceDurableObject<Env = unknown> extends DurableObject<Env> {
+	private sql: SqlStorage;
+	private initialized = false;
+	private outdated = false;
+
+	constructor(ctx: DurableObjectState, env: Env) {
+		super(ctx, env);
+		this.sql = ctx.storage.sql;
+	}
+
+	/**
+	 * Host identity and signing configuration. Implemented by the host
+	 * Worker's subclass; see {@link SpaceHostConfig}.
+	 */
+	protected abstract getHostConfig(): SpaceHostConfig | Promise<SpaceHostConfig>;
+
+	// ------------------------------------------------------------------
+	// Initialisation and schema versioning
+	// ------------------------------------------------------------------
+
+	private async ensureInitialized(): Promise<void> {
+		if (this.initialized) return;
+		await this.ctx.blockConcurrencyWhile(async () => {
+			if (this.initialized) return;
+			const hasMeta =
+				this.sql
+					.exec(
+						"SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'meta'",
+					)
+					.toArray().length > 0;
+			if (hasMeta) {
+				const row = this.sql
+					.exec("SELECT schema_version FROM meta LIMIT 1")
+					.toArray()[0];
+				if (
+					row &&
+					(row.schema_version as number) !== SPACE_SCHEMA_VERSION
+				) {
+					// Alpha policy: no migrations between schema versions. The DO
+					// refuses every RPC until `pds spaces reset` wipes it.
+					this.outdated = true;
+					this.initialized = true;
+					return;
+				}
+			}
+			this.sql.exec(SPACE_DO_SCHEMA);
+			this.initialized = true;
+		});
+	}
+
+	/**
+	 * Gate every RPC: initialise storage and refuse when the stored schema
+	 * belongs to a different alpha build.
+	 */
+	private async ensureOpen(): Promise<void> {
+		await this.ensureInitialized();
+		if (this.outdated) {
+			throw new SpaceError(
+				"SpacesSchemaOutdated",
+				"Space data was written by an incompatible alpha build. Run `pds spaces reset` to wipe space data (the public repo is unaffected).",
+			);
+		}
+	}
+
+	private readMeta(): SpaceMeta | null {
+		const row = this.sql.exec("SELECT * FROM meta LIMIT 1").toArray()[0];
+		if (!row) return null;
+		return {
+			uri: row.uri as string,
+			authority: row.authority as string,
+			type: row.type as string,
+			skey: row.skey as string,
+			isAuthority: (row.is_authority as number) === 1,
+			createdAt: row.created_at as string,
+			deletedAt: (row.deleted_at as string | null) ?? null,
+		};
+	}
+
+	/** Meta for an existing, non-deleted space, or throw. */
+	private requireLiveMeta(): SpaceMeta {
+		const meta = this.readMeta();
+		if (!meta) {
+			throw new SpaceError("SpaceNotFound", "Space is not initialised");
+		}
+		if (meta.deletedAt) {
+			throw new SpaceError("SpaceNotFound", "Space has been deleted");
+		}
+		return meta;
+	}
+
+	async rpcGetMeta(): Promise<SpaceMeta | null> {
+		await this.ensureOpen();
+		return this.readMeta();
+	}
+
+	/**
+	 * Initialise this DO as the operator's repo in a space (either role).
+	 * Idempotent for an existing live space with matching identity.
+	 */
+	async rpcInit(params: {
+		uri: string;
+		authority: string;
+		type: string;
+		skey: string;
+		isAuthority: boolean;
+		config?: SpaceConfig;
+	}): Promise<void> {
+		await this.ensureOpen();
+		const existing = this.readMeta();
+		if (existing) {
+			if (existing.uri !== params.uri) {
+				throw new SpaceError(
+					"InvalidSpaceUri",
+					`Space DO already holds ${existing.uri}`,
+				);
+			}
+			if (!existing.deletedAt) {
+				if (params.isAuthority && params.config) {
+					const hasConfig =
+						this.sql.exec("SELECT id FROM config").toArray().length > 0;
+					if (hasConfig) {
+						throw new SpaceError(
+							"SpaceAlreadyExists",
+							`Space already exists: ${params.uri}`,
+						);
+					}
+					this.writeConfig(params.config);
+				}
+				return;
+			}
+			// A previously deleted space may be created again: tables were
+			// wiped at deletion, so reviving is a fresh start.
+			this.sql.exec(
+				"UPDATE meta SET deleted_at = NULL, created_at = ?, is_authority = ?",
+				new Date().toISOString(),
+				params.isAuthority ? 1 : 0,
+			);
+			if (params.config) this.writeConfig(params.config);
+			return;
+		}
+		this.sql.exec(
+			`INSERT INTO meta (uri, authority, type, skey, is_authority, created_at, deleted_at, schema_version)
+			 VALUES (?, ?, ?, ?, ?, ?, NULL, ?)`,
+			params.uri,
+			params.authority,
+			params.type,
+			params.skey,
+			params.isAuthority ? 1 : 0,
+			new Date().toISOString(),
+			SPACE_SCHEMA_VERSION,
+		);
+		if (params.config) this.writeConfig(params.config);
+	}
+
+	// ------------------------------------------------------------------
+	// Permissioned repo: writes
+	// ------------------------------------------------------------------
+
+	async rpcApplyWrites(
+		writes: PreparedSpaceWrite[],
+	): Promise<ApplyWritesResult> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+
+		return this.ctx.storage.transactionSync(() => {
+			const stateRow = this.sql
+				.exec("SELECT set_hash, rev FROM repo_state WHERE id = 1")
+				.toArray()[0];
+			const prevRev = stateRow ? (stateRow.rev as string) : null;
+			const commit = RepoCommit.fromState(
+				stateRow ? new Uint8Array(stateRow.set_hash as ArrayBuffer) : null,
+			);
+			const rev = nextRev(prevRev);
+			const indexedAt = new Date().toISOString();
+			const results: ApplyWritesResult["results"] = [];
+			let idx = 0;
+
+			for (const write of writes) {
+				const prevRow = this.sql
+					.exec(
+						"SELECT cid FROM record WHERE collection = ? AND rkey = ?",
+						write.collection,
+						write.rkey,
+					)
+					.toArray()[0];
+				const prev = prevRow ? (prevRow.cid as string) : null;
+
+				if (write.action === "create" && prev) {
+					throw new SpaceError(
+						"RecordAlreadyExists",
+						`Record already exists: ${write.collection}/${write.rkey}`,
+					);
+				}
+				if (write.action !== "create" && !prev) {
+					throw new SpaceError(
+						"RecordNotFound",
+						`Record not found: ${write.collection}/${write.rkey}`,
+					);
+				}
+
+				if (write.action === "delete") {
+					this.sql.exec(
+						"DELETE FROM record WHERE collection = ? AND rkey = ?",
+						write.collection,
+						write.rkey,
+					);
+					this.sql.exec(
+						"DELETE FROM record_blob WHERE collection = ? AND rkey = ?",
+						write.collection,
+						write.rkey,
+					);
+					commit.setHash.remove(
+						`${write.collection}/${write.rkey}/${prev}`,
+					);
+					this.appendOplog(rev, idx++, write.collection, write.rkey, null, prev);
+					results.push({
+						action: "delete",
+						collection: write.collection,
+						rkey: write.rkey,
+						cid: null,
+					});
+					continue;
+				}
+
+				this.sql.exec(
+					`INSERT OR REPLACE INTO record (collection, rkey, cid, bytes, rev, indexed_at)
+					 VALUES (?, ?, ?, ?, ?, ?)`,
+					write.collection,
+					write.rkey,
+					write.cid,
+					write.bytes,
+					rev,
+					indexedAt,
+				);
+				this.sql.exec(
+					"DELETE FROM record_blob WHERE collection = ? AND rkey = ?",
+					write.collection,
+					write.rkey,
+				);
+				for (const blobCid of write.blobCids) {
+					this.sql.exec(
+						"INSERT OR IGNORE INTO record_blob (blob_cid, collection, rkey) VALUES (?, ?, ?)",
+						blobCid,
+						write.collection,
+						write.rkey,
+					);
+				}
+				if (prev) {
+					commit.setHash.remove(
+						`${write.collection}/${write.rkey}/${prev}`,
+					);
+				}
+				commit.setHash.add(
+					`${write.collection}/${write.rkey}/${write.cid}`,
+				);
+				this.appendOplog(
+					rev,
+					idx++,
+					write.collection,
+					write.rkey,
+					write.cid,
+					prev,
+				);
+				results.push({
+					action: write.action,
+					collection: write.collection,
+					rkey: write.rkey,
+					cid: write.cid,
+				});
+			}
+
+			this.sql.exec(
+				`INSERT INTO repo_state (id, set_hash, rev) VALUES (1, ?, ?)
+				 ON CONFLICT (id) DO UPDATE SET set_hash = excluded.set_hash, rev = excluded.rev`,
+				commit.setHash.state(),
+				rev,
+			);
+
+			return { rev, hash: commit.setHash.digest(), results };
+		});
+	}
+
+	private appendOplog(
+		rev: string,
+		idx: number,
+		collection: string,
+		rkey: string,
+		cid: string | null,
+		prev: string | null,
+	): void {
+		this.sql.exec(
+			"INSERT INTO oplog (rev, idx, collection, rkey, cid, prev) VALUES (?, ?, ?, ?, ?, ?)",
+			rev,
+			idx,
+			collection,
+			rkey,
+			cid,
+			prev,
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// Permissioned repo: reads
+	// ------------------------------------------------------------------
+
+	async rpcGetRecord(
+		collection: string,
+		rkey: string,
+	): Promise<{ cid: string; bytes: Uint8Array } | null> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		const row = this.sql
+			.exec(
+				"SELECT cid, bytes FROM record WHERE collection = ? AND rkey = ?",
+				collection,
+				rkey,
+			)
+			.toArray()[0];
+		if (!row) return null;
+		return {
+			cid: row.cid as string,
+			bytes: new Uint8Array(row.bytes as ArrayBuffer),
+		};
+	}
+
+	/**
+	 * List records ordered by (collection, rkey) — equivalent to record-URI
+	 * order since every record shares the space and repo prefix. Descending
+	 * by default, matching the reference; `reverse` flips to ascending.
+	 */
+	async rpcListRecords(params: {
+		collection?: string;
+		limit: number;
+		after?: { collection: string; rkey: string };
+		reverse?: boolean;
+		excludeValues?: boolean;
+	}): Promise<{ records: SpaceRecordRow[]; hasMore: boolean }> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		const asc = params.reverse === true;
+		const op = asc ? ">" : "<";
+		const order = asc ? "ASC" : "DESC";
+		const args: unknown[] = [];
+		let where = "1=1";
+		if (params.collection) {
+			where += " AND collection = ?";
+			args.push(params.collection);
+		}
+		if (params.after) {
+			where += ` AND (collection ${op} ? OR (collection = ? AND rkey ${op} ?))`;
+			args.push(params.after.collection, params.after.collection, params.after.rkey);
+		}
+		const rows = this.sql
+			.exec(
+				`SELECT collection, rkey, cid${params.excludeValues ? "" : ", bytes"} FROM record
+				 WHERE ${where}
+				 ORDER BY collection ${order}, rkey ${order}
+				 LIMIT ?`,
+				...args,
+				params.limit + 1,
+			)
+			.toArray();
+		const hasMore = rows.length > params.limit;
+		const page = hasMore ? rows.slice(0, params.limit) : rows;
+		return {
+			records: page.map((row) => ({
+				collection: row.collection as string,
+				rkey: row.rkey as string,
+				cid: row.cid as string,
+				...(params.excludeValues
+					? {}
+					: { bytes: new Uint8Array(row.bytes as ArrayBuffer) }),
+			})),
+			hasMore,
+		};
+	}
+
+	async rpcGetRepoState(): Promise<RepoState | null> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		const row = this.sql
+			.exec("SELECT set_hash, rev FROM repo_state WHERE id = 1")
+			.toArray()[0];
+		if (!row) return null;
+		return {
+			setHash: new Uint8Array(row.set_hash as ArrayBuffer),
+			rev: row.rev as string,
+		};
+	}
+
+	/**
+	 * List oplog entries after `since` (a rev) or `after` (an exact cursor
+	 * position). Creates and updates carry the record's current bytes when
+	 * the oplog cid still matches the live record; superseded values are
+	 * omitted. When the page reaches the head, `head` carries the repo
+	 * state read in the same transaction so the Worker can attach a freshly
+	 * signed commit without a state race.
+	 */
+	async rpcListRepoOps(params: {
+		since?: string;
+		after?: { rev: string; idx: number };
+		limit: number;
+		excludeValues?: boolean;
+	}): Promise<{ ops: OplogEntry[]; head?: RepoState }> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		return this.ctx.storage.transactionSync(() => {
+			const args: unknown[] = [];
+			let where = "1=1";
+			if (params.after) {
+				where += " AND (o.rev > ? OR (o.rev = ? AND o.idx > ?))";
+				args.push(params.after.rev, params.after.rev, params.after.idx);
+			} else if (params.since) {
+				where += " AND o.rev > ?";
+				args.push(params.since);
+			}
+			const values = params.excludeValues
+				? ""
+				: ", r.bytes AS live_bytes";
+			const rows = this.sql
+				.exec(
+					`SELECT o.rev, o.idx, o.collection, o.rkey, o.cid, o.prev${values}
+					 FROM oplog o
+					 ${params.excludeValues ? "" : "LEFT JOIN record r ON r.collection = o.collection AND r.rkey = o.rkey AND r.cid = o.cid"}
+					 WHERE ${where}
+					 ORDER BY o.rev ASC, o.idx ASC
+					 LIMIT ?`,
+					...args,
+					params.limit + 1,
+				)
+				.toArray();
+			const hasMore = rows.length > params.limit;
+			const page = hasMore ? rows.slice(0, params.limit) : rows;
+			const ops: OplogEntry[] = page.map((row) => ({
+				rev: row.rev as string,
+				idx: row.idx as number,
+				collection: row.collection as string,
+				rkey: row.rkey as string,
+				cid: (row.cid as string | null) ?? null,
+				prev: (row.prev as string | null) ?? null,
+				...(row.live_bytes
+					? { bytes: new Uint8Array(row.live_bytes as ArrayBuffer) }
+					: {}),
+			}));
+			if (hasMore) return { ops };
+			const stateRow = this.sql
+				.exec("SELECT set_hash, rev FROM repo_state WHERE id = 1")
+				.toArray()[0];
+			return {
+				ops,
+				...(stateRow
+					? {
+							head: {
+								setHash: new Uint8Array(
+									stateRow.set_hash as ArrayBuffer,
+								),
+								rev: stateRow.rev as string,
+							},
+						}
+					: {}),
+			};
+		});
+	}
+
+	/** Distinct blob CIDs referenced by records, ascending, paged. */
+	async rpcListBlobs(params: {
+		since?: string;
+		limit: number;
+		afterCid?: string;
+	}): Promise<{ cids: string[]; hasMore: boolean }> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		const args: unknown[] = [];
+		let where = "1=1";
+		if (params.since) {
+			where += " AND r.rev > ?";
+			args.push(params.since);
+		}
+		if (params.afterCid) {
+			where += " AND b.blob_cid > ?";
+			args.push(params.afterCid);
+		}
+		const rows = this.sql
+			.exec(
+				`SELECT DISTINCT b.blob_cid FROM record_blob b
+				 JOIN record r ON r.collection = b.collection AND r.rkey = b.rkey
+				 WHERE ${where}
+				 ORDER BY b.blob_cid ASC
+				 LIMIT ?`,
+				...args,
+				params.limit + 1,
+			)
+			.toArray();
+		const hasMore = rows.length > params.limit;
+		const page = hasMore ? rows.slice(0, params.limit) : rows;
+		return { cids: page.map((r) => r.blob_cid as string), hasMore };
+	}
+
+	/** Whether a blob CID is referenced by any record in this space. */
+	async rpcHasSpaceBlob(cid: string): Promise<boolean> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		return (
+			this.sql
+				.exec("SELECT 1 FROM record_blob WHERE blob_cid = ? LIMIT 1", cid)
+				.toArray().length > 0
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// Replay protection
+	// ------------------------------------------------------------------
+
+	/**
+	 * Record a single-use key. Returns true when the key was fresh (now
+	 * recorded), false when it was already seen and must be refused.
+	 */
+	async rpcCheckReplay(
+		kind: string,
+		key: string,
+		expiresAtSec: number,
+	): Promise<boolean> {
+		await this.ensureOpen();
+		const result = this.sql.exec(
+			"INSERT OR IGNORE INTO replay (kind, key, expires_at) VALUES (?, ?, ?)",
+			kind,
+			key,
+			expiresAtSec,
+		);
+		return result.rowsWritten > 0;
+	}
+
+	// ------------------------------------------------------------------
+	// Authority role: config, members, writers, notifications
+	// ------------------------------------------------------------------
+
+	private writeConfig(config: SpaceConfig): void {
+		this.sql.exec(
+			`INSERT INTO config (id, policy, managing_app, app_access, app_allowed)
+			 VALUES (1, ?, ?, ?, ?)
+			 ON CONFLICT (id) DO UPDATE SET
+				policy = excluded.policy,
+				managing_app = excluded.managing_app,
+				app_access = excluded.app_access,
+				app_allowed = excluded.app_allowed`,
+			config.policy.kind,
+			config.policy.kind === "managing-app" ? config.policy.managingApp : null,
+			config.appAccess.kind,
+			JSON.stringify(
+				config.appAccess.kind === "allowList" ? config.appAccess.allowed : [],
+			),
+		);
+	}
+
+	private readConfig(): SpaceConfig | null {
+		const row = this.sql.exec("SELECT * FROM config WHERE id = 1").toArray()[0];
+		if (!row) return null;
+		const policyKind = row.policy as string;
+		const policy: SpacePolicy =
+			policyKind === "managing-app"
+				? {
+						kind: "managing-app",
+						managingApp: row.managing_app as string,
+					}
+				: policyKind === "member-list"
+					? { kind: "member-list" }
+					: { kind: "public" };
+		const appAccess: SpaceAppAccess =
+			(row.app_access as string) === "allowList"
+				? {
+						kind: "allowList",
+						allowed: JSON.parse(row.app_allowed as string) as string[],
+					}
+				: { kind: "open" };
+		return { policy, appAccess };
+	}
+
+	/**
+	 * State needed to answer getSpaceCredential: meta (including the
+	 * deletion tombstone) and the simplespace config. Never throws on a
+	 * deleted space — a late credential request must get SpaceDeleted, not
+	 * SpaceNotFound, and that mapping is the caller's.
+	 */
+	async rpcGetAuthorityState(): Promise<{
+		meta: SpaceMeta | null;
+		config: SpaceConfig | null;
+	}> {
+		await this.ensureOpen();
+		return { meta: this.readMeta(), config: this.readConfig() };
+	}
+
+	async rpcUpdateConfig(update: {
+		policy?: SpacePolicy;
+		appAccess?: SpaceAppAccess;
+	}): Promise<void> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		const current = this.readConfig();
+		if (!current) {
+			throw new SpaceError("SpaceNotFound", "Space has no configuration");
+		}
+		this.writeConfig({
+			policy: update.policy ?? current.policy,
+			appAccess: update.appAccess ?? current.appAccess,
+		});
+	}
+
+	async rpcAddMember(did: string): Promise<void> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		this.sql.exec("INSERT OR IGNORE INTO member (did) VALUES (?)", did);
+	}
+
+	async rpcRemoveMember(did: string): Promise<void> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		this.sql.exec("DELETE FROM member WHERE did = ?", did);
+	}
+
+	async rpcIsMember(did: string): Promise<boolean> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		return (
+			this.sql.exec("SELECT 1 FROM member WHERE did = ?", did).toArray()
+				.length > 0
+		);
+	}
+
+	async rpcListMembers(params: {
+		limit: number;
+		afterDid?: string;
+	}): Promise<{ dids: string[]; hasMore: boolean }> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		const args: unknown[] = [];
+		let where = "1=1";
+		if (params.afterDid) {
+			where += " AND did > ?";
+			args.push(params.afterDid);
+		}
+		const rows = this.sql
+			.exec(
+				`SELECT did FROM member WHERE ${where} ORDER BY did ASC LIMIT ?`,
+				...args,
+				params.limit + 1,
+			)
+			.toArray();
+		const hasMore = rows.length > params.limit;
+		const page = hasMore ? rows.slice(0, params.limit) : rows;
+		return { dids: page.map((r) => r.did as string), hasMore };
+	}
+
+	/** Record a writer's latest (rev, hash), from notifyWrite or own writes. */
+	async rpcRecordWriter(
+		did: string,
+		rev: string,
+		hash: Uint8Array,
+	): Promise<void> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		this.sql.exec(
+			`INSERT INTO writer (did, rev, hash) VALUES (?, ?, ?)
+			 ON CONFLICT (did) DO UPDATE SET rev = excluded.rev, hash = excluded.hash`,
+			did,
+			rev,
+			hash,
+		);
+	}
+
+	async rpcListWriters(params: {
+		limit: number;
+		afterDid?: string;
+	}): Promise<{
+		repos: Array<{ did: string; rev: string; hash: Uint8Array }>;
+		hasMore: boolean;
+	}> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		const args: unknown[] = [];
+		let where = "1=1";
+		if (params.afterDid) {
+			where += " AND did > ?";
+			args.push(params.afterDid);
+		}
+		const rows = this.sql
+			.exec(
+				`SELECT did, rev, hash FROM writer WHERE ${where} ORDER BY did ASC LIMIT ?`,
+				...args,
+				params.limit + 1,
+			)
+			.toArray();
+		const hasMore = rows.length > params.limit;
+		const page = hasMore ? rows.slice(0, params.limit) : rows;
+		return {
+			repos: page.map((r) => ({
+				did: r.did as string,
+				rev: r.rev as string,
+				hash: new Uint8Array(r.hash as ArrayBuffer),
+			})),
+			hasMore,
+		};
+	}
+
+	/**
+	 * Register a syncing service for write notifications. The endpoint was
+	 * resolved by the Worker at registration time so fan-out never resolves
+	 * DIDs. Re-registration replaces the endpoint and extends the expiry.
+	 */
+	async rpcRegisterNotify(
+		service: string,
+		endpoint: string,
+	): Promise<{ expiresAt: string }> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		const expiresAt = new Date(
+			Date.now() + NOTIFY_REGISTRATION_DAYS * DAY_MS,
+		).toISOString();
+		this.sql.exec(
+			`INSERT INTO notify_registration (service, endpoint, expires_at) VALUES (?, ?, ?)
+			 ON CONFLICT (service) DO UPDATE SET endpoint = excluded.endpoint, expires_at = excluded.expires_at`,
+			service,
+			endpoint,
+			expiresAt,
+		);
+		return { expiresAt };
+	}
+
+	/** Idempotent: succeeds whether or not a registration existed. */
+	async rpcUnregisterNotify(service: string): Promise<void> {
+		await this.ensureOpen();
+		this.requireLiveMeta();
+		this.sql.exec("DELETE FROM notify_registration WHERE service = ?", service);
+	}
+
+	async rpcGetActiveRegistrations(): Promise<
+		Array<{ service: string; endpoint: string }>
+	> {
+		await this.ensureOpen();
+		return this.sql
+			.exec(
+				"SELECT service, endpoint FROM notify_registration WHERE expires_at > ?",
+				new Date().toISOString(),
+			)
+			.toArray()
+			.map((r) => ({
+				service: r.service as string,
+				endpoint: r.endpoint as string,
+			}));
+	}
+
+	/**
+	 * Queue outbound notifications for the alarm to deliver with bounded
+	 * retries. The Worker only enqueues; delivery happens here because this
+	 * DO holds no WebSocket and does no storage-bound work that a slow
+	 * outbound fetch could pin.
+	 */
+	async rpcEnqueueNotify(items: NotifyItem[]): Promise<void> {
+		await this.ensureOpen();
+		if (items.length === 0) return;
+		const now = Date.now();
+		for (const item of items) {
+			this.sql.exec(
+				"INSERT INTO notify_queue (service, body, attempts, next_at) VALUES (?, ?, 0, ?)",
+				item.service,
+				JSON.stringify({
+					endpoint: item.endpoint,
+					lxm: item.lxm,
+					body: item.body,
+				}),
+				now,
+			);
+		}
+		await this.scheduleNextAlarm();
+	}
+
+	// ------------------------------------------------------------------
+	// Deletion and status
+	// ------------------------------------------------------------------
+
+	/**
+	 * Tombstone the space (authority role). Enqueues nothing itself — the
+	 * caller reads the registrations from the result and enqueues
+	 * `notifySpaceDeleted` before the queue rows would be unreachable. The
+	 * meta row is retained so a late getSpaceCredential can answer
+	 * SpaceDeleted rather than SpaceNotFound. Idempotent.
+	 */
+	async rpcDeleteSpace(): Promise<{
+		registrations: Array<{ service: string; endpoint: string }>;
+	}> {
+		await this.ensureOpen();
+		const meta = this.readMeta();
+		if (!meta) {
+			throw new SpaceError("SpaceNotFound", "Space is not initialised");
+		}
+		if (meta.deletedAt) return { registrations: [] };
+		const registrations = await this.rpcGetActiveRegistrations();
+		this.ctx.storage.transactionSync(() => {
+			this.sql.exec(
+				"UPDATE meta SET deleted_at = ?",
+				new Date().toISOString(),
+			);
+			for (const table of [
+				"record",
+				"record_blob",
+				"repo_state",
+				"oplog",
+				"config",
+				"member",
+				"writer",
+				"notify_registration",
+				"replay",
+			]) {
+				this.sql.exec(`DELETE FROM ${table}`);
+			}
+		});
+		return { registrations };
+	}
+
+	/** Wipe everything, including queued notifications and alarms. */
+	async rpcDestroy(): Promise<void> {
+		await this.ctx.storage.deleteAlarm();
+		await this.ctx.storage.deleteAll();
+		this.initialized = false;
+		this.outdated = false;
+	}
+
+	async rpcStatus(): Promise<{
+		meta: SpaceMeta | null;
+		outdated: boolean;
+		recordCount: number;
+		memberCount: number;
+		writerCount: number;
+		queuedNotifications: number;
+	}> {
+		await this.ensureInitialized();
+		if (this.outdated) {
+			return {
+				meta: null,
+				outdated: true,
+				recordCount: 0,
+				memberCount: 0,
+				writerCount: 0,
+				queuedNotifications: 0,
+			};
+		}
+		const count = (table: string): number =>
+			(this.sql.exec(`SELECT COUNT(*) AS n FROM ${table}`).toArray()[0]
+				?.n as number) ?? 0;
+		return {
+			meta: this.readMeta(),
+			outdated: false,
+			recordCount: count("record"),
+			memberCount: count("member"),
+			writerCount: count("writer"),
+			queuedNotifications: count("notify_queue"),
+		};
+	}
+
+	// ------------------------------------------------------------------
+	// Alarm: notification fan-out, oplog compaction, replay cleanup
+	// ------------------------------------------------------------------
+
+	override async alarm(): Promise<void> {
+		await this.ensureInitialized();
+		if (this.outdated) return;
+
+		await this.deliverQueuedNotifications();
+		this.runMaintenanceIfDue();
+		await this.scheduleNextAlarm();
+	}
+
+	private async deliverQueuedNotifications(): Promise<void> {
+		const due = this.sql
+			.exec(
+				"SELECT id, service, body, attempts, next_at FROM notify_queue WHERE next_at <= ? ORDER BY next_at ASC LIMIT ?",
+				Date.now(),
+				NOTIFY_BATCH,
+			)
+			.toArray() as unknown as QueueRow[];
+		if (due.length === 0) return;
+
+		const meta = this.readMeta();
+		if (!meta) {
+			this.sql.exec("DELETE FROM notify_queue");
+			return;
+		}
+		const host = await this.getHostConfig();
+		const keypair = await host.getKeypair();
+
+		for (const row of due) {
+			let delivered = false;
+			try {
+				const parsed = JSON.parse(row.body) as {
+					endpoint: string;
+					lxm: string;
+					body: Record<string, unknown>;
+				};
+				const token = await createServiceJwt(
+					{ iss: meta.authority, aud: row.service, lxm: parsed.lxm },
+					keypair,
+				);
+				const res = await fetch(`${parsed.endpoint}/xrpc/${parsed.lxm}`, {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						Authorization: `Bearer ${token}`,
+					},
+					body: JSON.stringify(parsed.body),
+				});
+				delivered = res.ok;
+				if (!res.ok) {
+					console.warn(
+						`notify ${parsed.lxm} to ${row.service} failed: ${res.status}`,
+					);
+				}
+			} catch (err) {
+				console.warn(`notify to ${row.service} errored:`, err);
+			}
+
+			if (delivered || row.attempts + 1 >= NOTIFY_MAX_ATTEMPTS) {
+				this.sql.exec("DELETE FROM notify_queue WHERE id = ?", row.id);
+			} else {
+				this.sql.exec(
+					"UPDATE notify_queue SET attempts = ?, next_at = ? WHERE id = ?",
+					row.attempts + 1,
+					Date.now() + NOTIFY_BACKOFF_BASE_MS * 2 ** row.attempts,
+					row.id,
+				);
+			}
+		}
+	}
+
+	private runMaintenanceIfDue(): void {
+		const now = Date.now();
+		const last =
+			(this.sql
+				.exec(
+					"SELECT expires_at FROM replay WHERE kind = '__maintenance' AND key = 'last' LIMIT 1",
+				)
+				.toArray()[0]?.expires_at as number | undefined) ?? 0;
+		if (now - last < MAINTENANCE_INTERVAL_MS) return;
+
+		// Oplog compaction: 30 days or 10,000 ops, whichever is smaller.
+		// DO SQLite is billed and capped; the reference has no compaction
+		// yet, ours must.
+		this.sql.exec(
+			"DELETE FROM oplog WHERE rev < ?",
+			tidCutoff(OPLOG_RETENTION_DAYS * DAY_MS),
+		);
+		const excess = this.sql
+			.exec(
+				"SELECT rev, idx FROM oplog ORDER BY rev DESC, idx DESC LIMIT 1 OFFSET ?",
+				OPLOG_RETENTION_OPS,
+			)
+			.toArray()[0];
+		if (excess) {
+			this.sql.exec(
+				"DELETE FROM oplog WHERE rev < ? OR (rev = ? AND idx <= ?)",
+				excess.rev,
+				excess.rev,
+				excess.idx,
+			);
+		}
+
+		// Replay entries expire on their own clock.
+		this.sql.exec(
+			"DELETE FROM replay WHERE kind != '__maintenance' AND expires_at < ?",
+			Math.floor(now / 1000),
+		);
+		// Expired notify registrations.
+		this.sql.exec(
+			"DELETE FROM notify_registration WHERE expires_at <= ?",
+			new Date(now).toISOString(),
+		);
+
+		this.sql.exec(
+			`INSERT INTO replay (kind, key, expires_at) VALUES ('__maintenance', 'last', ?)
+			 ON CONFLICT (kind, key) DO UPDATE SET expires_at = excluded.expires_at`,
+			now,
+		);
+	}
+
+	private async scheduleNextAlarm(): Promise<void> {
+		const nextQueue = this.sql
+			.exec("SELECT MIN(next_at) AS next FROM notify_queue")
+			.toArray()[0]?.next as number | null;
+		const nextMaintenance = Date.now() + MAINTENANCE_INTERVAL_MS;
+		const next = nextQueue
+			? Math.min(Math.max(nextQueue, Date.now() + 1000), nextMaintenance)
+			: nextMaintenance;
+		const current = await this.ctx.storage.getAlarm();
+		if (current === null || next < current) {
+			await this.ctx.storage.setAlarm(next);
+		}
+	}
+}

--- a/packages/spaces/src/space-uri.ts
+++ b/packages/spaces/src/space-uri.ts
@@ -1,0 +1,99 @@
+/**
+ * Space URI handling.
+ *
+ * A space is addressed as `at://{authorityDid}/space/{typeNsid}/{skey}` —
+ * the literal `space` marker keeps it unambiguous with public record URIs
+ * because a collection NSID always contains at least two dots. A record in
+ * a space appends `/{authorDid}/{collection}/{rkey}`.
+ */
+
+import { isDid, isNsid, isRecordKey } from "@atcute/lexicons/syntax";
+import { SpaceError } from "./errors.js";
+
+export interface SpaceRef {
+	/** The full space URI. */
+	uri: string;
+	/** The space authority DID. */
+	authority: string;
+	/** The space type NSID. */
+	type: string;
+	/** The space key (record-key syntax). */
+	skey: string;
+}
+
+/**
+ * Parse a space URI. Returns null when the string is not a valid space
+ * reference.
+ */
+export function parseSpaceUri(uri: string): SpaceRef | null {
+	if (!uri.startsWith("at://")) return null;
+	const parts = uri.slice("at://".length).split("/");
+	if (parts.length !== 4) return null;
+	const [authority, marker, type, skey] = parts as [
+		string,
+		string,
+		string,
+		string,
+	];
+	if (marker !== "space") return null;
+	if (!isDid(authority) || !isNsid(type) || !isRecordKey(skey)) return null;
+	const ref = { uri: formatSpaceUri(authority, type, skey), authority, type, skey };
+	// Round-trip requirement mirrors the reference's SpaceRef.parse.
+	if (ref.uri !== uri) return null;
+	return ref;
+}
+
+/** Parse a space URI or throw an InvalidSpaceUri error. */
+export function requireSpaceUri(uri: string | undefined): SpaceRef {
+	const ref = uri ? parseSpaceUri(uri) : null;
+	if (!ref) {
+		throw new SpaceError("InvalidSpaceUri", `Invalid space URI: ${uri}`);
+	}
+	return ref;
+}
+
+export function formatSpaceUri(
+	authority: string,
+	type: string,
+	skey: string,
+): string {
+	return `at://${authority}/space/${type}/${skey}`;
+}
+
+/** URI of a record within a space: `{spaceUri}/{repoDid}/{collection}/{rkey}`. */
+export function spaceRecordUri(
+	spaceUri: string,
+	repo: string,
+	collection: string,
+	rkey: string,
+): string {
+	return `${spaceUri}/${repo}/${collection}/${rkey}`;
+}
+
+const BASE32_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567";
+
+/**
+ * Stable identifier for a space used in R2 key prefixes: the lowercase,
+ * unpadded base32 encoding of the SHA-256 of the space URI. Deterministic,
+ * filesystem-safe and free of the URI's slashes and colons.
+ */
+export async function spaceId(spaceUri: string): Promise<string> {
+	const digest = new Uint8Array(
+		await crypto.subtle.digest("SHA-256", new TextEncoder().encode(spaceUri)),
+	);
+	let out = "";
+	let bits = 0;
+	let value = 0;
+	for (const byte of digest) {
+		value = (value << 8) | byte;
+		bits += 8;
+		while (bits >= 5) {
+			out += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+			bits -= 5;
+		}
+	}
+	if (bits > 0) {
+		out += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+	}
+	return out;
+}

--- a/packages/spaces/src/tid.ts
+++ b/packages/spaces/src/tid.ts
@@ -1,0 +1,47 @@
+/**
+ * Revision (TID) helpers for the space repo.
+ */
+
+import { now as tidNow } from "@atcute/tid";
+
+const S32_CHAR = "234567abcdefghijklmnopqrstuvwxyz";
+
+/**
+ * Next revision: a fresh TID guaranteed strictly greater than `prev`.
+ * `@atcute/tid`'s clock is monotonic within an isolate, but the previous
+ * rev may come from a different isolate's clock (e.g. after a DO restart),
+ * so bump lexicographically when needed.
+ */
+export function nextRev(prev: string | null | undefined): string {
+	const candidate = tidNow();
+	if (!prev || candidate > prev) return candidate;
+	// Increment the previous TID by one in s32 space.
+	const chars = prev.split("");
+	for (let i = chars.length - 1; i >= 0; i--) {
+		const idx = S32_CHAR.indexOf(chars[i]!);
+		if (idx < S32_CHAR.length - 1) {
+			chars[i] = S32_CHAR[idx + 1]!;
+			return chars.join("");
+		}
+		chars[i] = S32_CHAR[0]!;
+	}
+	// prev was the maximal TID; not reachable with real clocks.
+	return candidate;
+}
+
+/**
+ * The smallest TID whose timestamp is `ms` milliseconds in the past, with a
+ * zero clockid. Used as a deletion cutoff for oplog compaction.
+ */
+export function tidCutoff(msAgo: number): string {
+	const micros = BigInt(Math.max(0, Date.now() - msAgo)) * 1000n;
+	// TID layout: 53 bits of microseconds followed by 10 bits of clockid,
+	// encoded as 13 sortable-base32 characters.
+	let value = (micros << 10n) & ((1n << 63n) - 1n);
+	let out = "";
+	for (let i = 12; i >= 0; i--) {
+		out = S32_CHAR[Number(value & 31n)] + out;
+		value >>= 5n;
+	}
+	return out;
+}

--- a/packages/spaces/src/types.ts
+++ b/packages/spaces/src/types.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared types crossing the Worker ↔ Durable Object RPC boundary.
+ */
+
+import type { Keypair } from "@atproto/crypto";
+
+/** A write prepared by the Worker: validated, CBOR-encoded, CID computed. */
+export type PreparedSpaceWrite =
+	| {
+			action: "create" | "update";
+			collection: string;
+			rkey: string;
+			cid: string;
+			bytes: Uint8Array;
+			/** Blob CIDs referenced by the record. */
+			blobCids: string[];
+	  }
+	| {
+			action: "delete";
+			collection: string;
+			rkey: string;
+	  };
+
+export interface ApplyWritesResult {
+	rev: string;
+	/** sha256 digest of the LtHash state after the batch. */
+	hash: Uint8Array;
+	results: Array<{
+		action: "create" | "update" | "delete";
+		collection: string;
+		rkey: string;
+		cid: string | null;
+	}>;
+}
+
+export interface SpaceMeta {
+	uri: string;
+	authority: string;
+	type: string;
+	skey: string;
+	isAuthority: boolean;
+	createdAt: string;
+	deletedAt: string | null;
+}
+
+export type SpacePolicy =
+	| { kind: "public" }
+	| { kind: "member-list" }
+	| { kind: "managing-app"; managingApp: string };
+
+export type SpaceAppAccess =
+	| { kind: "open" }
+	| { kind: "allowList"; allowed: string[] };
+
+export interface SpaceConfig {
+	policy: SpacePolicy;
+	appAccess: SpaceAppAccess;
+}
+
+export interface RepoState {
+	setHash: Uint8Array;
+	rev: string;
+}
+
+export interface SpaceRecordRow {
+	collection: string;
+	rkey: string;
+	cid: string;
+	bytes?: Uint8Array;
+}
+
+export interface OplogEntry {
+	rev: string;
+	idx: number;
+	collection: string;
+	rkey: string;
+	cid: string | null;
+	prev: string | null;
+	/** Current record bytes for creates/updates that are not stale. */
+	bytes?: Uint8Array;
+}
+
+export interface NotifyItem {
+	service: string;
+	endpoint: string;
+	lxm: string;
+	body: Record<string, unknown>;
+}
+
+/**
+ * Host configuration for the space engine's Durable Objects. Supplied by
+ * the host Worker's subclass — the engine never reads env vars itself, so
+ * the same class can later serve a dedicated authority DID with no account
+ * attached.
+ */
+export interface SpaceHostConfig {
+	/** The DID whose permissioned repos this engine serves. */
+	operatorDid: string;
+	/** Signing keypair provider (service JWTs for notification fan-out). */
+	getKeypair(): Promise<Keypair>;
+}

--- a/packages/spaces/test/fixtures/spaces-worker/index.ts
+++ b/packages/spaces/test/fixtures/spaces-worker/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Test fixture worker: concrete Durable Object subclasses supplying host
+ * configuration, simulating how a host PDS embeds the engine. The host
+ * config deliberately uses a DID with no account attached anywhere —
+ * exercising the S9 requirement that the engine takes its identity from
+ * the caller rather than the environment.
+ */
+
+import { Secp256k1Keypair } from "@atproto/crypto";
+import { SpaceDurableObject, SpaceIndexDurableObject } from "../../../src/index";
+import type { SpaceHostConfig } from "../../../src/index";
+
+/** Deterministic test signing key (hex-encoded secp256k1 private key). */
+export const TEST_SIGNING_KEY =
+	"e5b452e70de7fb7864fdd7f0d67c6dbd0f128413a1daa1b2b8a871e906fc90cc";
+
+export const TEST_OPERATOR_DID = "did:web:operator.test";
+
+let keypairPromise: Promise<Secp256k1Keypair> | null = null;
+
+export class TestSpaceDurableObject extends SpaceDurableObject {
+	protected getHostConfig(): SpaceHostConfig {
+		return {
+			operatorDid: TEST_OPERATOR_DID,
+			getKeypair: () => {
+				keypairPromise ??= Secp256k1Keypair.import(TEST_SIGNING_KEY);
+				return keypairPromise;
+			},
+		};
+	}
+}
+
+export class TestSpaceIndexDurableObject extends SpaceIndexDurableObject {}
+
+export default {
+	fetch(): Response {
+		return new Response("ok");
+	},
+};

--- a/packages/spaces/test/fixtures/spaces-worker/worker-configuration.d.ts
+++ b/packages/spaces/test/fixtures/spaces-worker/worker-configuration.d.ts
@@ -1,0 +1,12 @@
+// Test fixture types - the bindings provided to the fixture worker
+import type {
+	TestSpaceDurableObject,
+	TestSpaceIndexDurableObject,
+} from "./index";
+
+declare global {
+	interface Env {
+		SPACES: DurableObjectNamespace<TestSpaceDurableObject>;
+		SPACES_INDEX: DurableObjectNamespace<TestSpaceIndexDurableObject>;
+	}
+}

--- a/packages/spaces/test/fixtures/spaces-worker/wrangler.jsonc
+++ b/packages/spaces/test/fixtures/spaces-worker/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+	// Test configuration for the spaces engine fixture worker
+	"name": "spaces-test",
+	"main": "index.ts",
+	"compatibility_date": "2025-12-02",
+	"compatibility_flags": ["nodejs_compat"],
+	"durable_objects": {
+		"bindings": [
+			{
+				"name": "SPACES",
+				"class_name": "TestSpaceDurableObject",
+			},
+			{
+				"name": "SPACES_INDEX",
+				"class_name": "TestSpaceIndexDurableObject",
+			},
+		],
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_sqlite_classes": [
+				"TestSpaceDurableObject",
+				"TestSpaceIndexDurableObject",
+			],
+		},
+	],
+}

--- a/packages/spaces/test/index-do.test.ts
+++ b/packages/spaces/test/index-do.test.ts
@@ -1,0 +1,117 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+function indexStub() {
+	return env.SPACES_INDEX.get(env.SPACES_INDEX.idFromName("spaces"));
+}
+
+const AUTHORITY = "did:web:operator.test";
+
+let n = 0;
+function entry(overrides: Record<string, unknown> = {}) {
+	const skey = `idx${n++}x`;
+	return {
+		uri: `at://${AUTHORITY}/space/app.bsky.group/${skey}`,
+		authority: AUTHORITY,
+		type: "app.bsky.group",
+		skey,
+		isAuthority: true,
+		...overrides,
+	};
+}
+
+describe("SpaceIndexDurableObject", () => {
+	it("registers pending, activates and lists", async () => {
+		const stub = indexStub();
+		const e = entry();
+		await stub.rpcRegister(e);
+		expect((await stub.rpcGet(e.uri))?.state).toBe("pending");
+
+		await stub.rpcActivate(e.uri);
+		expect((await stub.rpcGet(e.uri))?.state).toBe("active");
+
+		const listed = await stub.rpcList({ limit: 100, state: "active" });
+		expect(listed.spaces.map((s) => s.uri)).toContain(e.uri);
+	});
+
+	it("filters by type and authority", async () => {
+		const stub = indexStub();
+		const a = entry({ type: "app.bsky.personal" });
+		a.uri = `at://${AUTHORITY}/space/app.bsky.personal/${a.skey}`;
+		await stub.rpcRegister(a);
+		await stub.rpcActivate(a.uri);
+
+		const byType = await stub.rpcList({
+			limit: 100,
+			type: "app.bsky.personal",
+		});
+		expect(byType.spaces.every((s) => s.type === "app.bsky.personal")).toBe(
+			true,
+		);
+		expect(byType.spaces.map((s) => s.uri)).toContain(a.uri);
+
+		const byAuthority = await stub.rpcList({
+			limit: 100,
+			authority: "did:web:someone-else.test",
+		});
+		expect(byAuthority.spaces).toEqual([]);
+	});
+
+	it("re-registering an active entry keeps it active", async () => {
+		const stub = indexStub();
+		const e = entry();
+		await stub.rpcRegister(e);
+		await stub.rpcActivate(e.uri);
+		await stub.rpcRegister(e);
+		expect((await stub.rpcGet(e.uri))?.state).toBe("active");
+	});
+
+	it("marks deleted and counts stats", async () => {
+		const stub = indexStub();
+		const e = entry();
+		await stub.rpcRegister(e);
+		await stub.rpcActivate(e.uri);
+		await stub.rpcMarkDeleted(e.uri);
+		expect((await stub.rpcGet(e.uri))?.state).toBe("deleted");
+
+		const stats = await stub.rpcStats();
+		expect(stats.total).toBeGreaterThan(0);
+		expect(stats.deleted).toBeGreaterThan(0);
+	});
+
+	it("cleans up stale pending entries on alarm", async () => {
+		const stub = indexStub();
+		const stale = entry();
+		await stub.rpcRegister(stale);
+		// Backdate the pending entry past the TTL, then run the alarm.
+		await runInDurableObject(stub, async (instance, state) => {
+			state.storage.sql.exec(
+				"UPDATE space SET updated_at = ? WHERE uri = ?",
+				new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(),
+				stale.uri,
+			);
+			await instance.alarm();
+		});
+		expect(await stub.rpcGet(stale.uri)).toBe(null);
+	});
+
+	it("pages with a cursor", async () => {
+		const stub = indexStub();
+		for (let i = 0; i < 3; i++) {
+			const e = entry();
+			await stub.rpcRegister(e);
+			await stub.rpcActivate(e.uri);
+		}
+		const page1 = await stub.rpcList({ limit: 2 });
+		expect(page1.spaces).toHaveLength(2);
+		expect(page1.hasMore).toBe(true);
+		const page2 = await stub.rpcList({
+			limit: 100,
+			afterUri: page1.spaces[1]!.uri,
+		});
+		expect(page2.spaces.length).toBeGreaterThan(0);
+		expect(
+			page2.spaces.every((s) => s.uri > page1.spaces[1]!.uri),
+		).toBe(true);
+	});
+});

--- a/packages/spaces/test/index-do.test.ts
+++ b/packages/spaces/test/index-do.test.ts
@@ -79,7 +79,7 @@ describe("SpaceIndexDurableObject", () => {
 		expect(stats.deleted).toBeGreaterThan(0);
 	});
 
-	it("cleans up stale pending entries on alarm", async () => {
+	it("tombstones stale pending entries on alarm, keeping them discoverable", async () => {
 		const stub = indexStub();
 		const stale = entry();
 		await stub.rpcRegister(stale);
@@ -92,7 +92,15 @@ describe("SpaceIndexDurableObject", () => {
 			);
 			await instance.alarm();
 		});
-		expect(await stub.rpcGet(stale.uri)).toBe(null);
+		// Not removed: the row is the only durable manifest reset has for
+		// finding a space DO that was initialised but never activated.
+		expect((await stub.rpcGet(stale.uri))?.state).toBe("deleted");
+		const listed = await stub.rpcList({ limit: 1000 });
+		expect(listed.spaces.map((s) => s.uri)).toContain(stale.uri);
+
+		// A revived registration goes back to pending.
+		await stub.rpcRegister(stale);
+		expect((await stub.rpcGet(stale.uri))?.state).toBe("pending");
 	});
 
 	it("pages with a cursor", async () => {

--- a/packages/spaces/test/space-do.test.ts
+++ b/packages/spaces/test/space-do.test.ts
@@ -1,0 +1,488 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { LtHash, RepoCommit, verifyCommit } from "@atproto/space";
+import { Secp256k1Keypair } from "@atproto/crypto";
+import { encode } from "@atproto/lex-cbor";
+import type { PreparedSpaceWrite } from "../src/types";
+import {
+	TEST_OPERATOR_DID,
+	TEST_SIGNING_KEY,
+	type TestSpaceDurableObject,
+} from "./fixtures/spaces-worker/index";
+
+const AUTHORITY = TEST_OPERATOR_DID;
+
+/**
+ * Run an RPC method expected to throw and return its error message. The
+ * error is caught inside the DO isolate: a rejected RPC stub promise is
+ * double-reported by the workers pool as an unhandled rejection even when
+ * the client handles it, so crossing the boundary with the rejection would
+ * fail the run.
+ */
+async function rpcError(
+	stub: DurableObjectStub<TestSpaceDurableObject>,
+	fn: (instance: TestSpaceDurableObject) => Promise<unknown>,
+): Promise<string> {
+	return runInDurableObject(stub, async (instance) => {
+		try {
+			await fn(instance);
+			return "";
+		} catch (e) {
+			return e instanceof Error ? e.message : String(e);
+		}
+	});
+}
+
+let spaceCounter = 0;
+function freshSpace(): {
+	uri: string;
+	stub: DurableObjectStub<TestSpaceDurableObject>;
+} {
+	const uri = `at://${AUTHORITY}/space/app.bsky.group/space${spaceCounter++}x`;
+	const stub = env.SPACES.get(env.SPACES.idFromName(uri));
+	return { uri, stub };
+}
+
+async function initSpace(
+	stub: DurableObjectStub<TestSpaceDurableObject>,
+	uri: string,
+	isAuthority = true,
+): Promise<void> {
+	await stub.rpcInit({
+		uri,
+		authority: AUTHORITY,
+		type: "app.bsky.group",
+		skey: uri.split("/").pop()!,
+		isAuthority,
+		...(isAuthority
+			? {
+					config: {
+						policy: { kind: "member-list" as const },
+						appAccess: { kind: "open" as const },
+					},
+				}
+			: {}),
+	});
+}
+
+function write(
+	action: "create" | "update",
+	rkey: string,
+	value: Record<string, unknown>,
+	blobCids: string[] = [],
+): PreparedSpaceWrite & { cid: string } {
+	const bytes = encode(value);
+	// A stable fake CID string is fine for engine tests: the DO treats CIDs
+	// as opaque strings. Uniqueness per value is what matters.
+	const cid = `bafyfake${rkey}${String(bytes.length)}${String(value.n ?? "")}`;
+	return {
+		action,
+		collection: "app.bsky.feed.post",
+		rkey,
+		cid,
+		bytes,
+		blobCids,
+	};
+}
+
+describe("SpaceDurableObject", () => {
+	it("initialises and reports meta", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+		const meta = await stub.rpcGetMeta();
+		expect(meta).toMatchObject({
+			uri,
+			authority: AUTHORITY,
+			type: "app.bsky.group",
+			isAuthority: true,
+			deletedAt: null,
+		});
+	});
+
+	it("applies create, update and delete with a consistent LtHash", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+
+		const w1 = write("create", "aaa", { $type: "app.bsky.feed.post", n: 1 });
+		const w2 = write("create", "bbb", { $type: "app.bsky.feed.post", n: 2 });
+		const r1 = await stub.rpcApplyWrites([w1, w2]);
+		expect(r1.results).toHaveLength(2);
+		expect(r1.rev).toMatch(/^[2-7a-z]{13}$/);
+
+		// Recompute the expected LtHash from the element strings.
+		const expected = new LtHash();
+		expected.add(`app.bsky.feed.post/aaa/${w1.cid}`);
+		expected.add(`app.bsky.feed.post/bbb/${w2.cid}`);
+		expect(new Uint8Array(r1.hash)).toEqual(expected.digest());
+
+		// Update aaa and delete bbb.
+		const w3 = write("update", "aaa", { $type: "app.bsky.feed.post", n: 3 });
+		const r2 = await stub.rpcApplyWrites([
+			w3,
+			{ action: "delete", collection: "app.bsky.feed.post", rkey: "bbb" },
+		]);
+		expect(r2.rev > r1.rev).toBe(true);
+
+		expected.remove(`app.bsky.feed.post/aaa/${w1.cid}`);
+		expected.add(`app.bsky.feed.post/aaa/${w3.cid}`);
+		expected.remove(`app.bsky.feed.post/bbb/${w2.cid}`);
+		expect(new Uint8Array(r2.hash)).toEqual(expected.digest());
+
+		// The persisted state round-trips through RepoCommit and matches.
+		const state = await stub.rpcGetRepoState();
+		expect(state?.rev).toBe(r2.rev);
+		const commit = RepoCommit.fromState(new Uint8Array(state!.setHash));
+		expect(commit.setHash.digest()).toEqual(expected.digest());
+	});
+
+	it("signs verifiable commits from persisted state", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+		const w = write("create", "sig", { $type: "app.bsky.feed.post", n: 9 });
+		await stub.rpcApplyWrites([w]);
+
+		const state = await stub.rpcGetRepoState();
+		const keypair = await Secp256k1Keypair.import(TEST_SIGNING_KEY);
+		const ctx = { space: uri, author: AUTHORITY, rev: state!.rev };
+		const signed = await RepoCommit.fromState(
+			new Uint8Array(state!.setHash),
+		).sign(ctx, keypair);
+		expect(await verifyCommit(signed, ctx, keypair.did())).toBe(true);
+	});
+
+	it("rejects duplicate creates and missing updates/deletes", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+		const w = write("create", "dup", { $type: "app.bsky.feed.post", n: 1 });
+		await stub.rpcApplyWrites([w]);
+		expect(await rpcError(stub, (i) => i.rpcApplyWrites([w]))).toMatch(
+			/RecordAlreadyExists/,
+		);
+		expect(
+			await rpcError(stub, (i) =>
+				i.rpcApplyWrites([
+					write("update", "missing", { $type: "app.bsky.feed.post" }),
+				]),
+			),
+		).toMatch(/RecordNotFound/);
+		expect(
+			await rpcError(stub, (i) =>
+				i.rpcApplyWrites([
+					{ action: "delete", collection: "app.bsky.feed.post", rkey: "nope" },
+				]),
+			),
+		).toMatch(/RecordNotFound/);
+	});
+
+	it("a failed batch applies nothing", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+		const ok = write("create", "keep", { $type: "app.bsky.feed.post", n: 1 });
+		await stub.rpcApplyWrites([ok]);
+		const before = await stub.rpcGetRepoState();
+
+		expect(
+			await rpcError(stub, (i) =>
+				i.rpcApplyWrites([
+					write("create", "newone", { $type: "app.bsky.feed.post", n: 2 }),
+					ok, // duplicate create -> whole batch fails
+				]),
+			),
+		).toMatch(/RecordAlreadyExists/);
+
+		const after = await stub.rpcGetRepoState();
+		expect(after?.rev).toBe(before?.rev);
+		expect(new Uint8Array(after!.setHash)).toEqual(
+			new Uint8Array(before!.setHash),
+		);
+		expect(await stub.rpcGetRecord("app.bsky.feed.post", "newone")).toBe(null);
+	});
+
+	it("returns records and pages listRecords descending by default", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+		for (const rkey of ["aaa", "bbb", "ccc"]) {
+			await stub.rpcApplyWrites([
+				write("create", rkey, { $type: "app.bsky.feed.post", rkey }),
+			]);
+		}
+		const rec = await stub.rpcGetRecord("app.bsky.feed.post", "bbb");
+		expect(rec).not.toBe(null);
+
+		const page1 = await stub.rpcListRecords({ limit: 2 });
+		expect(page1.records.map((r) => r.rkey)).toEqual(["ccc", "bbb"]);
+		expect(page1.hasMore).toBe(true);
+		const page2 = await stub.rpcListRecords({
+			limit: 2,
+			after: { collection: "app.bsky.feed.post", rkey: "bbb" },
+		});
+		expect(page2.records.map((r) => r.rkey)).toEqual(["aaa"]);
+		expect(page2.hasMore).toBe(false);
+
+		const asc = await stub.rpcListRecords({ limit: 10, reverse: true });
+		expect(asc.records.map((r) => r.rkey)).toEqual(["aaa", "bbb", "ccc"]);
+
+		const meta = await stub.rpcListRecords({ limit: 10, excludeValues: true });
+		expect(meta.records[0]?.bytes).toBeUndefined();
+	});
+
+	it("serves the oplog with values, cursors and head state", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+		const w1 = write("create", "one", { $type: "app.bsky.feed.post", n: 1 });
+		const w2 = write("create", "two", { $type: "app.bsky.feed.post", n: 2 });
+		const r1 = await stub.rpcApplyWrites([w1, w2]);
+		const w3 = write("update", "one", { $type: "app.bsky.feed.post", n: 3 });
+		const r2 = await stub.rpcApplyWrites([w3]);
+
+		// Full log from the start reaches the head: ops + head state.
+		const all = await stub.rpcListRepoOps({ limit: 100 });
+		expect(all.ops).toHaveLength(3);
+		expect(all.head?.rev).toBe(r2.rev);
+		// The create of "one" was superseded: no value. The create of "two"
+		// and the update of "one" are current: values inlined.
+		const [op1, op2, op3] = all.ops;
+		expect(op1?.cid).toBe(w1.cid);
+		expect(op1?.bytes).toBeUndefined();
+		expect(op2?.bytes).not.toBeUndefined();
+		expect(op3?.cid).toBe(w3.cid);
+		expect(op3?.prev).toBe(w1.cid);
+		expect(op3?.bytes).not.toBeUndefined();
+
+		// since filters by rev; a full page withholds head.
+		const sinceR1 = await stub.rpcListRepoOps({ since: r1.rev, limit: 100 });
+		expect(sinceR1.ops).toHaveLength(1);
+		expect(sinceR1.ops[0]?.rev).toBe(r2.rev);
+
+		const paged = await stub.rpcListRepoOps({ limit: 2 });
+		expect(paged.ops).toHaveLength(2);
+		expect(paged.head).toBeUndefined();
+		const rest = await stub.rpcListRepoOps({
+			after: { rev: paged.ops[1]!.rev, idx: paged.ops[1]!.idx },
+			limit: 2,
+		});
+		expect(rest.ops).toHaveLength(1);
+		expect(rest.head?.rev).toBe(r2.rev);
+	});
+
+	it("tracks blob references per record", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+		await stub.rpcApplyWrites([
+			write("create", "withblob", { $type: "app.bsky.feed.post" }, [
+				"bafblob1",
+				"bafblob2",
+			]),
+		]);
+		expect(await stub.rpcHasSpaceBlob("bafblob1")).toBe(true);
+		expect(await stub.rpcHasSpaceBlob("bafother")).toBe(false);
+
+		const blobs = await stub.rpcListBlobs({ limit: 10 });
+		expect(blobs.cids.sort()).toEqual(["bafblob1", "bafblob2"]);
+
+		// Updating the record to drop a blob removes the reference.
+		await stub.rpcApplyWrites([
+			write("update", "withblob", { $type: "app.bsky.feed.post", n: 2 }, [
+				"bafblob1",
+			]),
+		]);
+		expect(await stub.rpcHasSpaceBlob("bafblob2")).toBe(false);
+	});
+
+	it("enforces single-use replay keys", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+		const exp = Math.floor(Date.now() / 1000) + 60;
+		expect(await stub.rpcCheckReplay("dpop", "jti-1", exp)).toBe(true);
+		expect(await stub.rpcCheckReplay("dpop", "jti-1", exp)).toBe(false);
+		expect(await stub.rpcCheckReplay("delegation", "jti-1", exp)).toBe(true);
+	});
+
+	it("manages members, writers and notify registrations", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+		await stub.rpcAddMember("did:web:bob.test");
+		await stub.rpcAddMember("did:web:carol.test");
+		expect(await stub.rpcIsMember("did:web:bob.test")).toBe(true);
+		const members = await stub.rpcListMembers({ limit: 10 });
+		expect(members.dids).toEqual(["did:web:bob.test", "did:web:carol.test"]);
+		await stub.rpcRemoveMember("did:web:bob.test");
+		expect(await stub.rpcIsMember("did:web:bob.test")).toBe(false);
+
+		const hash = new Uint8Array(32).fill(7);
+		await stub.rpcRecordWriter("did:web:bob.test", "3kzzzzzzzzzzz", hash);
+		const writers = await stub.rpcListWriters({ limit: 10 });
+		expect(writers.repos).toHaveLength(1);
+		expect(writers.repos[0]).toMatchObject({
+			did: "did:web:bob.test",
+			rev: "3kzzzzzzzzzzz",
+		});
+		expect(new Uint8Array(writers.repos[0]!.hash)).toEqual(hash);
+
+		const reg = await stub.rpcRegisterNotify(
+			"did:web:syncer.test",
+			"https://syncer.test",
+		);
+		expect(Date.parse(reg.expiresAt)).toBeGreaterThan(Date.now());
+		expect(await stub.rpcGetActiveRegistrations()).toEqual([
+			{ service: "did:web:syncer.test", endpoint: "https://syncer.test" },
+		]);
+		await stub.rpcUnregisterNotify("did:web:syncer.test");
+		expect(await stub.rpcGetActiveRegistrations()).toEqual([]);
+		// Idempotent unregister.
+		await stub.rpcUnregisterNotify("did:web:syncer.test");
+	});
+
+	it("updates and reads simplespace config", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+		const s1 = await stub.rpcGetAuthorityState();
+		expect(s1.config).toEqual({
+			policy: { kind: "member-list" },
+			appAccess: { kind: "open" },
+		});
+		await stub.rpcUpdateConfig({
+			policy: { kind: "managing-app", managingApp: "did:web:app.test#svc" },
+		});
+		const s2 = await stub.rpcGetAuthorityState();
+		expect(s2.config?.policy).toEqual({
+			kind: "managing-app",
+			managingApp: "did:web:app.test#svc",
+		});
+		// appAccess untouched by partial update.
+		expect(s2.config?.appAccess).toEqual({ kind: "open" });
+		await stub.rpcUpdateConfig({
+			appAccess: { kind: "allowList", allowed: ["https://app.test/client"] },
+		});
+		const s3 = await stub.rpcGetAuthorityState();
+		expect(s3.config?.appAccess).toEqual({
+			kind: "allowList",
+			allowed: ["https://app.test/client"],
+		});
+	});
+
+	it("createSpace conflicts on a live space and revives a deleted one", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+		expect(
+			await rpcError(stub, (i) =>
+				i.rpcInit({
+					uri,
+					authority: AUTHORITY,
+					type: "app.bsky.group",
+					skey: uri.split("/").pop()!,
+					isAuthority: true,
+					config: {
+						policy: { kind: "member-list" },
+						appAccess: { kind: "open" },
+					},
+				}),
+			),
+		).toMatch(/SpaceAlreadyExists/);
+
+		await stub.rpcApplyWrites([
+			write("create", "gone", { $type: "app.bsky.feed.post" }),
+		]);
+		const del = await stub.rpcDeleteSpace();
+		expect(del.registrations).toEqual([]);
+
+		// Tombstone: reads fail SpaceNotFound, authority state shows deleted.
+		expect(
+			await rpcError(stub, (i) => i.rpcGetRecord("app.bsky.feed.post", "gone")),
+		).toMatch(/SpaceNotFound/);
+		const state = await stub.rpcGetAuthorityState();
+		expect(state.meta?.deletedAt).not.toBe(null);
+		expect(state.config).toBe(null);
+		// Idempotent delete.
+		const again = await stub.rpcDeleteSpace();
+		expect(again.registrations).toEqual([]);
+
+		// Re-creation revives with a clean slate.
+		await initSpace(stub, uri);
+		const revived = await stub.rpcGetAuthorityState();
+		expect(revived.meta?.deletedAt).toBe(null);
+		expect(await stub.rpcGetRecord("app.bsky.feed.post", "gone")).toBe(null);
+	});
+
+	it("refuses every RPC when the stored schema version is outdated", async () => {
+		const { uri, stub } = freshSpace();
+		// Prepare a meta table from a "different alpha build" before the
+		// engine ever initialises this DO.
+		await runInDurableObject(stub, async (_instance, state) => {
+			state.storage.sql.exec(`
+				CREATE TABLE meta (
+					uri TEXT, authority TEXT, type TEXT, skey TEXT,
+					is_authority INTEGER, created_at TEXT, deleted_at TEXT,
+					schema_version INTEGER
+				)
+			`);
+			state.storage.sql.exec(
+				"INSERT INTO meta (uri, schema_version) VALUES (?, ?)",
+				uri,
+				999,
+			);
+		});
+
+		expect(await rpcError(stub, (i) => i.rpcGetMeta())).toMatch(
+			/SpacesSchemaOutdated/,
+		);
+		expect(
+			await rpcError(stub, (i) =>
+				i.rpcApplyWrites([
+					write("create", "x", { $type: "app.bsky.feed.post" }),
+				]),
+			),
+		).toMatch(/SpacesSchemaOutdated/);
+		const status = await stub.rpcStatus();
+		expect(status.outdated).toBe(true);
+
+		// Reset wipes it back to a usable state.
+		await stub.rpcDestroy();
+		await initSpace(stub, uri);
+		expect((await stub.rpcGetMeta())?.uri).toBe(uri);
+	});
+
+	it("enqueues notifications and delivers them from the alarm", async () => {
+		const { uri, stub } = freshSpace();
+		await initSpace(stub, uri);
+
+		const delivered: Array<{ url: string; auth: string | null; body: string }> =
+			[];
+		await runInDurableObject(stub, async (instance) => {
+			// Intercept outbound fetch from the DO.
+			(globalThis as { fetch: typeof fetch }).fetch = (async (
+				input: RequestInfo | URL,
+				init?: RequestInit,
+			) => {
+				const headers = new Headers(init?.headers);
+				delivered.push({
+					url: String(input),
+					auth: headers.get("Authorization"),
+					body: String(init?.body),
+				});
+				return new Response("{}", { status: 200 });
+			}) as typeof fetch;
+
+			await instance.rpcEnqueueNotify([
+				{
+					service: "did:web:syncer.test",
+					endpoint: "https://syncer.test",
+					lxm: "com.atproto.space.notifyWrite",
+					body: { space: uri, repo: AUTHORITY, rev: "3kaaaaaaaaaa2" },
+				},
+			]);
+			await instance.alarm();
+		});
+
+		expect(delivered).toHaveLength(1);
+		expect(delivered[0]!.url).toBe(
+			"https://syncer.test/xrpc/com.atproto.space.notifyWrite",
+		);
+		expect(delivered[0]!.auth).toMatch(/^Bearer /);
+		expect(JSON.parse(delivered[0]!.body)).toMatchObject({ space: uri });
+
+		// Queue is drained.
+		const status = await stub.rpcStatus();
+		expect(status.queuedNotifications).toBe(0);
+	});
+});

--- a/packages/spaces/test/space-do.test.ts
+++ b/packages/spaces/test/space-do.test.ts
@@ -310,7 +310,12 @@ describe("SpaceDurableObject", () => {
 		expect(await stub.rpcIsMember("did:web:bob.test")).toBe(false);
 
 		const hash = new Uint8Array(32).fill(7);
-		await stub.rpcRecordWriter("did:web:bob.test", "3kzzzzzzzzzzz", hash);
+		const first = await stub.rpcRecordWriter(
+			"did:web:bob.test",
+			"3kzzzzzzzzzzz",
+			hash,
+		);
+		expect(first.advanced).toBe(true);
 		const writers = await stub.rpcListWriters({ limit: 10 });
 		expect(writers.repos).toHaveLength(1);
 		expect(writers.repos[0]).toMatchObject({
@@ -318,6 +323,35 @@ describe("SpaceDurableObject", () => {
 			rev: "3kzzzzzzzzzzz",
 		});
 		expect(new Uint8Array(writers.repos[0]!.hash)).toEqual(hash);
+
+		// A delayed or replayed notification with an older rev never rolls
+		// the writer set backwards, and reports that nothing advanced.
+		const staleHash = new Uint8Array(32).fill(9);
+		const stale = await stub.rpcRecordWriter(
+			"did:web:bob.test",
+			"3kaaaaaaaaaaa",
+			staleHash,
+		);
+		expect(stale.advanced).toBe(false);
+		const equal = await stub.rpcRecordWriter(
+			"did:web:bob.test",
+			"3kzzzzzzzzzzz",
+			staleHash,
+		);
+		expect(equal.advanced).toBe(false);
+		const unchanged = await stub.rpcListWriters({ limit: 10 });
+		expect(unchanged.repos[0]).toMatchObject({ rev: "3kzzzzzzzzzzz" });
+		expect(new Uint8Array(unchanged.repos[0]!.hash)).toEqual(hash);
+
+		// A newer rev advances again.
+		const newer = await stub.rpcRecordWriter(
+			"did:web:bob.test",
+			"3lzzzzzzzzzzz",
+			staleHash,
+		);
+		expect(newer.advanced).toBe(true);
+		const advancedState = await stub.rpcListWriters({ limit: 10 });
+		expect(advancedState.repos[0]).toMatchObject({ rev: "3lzzzzzzzzzzz" });
 
 		const reg = await stub.rpcRegisterNotify(
 			"did:web:syncer.test",

--- a/packages/spaces/test/space-uri.test.ts
+++ b/packages/spaces/test/space-uri.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatSpaceUri,
+	parseSpaceUri,
+	requireSpaceUri,
+	spaceId,
+	spaceRecordUri,
+} from "../src/space-uri";
+import { spaceBlobKey, spaceBlobPrefix } from "../src/blob-keys";
+import { SpaceError } from "../src/errors";
+import { nextRev, tidCutoff } from "../src/tid";
+
+const AUTHORITY = "did:web:alice.test";
+const URI = `at://${AUTHORITY}/space/app.bsky.group/3kbcq3p7ad400`;
+
+describe("parseSpaceUri", () => {
+	it("parses a valid space URI", () => {
+		const ref = parseSpaceUri(URI);
+		expect(ref).toEqual({
+			uri: URI,
+			authority: AUTHORITY,
+			type: "app.bsky.group",
+			skey: "3kbcq3p7ad400",
+		});
+	});
+
+	it("round-trips through formatSpaceUri", () => {
+		expect(formatSpaceUri(AUTHORITY, "app.bsky.group", "3kbcq3p7ad400")).toBe(
+			URI,
+		);
+	});
+
+	it("rejects non-space URIs", () => {
+		expect(parseSpaceUri("at://did:web:a.test/app.bsky.feed.post/abc")).toBe(
+			null,
+		);
+		expect(parseSpaceUri("https://example.com")).toBe(null);
+		expect(parseSpaceUri("at://did:web:a.test/space/app.bsky.group")).toBe(
+			null,
+		);
+		expect(
+			parseSpaceUri("at://did:web:a.test/space/app.bsky.group/a/b"),
+		).toBe(null);
+		expect(parseSpaceUri("at://notadid/space/app.bsky.group/abc")).toBe(null);
+		expect(parseSpaceUri("at://did:web:a.test/space/notansid/abc")).toBe(null);
+	});
+
+	it("requireSpaceUri throws InvalidSpaceUri", () => {
+		expect(() => requireSpaceUri("nope")).toThrow(SpaceError);
+		expect(() => requireSpaceUri(undefined)).toThrow(/InvalidSpaceUri/);
+	});
+});
+
+describe("spaceRecordUri", () => {
+	it("appends repo, collection and rkey to the space URI", () => {
+		expect(
+			spaceRecordUri(URI, "did:web:bob.test", "app.bsky.feed.post", "3kabc"),
+		).toBe(`${URI}/did:web:bob.test/app.bsky.feed.post/3kabc`);
+	});
+});
+
+describe("spaceId", () => {
+	it("is deterministic, lowercase base32 of sha-256", async () => {
+		const a = await spaceId(URI);
+		const b = await spaceId(URI);
+		expect(a).toBe(b);
+		expect(a).toMatch(/^[a-z2-7]{52}$/);
+		expect(await spaceId(`${URI}x`)).not.toBe(a);
+	});
+
+	it("feeds R2 key helpers", async () => {
+		const id = await spaceId(URI);
+		expect(spaceBlobPrefix("did:web:op.test", id)).toBe(
+			`did:web:op.test/space/${id}/`,
+		);
+		expect(spaceBlobKey("did:web:op.test", id, "bafcid")).toBe(
+			`did:web:op.test/space/${id}/bafcid`,
+		);
+	});
+});
+
+describe("nextRev", () => {
+	it("returns a fresh TID when there is no previous rev", () => {
+		expect(nextRev(null)).toMatch(/^[2-7a-z]{13}$/);
+	});
+
+	it("is strictly greater than the previous rev", () => {
+		let rev = nextRev(null);
+		for (let i = 0; i < 100; i++) {
+			const next = nextRev(rev);
+			expect(next > rev).toBe(true);
+			rev = next;
+		}
+	});
+
+	it("increments past a future previous rev", () => {
+		const future = "zzzzzzzzzzzzy";
+		expect(nextRev(future) > future).toBe(true);
+	});
+});
+
+describe("tidCutoff", () => {
+	it("is a valid TID below the current clock", () => {
+		const cutoff = tidCutoff(1000 * 60);
+		const now = nextRev(null);
+		expect(cutoff).toMatch(/^[2-7a-z]{13}$/);
+		expect(cutoff < now).toBe(true);
+	});
+
+	it("orders by age", () => {
+		expect(tidCutoff(60_000) > tidCutoff(120_000)).toBe(true);
+	});
+});

--- a/packages/spaces/test/tsconfig.json
+++ b/packages/spaces/test/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"moduleResolution": "bundler",
+		"types": [
+			"@cloudflare/workers-types",
+			"@cloudflare/vitest-pool-workers",
+			"@cloudflare/vitest-pool-workers/types"
+		]
+	},
+	"include": [
+		"./**/*.ts",
+		"../src/**/*.ts",
+		"./fixtures/spaces-worker/worker-configuration.d.ts"
+	]
+}

--- a/packages/spaces/tsconfig.json
+++ b/packages/spaces/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"moduleResolution": "bundler",
+		"types": ["@cloudflare/workers-types"]
+	},
+	"include": ["src"]
+}

--- a/packages/spaces/tsdown.config.ts
+++ b/packages/spaces/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig([
+	{
+		entry: { index: "src/index.ts" },
+		format: ["esm"],
+		fixedExtension: false,
+		dts: true,
+		external: [/^cloudflare:/],
+	},
+]);

--- a/packages/spaces/vitest.config.ts
+++ b/packages/spaces/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+
+export default defineConfig({
+	plugins: [
+		cloudflareTest({
+			wrangler: { configPath: "./test/fixtures/spaces-worker/wrangler.jsonc" },
+		}),
+	],
+	resolve: {
+		conditions: ["worker", "browser", "node", "require"],
+		alias: {
+			pino: "pino/browser.js",
+		},
+	},
+	test: {
+		globals: true,
+		maxWorkers: 1,
+		isolate: false,
+		exclude: ["node_modules/**"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     devDependencies:
       '@changesets/changelog-github':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^0.5.2
+        version: 0.5.2
       '@changesets/cli':
-        specifier: ^3.0.1
-        version: 3.0.1
+        specifier: ^2.29.8
+        version: 2.29.8(@types/node@24.10.11)
       '@types/node':
         specifier: ^24.10.4
         version: 24.10.11
@@ -28,7 +28,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.0-beta.1
-        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   apps/check:
     dependencies:
@@ -77,7 +77,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.3.0(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -86,10 +86,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.0.14
-        version: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
       vite-plugin-solid:
         specifier: ^2.11.12
-        version: 2.11.12(solid-js@1.9.13)(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 2.11.12(solid-js@1.9.13)(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
       wrangler:
         specifier: ^4.94.0
         version: 4.94.0(@cloudflare/workers-types@4.20260524.1)
@@ -102,10 +102,10 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.17.0
-        version: 1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))
+        version: 1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))
       vite:
         specifier: ^6.4.1
-        version: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       wrangler:
         specifier: ^4.93.0
         version: 4.94.0(@cloudflare/workers-types@4.20260524.1)
@@ -114,10 +114,10 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.39.2
-        version: 0.39.2(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)(yaml@2.9.0))(typescript@6.0.3)
+        version: 0.39.2(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0))(typescript@6.0.3)
       astro:
         specifier: ^6.3.1
-        version: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)
       hls.js:
         specifier: ^1.6.16
         version: 1.6.16
@@ -194,7 +194,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.0-beta.1
-        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   packages/pds:
     dependencies:
@@ -276,10 +276,10 @@ importers:
         version: 0.18.20
       '@cloudflare/vite-plugin':
         specifier: ^1.17.0
-        version: 1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))
+        version: 1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.16.9
-        version: 0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       '@cloudflare/workers-types':
         specifier: ^4.20260524.1
         version: 4.20260524.1
@@ -306,16 +306,74 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.1
-        version: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
         specifier: 4.1.0-beta.1
-        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       wrangler:
         specifier: ^4.93.0
         version: 4.94.0(@cloudflare/workers-types@4.20260524.1)
       ws:
         specifier: ^8.18.3
         version: 8.19.0
+
+  packages/spaces:
+    dependencies:
+      '@atcute/cid':
+        specifier: ^2.3.0
+        version: 2.4.1
+      '@atcute/lexicons':
+        specifier: ^1.2.6
+        version: 1.3.0
+      '@atcute/tid':
+        specifier: ^1.1.1
+        version: 1.1.1
+      '@atproto/crypto':
+        specifier: ^0.4.5
+        version: 0.4.5
+      '@atproto/lex-cbor':
+        specifier: ^0.1.6
+        version: 0.1.6
+      '@atproto/lex-data':
+        specifier: ^0.1.7
+        version: 0.1.7
+      '@atproto/lex-json':
+        specifier: ^0.0.11
+        version: 0.0.11
+      '@atproto/space':
+        specifier: 0.0.0-spaces-alpha-20260818163953
+        version: 0.0.0-spaces-alpha-20260818163953
+      hono:
+        specifier: ^4.11.3
+        version: 4.11.8
+    devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.18.2
+        version: 0.18.2
+      '@atproto/jwk-jose':
+        specifier: ^0.2.1
+        version: 0.2.4
+      '@cloudflare/vitest-pool-workers':
+        specifier: ^0.16.9
+        version: 0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@cloudflare/workers-types':
+        specifier: ^4.20260524.1
+        version: 4.20260524.1
+      publint:
+        specifier: ^0.3.16
+        version: 0.3.17
+      tsdown:
+        specifier: ^0.18.3
+        version: 0.18.4(@arethetypeswrong/core@0.18.2)(oxc-resolver@11.17.0)(publint@0.3.17)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.0-beta.1
+        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      wrangler:
+        specifier: ^4.93.0
+        version: 4.94.0(@cloudflare/workers-types@4.20260524.1)
 
 packages:
 
@@ -510,12 +568,24 @@ packages:
   '@atproto/api@0.18.20':
     resolution: {integrity: sha512-BZYZkh2VJIFCXEnc/vzKwAwWjAQQTgbNJ8FBxpBK+z+KYh99O0uPCsRYKoCQsRrnkgrhzdU9+g2G+7zanTIGbw==}
 
+  '@atproto/common-web@0.0.0-spaces-alpha-20260818163953':
+    resolution: {integrity: sha512-9D7IJ5HAsQxFWibfL1+F26envBEoDR24e1q8diXrA8LfzVoRLP3zUlPWDG02zaumxgAPIIO5Yr5yuhzHYusEUg==}
+    engines: {node: '>=22'}
+
   '@atproto/common-web@0.4.16':
     resolution: {integrity: sha512-Ufvaff5JgxUyUyTAG0/3o7ltpy3lnZ1DvLjyAnvAf+hHfiK7OMQg+8byr+orN+KP9MtIQaRTsCgYPX+PxMKUoA==}
+
+  '@atproto/common@0.0.0-spaces-alpha-20260818163953':
+    resolution: {integrity: sha512-lzXomMvIHMFbmXPpsnuNUok4yZB4E67FJyNL/D3RVqxzL+OgkyPilsOYPIVzCRLZFzrVdy8Lah7kfLdxaHptgQ==}
+    engines: {node: '>=22'}
 
   '@atproto/common@0.5.11':
     resolution: {integrity: sha512-WRlT4s+wv80WdQuzkQub9D5vTD82O8dH2p91u4b+x3O17q5IQbmA3Lj+1NICINNSy2voqloqAWdqXEkRfdlAPw==}
     engines: {node: '>=18.7.0'}
+
+  '@atproto/crypto@0.0.0-spaces-alpha-20260818163953':
+    resolution: {integrity: sha512-Cjqoa3BKUFaqkdZkiZy+aQJTPxFGFv0yNmbsF21zh+gK3Hvkjdgxg7TjlaFasLIy6RKY1k9weD3SztVKKMoZzw==}
+    engines: {node: '>=22'}
 
   '@atproto/crypto@0.4.5':
     resolution: {integrity: sha512-n40aKkMoCatP0u9Yvhrdk6fXyOHFDDbkdm4h4HCyWW+KlKl8iXfD5iV+ECq+w5BM+QH25aIpt3/j6EUNerhLxw==}
@@ -528,8 +598,16 @@ packages:
     resolution: {integrity: sha512-BlnwQ+obL+4ZA71KH/EzZ3TY+cpSxnLiUI85mjBJIQwvDF/oN2sQA18wIj9jpduviIt2b/cMtlJuzHjzBkfXvw==}
     engines: {node: '>=22'}
 
+  '@atproto/jwk-jose@0.2.4':
+    resolution: {integrity: sha512-gzDoA0JTwnc0ZJOBLM7WX9xFxtynRS2K1Bofb8epzoMWDQvyvfbPcfkdPrKFM7NXCFUVpGpBnsCB8KFPTf1rCg==}
+    engines: {node: '>=22'}
+
   '@atproto/jwk@0.6.0':
     resolution: {integrity: sha512-bDoJPvt7TrQVi/rBfBrSSpGykhtIriKxeYCYQTiPRKFfyRhbgpElF0wPXADjIswnbzZdOwbY63az4E/CFVT3Tw==}
+
+  '@atproto/jwk@0.7.4':
+    resolution: {integrity: sha512-tq7TUDmNfe1yDfpRgdGQMJdl9TUlJmREQNCag9yg5w8Evu+TOiFiLgiOCbo7X4ouRPSgd1DpOzXbUa8UyKKMZA==}
+    engines: {node: '>=22'}
 
   '@atproto/lex-cbor@0.0.11':
     resolution: {integrity: sha512-A7ETtPsEsJ/VuPJOFw4bPNTKxHvFN1JbTQ2NjLuisd3ry7fVxgMpo/qGXsUQsAh/I/uziGbhpNqdS6GnI2p/Wg==}
@@ -537,14 +615,26 @@ packages:
   '@atproto/lex-cbor@0.0.3':
     resolution: {integrity: sha512-N8lCV3kK5ZcjSOWxKLWqzlnaSpK4isjXRZ0EqApl/5y9KB64s78hQ/U3KIE5qnPRlBbW5kSH3YACoU27u9nTOA==}
 
+  '@atproto/lex-cbor@0.1.6':
+    resolution: {integrity: sha512-PxLQy7jzV8u9zTGURNF8ZczLPk+ZH+WNx/2z/z7RacJbu7sWNpx26U2pC7cIkWtt4jyDaruaLhssw3w3atLotA==}
+    engines: {node: '>=22'}
+
   '@atproto/lex-data@0.0.11':
     resolution: {integrity: sha512-4+KTtHdqwlhiTKA7D4SACea4jprsNpCQsNALW09wsZ6IHhCDGO5tr1cmV+QnLYe3G3mu1E1yXHXbPUHrUUDT/A==}
 
   '@atproto/lex-data@0.0.3':
     resolution: {integrity: sha512-ivo1IpY/EX+RIpxPgCf4cPhQo5bfu4nrpa1vJCt8hCm9SfoonJkDFGa0n4SMw4JnXZoUcGcrJ46L+D8bH6GI2g==}
 
+  '@atproto/lex-data@0.1.7':
+    resolution: {integrity: sha512-kW/dPLqo/WgCLV+XESR4JKwV6c1rZWJGOfuPupZGTjEDAKoBbKXdaEzX9/1vKQYbZ9U3j0DS/n7OFFK7wBugyQ==}
+    engines: {node: '>=22'}
+
   '@atproto/lex-json@0.0.11':
     resolution: {integrity: sha512-2IExAoQ4KsR5fyPa1JjIvtR316PvdgRH/l3BVGLBd3cSxM3m5MftIv1B6qZ9HjNiK60SgkWp0mi9574bTNDhBQ==}
+
+  '@atproto/lex-json@0.1.6':
+    resolution: {integrity: sha512-mvrAd0lbyuecIHjyld8QN6MN6CBf4j0GCxLzegsvLh0SvDf+GbYWklkcQqmITL44yFQOwmA/QNIQj0Uvh7+R/g==}
+    engines: {node: '>=22'}
 
   '@atproto/lexicon@0.6.1':
     resolution: {integrity: sha512-/vI1kVlY50Si+5MXpvOucelnYwb0UJ6Qto5mCp+7Q5C+Jtp+SoSykAPVvjVtTnQUH2vrKOFOwpb3C375vSKzXw==}
@@ -559,6 +649,10 @@ packages:
   '@atproto/repo@0.8.12':
     resolution: {integrity: sha512-QpVTVulgfz5PUiCTELlDBiRvnsnwrFWi+6CfY88VwXzrRHd9NE8GItK7sfxQ6U65vD/idH8ddCgFrlrsn1REPQ==}
     engines: {node: '>=18.7.0'}
+
+  '@atproto/space@0.0.0-spaces-alpha-20260818163953':
+    resolution: {integrity: sha512-0TQwGc7tD+ctccBD7ZD52BJ8RKUKR7hN2MtzDztJbTJSLIY4GYdr6XTnwdlsJBfDBvIqhpFp/9oHdELZLecuyw==}
+    engines: {node: '>=22'}
 
   '@atproto/syntax@0.0.0-spaces-alpha-20260818163953':
     resolution: {integrity: sha512-Xl2fpD/NcfVOWpHR86HKym2XNDYHmgiqThZXoYMwh9XUo+/LgVZYGVpSecfKRBcQ5tNGiRivE1Fvio5YDfJ3lA==}
@@ -647,6 +741,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -670,74 +768,66 @@ packages:
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
 
-  '@changesets/apply-release-plan@8.0.0':
-    resolution: {integrity: sha512-kUd2pbf1w5/AYmBMb0Tt+rkIPCjFJdT0SZMrkOjJT/WV/QbtmvkyB5jkV0oaNPheavprZk+SfUiozUti7TIL2w==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/apply-release-plan@7.0.14':
+    resolution: {integrity: sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==}
 
-  '@changesets/assemble-release-plan@7.0.0':
-    resolution: {integrity: sha512-oEW8BxdA604kGGtDSCiHr5w9Tv4UWe9I2k61IBNZzCOE1kbYaJj4v+lFQNgcEZFkUc2pV/+hASErGDvpJOZCTg==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/assemble-release-plan@6.0.9':
+    resolution: {integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==}
 
-  '@changesets/changelog-git@1.0.0':
-    resolution: {integrity: sha512-3Dst2Ime2Op5nd4XmWJLPIgp11ZFqJqSkVug9izK6TDcIV4YlhPS4ECbEVR+eGI0bk0r1ItogD4j2Oli87bJrA==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/changelog-git@0.2.1':
+    resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/changelog-github@1.0.0':
-    resolution: {integrity: sha512-PNCSH5CGJrqOKxRjrMp2NLhceQv2QBs6HkjrLvYQqsEE2/ItN5R8GD/mskZZluoNWYvjPYFsY9T6swXfp5E0UA==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/changelog-github@0.5.2':
+    resolution: {integrity: sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==}
 
-  '@changesets/cli@3.0.1':
-    resolution: {integrity: sha512-3IVpRSgiKDj2aRbBHKtWTXSRH2/iR3bWxau9iQUoEsZjDhRIj9nhl90k7FWMxZAJvLgJBbgMq8+qS0xQsenYsQ==}
-    engines: {node: ^22.11 || ^24 || >=26, npm: '>=10.9.0', pnpm: '>=10.0.0', yarn: '>=4.5.2'}
+  '@changesets/cli@2.29.8':
+    resolution: {integrity: sha512-1weuGZpP63YWUYjay/E84qqwcnt5yJMM0tep10Up7Q5cS/DGe2IZ0Uj3HNMxGhCINZuR7aO9WBMdKnPit5ZDPA==}
     hasBin: true
 
-  '@changesets/config@4.0.0':
-    resolution: {integrity: sha512-mw95/YrkOuhZZxfnVAA4bSXOFUi+KlhzOBTM8C4x777NhUU6HWIl9Z+K+nME+E4PVsv5NQVQwTfiHihAS1A/ow==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/config@3.1.2':
+    resolution: {integrity: sha512-CYiRhA4bWKemdYi/uwImjPxqWNpqGPNbEBdX1BdONALFIDK7MCUj6FPkzD+z9gJcvDFUQJn9aDVf4UG7OT6Kog==}
 
-  '@changesets/errors@1.0.0':
-    resolution: {integrity: sha512-ElN/mEzn6zmETgjwf5MclCMa9ef59sAR0lfO8VSYIsiRvbC2FbLB/92EoYw10Sl0kGixxHFiJZUSv7dA+YpR8g==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/errors@0.2.0':
+    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
 
-  '@changesets/format@0.1.2':
-    resolution: {integrity: sha512-Caez5XtNXCFS/G5bwyav3wuXL0tMxVd2ZGbaumWbzN08tyzO21asCw7JZhNtVsAZDCvDRUzZN+Iit9SyRITSYA==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/get-dependents-graph@2.1.3':
+    resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
 
-  '@changesets/get-dependents-graph@3.0.0':
-    resolution: {integrity: sha512-ji/t5wFA1zREKXRUePE6Qi+Qu2UgxCeSSGQrphezwvQZrp49B7sJ+8+wvM0tA7zPeSxYKCojDy3WWgrl+s+awg==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/get-github-info@0.7.0':
+    resolution: {integrity: sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==}
 
-  '@changesets/get-github-info@1.0.0':
-    resolution: {integrity: sha512-nf5zPSqEKW0eXiJ4ltbjyIQ/srUHfxbghkLCjKdOLI3LehKXhiqxXcpja39eGPaj6qqGx2lFCrLJ7VWYUf9H2w==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/get-release-plan@4.0.14':
+    resolution: {integrity: sha512-yjZMHpUHgl4Xl5gRlolVuxDkm4HgSJqT93Ri1Uz8kGrQb+5iJ8dkXJ20M2j/Y4iV5QzS2c5SeTxVSKX+2eMI0g==}
 
-  '@changesets/git@4.0.0':
-    resolution: {integrity: sha512-uIEswpPUgzBBqrC0qg13byNaPorzhf05LE2T+gRizEKCXvMsJC6NPJp5iNDSV/gYj4Viqh09UiOF5E7XWeH5lQ==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/get-version-range-type@0.4.0':
+    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
 
-  '@changesets/parse@1.0.0':
-    resolution: {integrity: sha512-P0iaMb9p9CRYZiTgAllEIF9AUMQHIy1G72tKlcIqJp61icZSsKQNiOPdxAMZG8m/DvZwt/oz5xEbTpike//dWg==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/git@3.0.4':
+    resolution: {integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==}
 
-  '@changesets/pre@3.0.0':
-    resolution: {integrity: sha512-Zm/6YliV/a2oeWTqHJf6KxLrQwgcK1i/BRDl2m0EKZvbnxV5fG9QRhwJJGshjsZTUTS6dkfURQ2K6aAvgNw/3Q==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/logger@0.1.1':
+    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
 
-  '@changesets/read@1.0.0':
-    resolution: {integrity: sha512-8TdE2PwG6yArPt5Ozej83Z6iHz1G8BDBKvIEKZ455MccR4K3GNbLR2XqjBxa+5yLFnEd3xAOPXYboBg1pt8stQ==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/parse@0.4.2':
+    resolution: {integrity: sha512-Uo5MC5mfg4OM0jU3up66fmSn6/NE9INK+8/Vn/7sMVcdWg46zfbvvUSjD9EMonVqPi9fbrJH9SXHn48Tr1f2yA==}
 
-  '@changesets/should-skip-package@1.0.0':
-    resolution: {integrity: sha512-pwqoJmbONn1XgXmZXPEExgAaT+HdZLjALFTDgIm+PnS5KeO2nLtzA2/Q+4aMFY14kFMuXKG30MObhvDzWgzDgg==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/pre@2.0.2':
+    resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
 
-  '@changesets/types@7.0.0':
-    resolution: {integrity: sha512-c5GoiQyt3pxiXjrWSNoP8/GRf4kG+VnKzovx1OQM8dYYALlSwgedmkPmJ+ZqGxqwg9D3Bkj85Uo4KLd5BN3A0w==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/read@0.6.6':
+    resolution: {integrity: sha512-P5QaN9hJSQQKJShzzpBT13FzOSPyHbqdoIBUd2DJdgvnECCyO6LmAOWSV+O8se2TaZJVwSXjL+v9yhb+a9JeJg==}
 
-  '@changesets/write@1.0.1':
-    resolution: {integrity: sha512-q/ThtP9gcnEP6xlv7LrY26C2mHqdGBti/MmOVngt/M/oIGYkssmQGxPK9WzBNt2juVcH/vml2WQ+ra8LXYOTaA==}
-    engines: {node: ^22.11 || ^24 || >=26}
+  '@changesets/should-skip-package@0.1.2':
+    resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
+
+  '@changesets/types@4.1.0':
+    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+
+  '@changesets/types@6.1.0':
+    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
+
+  '@changesets/write@0.4.0':
+    resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
@@ -746,19 +836,11 @@ packages:
     resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
     engines: {node: '>= 20.12.0'}
 
-  '@clack/core@1.4.3':
-    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
-    engines: {node: '>= 20.12.0'}
-
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@clack/prompts@1.4.0':
     resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
-    engines: {node: '>= 20.12.0'}
-
-  '@clack/prompts@1.7.0':
-    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
   '@cloudflare/kv-asset-handler@0.5.0':
@@ -1356,6 +1438,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@ipld/car@5.4.2':
     resolution: {integrity: sha512-gfyrJvePyXnh2Fbj8mPg4JYvEZ3izhk8C9WgAle7xIYbrJNSXmNQ6BxAls8Gof97vvGbCROdxbTWRmHJtTCbcg==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
@@ -1399,17 +1490,11 @@ packages:
   '@loaderkit/resolve@1.0.4':
     resolution: {integrity: sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==}
 
-  '@manypkg/find-root@3.1.0':
-    resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
-    engines: {node: '>=20.0.0'}
+  '@manypkg/find-root@1.1.0':
+    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
-  '@manypkg/get-packages@3.1.0':
-    resolution: {integrity: sha512-0TbBVyvPrP7xGYBI/cP8UP+yl/z+HtbTttAD7FMAJgn/kXOTwh5/60TsqP9ZYY710forNfyV0N8P/IE/ujGZJg==}
-    engines: {node: '>=20.0.0'}
-
-  '@manypkg/tools@2.1.2':
-    resolution: {integrity: sha512-6QEf6yqFbETdwGITKq57aYoPfX/3K8XFNwsAlx0C1M7o8cb79sv1M3w+tWuWvIcSbNqrLF7OD7YpZMVVz335hQ==}
-    engines: {node: '>=20.0.0'}
+  '@manypkg/get-packages@1.1.3':
+    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -1633,9 +1718,8 @@ packages:
     resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
     engines: {node: '>=20.0.0'}
 
-  '@pnpm/deps.graph-sequencer@1100.0.1':
-    resolution: {integrity: sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A==}
-    engines: {node: '>=22.13'}
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -2229,6 +2313,9 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
   '@types/node@24.10.11':
     resolution: {integrity: sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==}
 
@@ -2305,6 +2392,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -2335,6 +2426,9 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2344,6 +2438,10 @@ packages:
 
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
 
   asn1js@3.0.7:
     resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
@@ -2417,6 +2515,10 @@ packages:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
+  better-path-resolve@1.0.0:
+    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
+    engines: {node: '>=4'}
+
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
@@ -2444,10 +2546,6 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
-
-  cac@7.0.0:
-    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
-    engines: {node: '>=20.19.0'}
 
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -2499,9 +2597,16 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -2574,6 +2679,10 @@ packages:
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
@@ -2610,8 +2719,8 @@ packages:
   custom-event-polyfill@1.0.7:
     resolution: {integrity: sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==}
 
-  dataloader@2.2.3:
-    resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2642,6 +2751,10 @@ packages:
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
+  detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -2659,6 +2772,10 @@ packages:
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
   direction@2.0.1:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
     hasBin: true
@@ -2675,6 +2792,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
@@ -2705,6 +2826,10 @@ packages:
   enhanced-resolve@5.22.0:
     resolution: {integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==}
     engines: {node: '>=10.13.0'}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -2754,6 +2879,11 @@ packages:
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
 
@@ -2798,6 +2928,9 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extendable-error@0.1.7:
+    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2858,6 +2991,14 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
+  fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2884,6 +3025,10 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2983,8 +3128,8 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
-  human-id@4.2.1:
-    resolution: {integrity: sha512-zPGsiS+dWoTZtZ4AtpA9Y+BdSFSNWvnouNlWNoUFyAM6xHOHmdCvqO3k8AIbdamCOv4gUFUVNPf6rJFfc4UiJw==}
+  human-id@4.1.3:
+    resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
   i18next@26.2.0:
@@ -2995,14 +3140,19 @@ packages:
       typescript:
         optional: true
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   idb-keyval@6.2.4:
     resolution: {integrity: sha512-D/NzHWUmYJGXi++z67aMSrnisb9A3621CyRK5G89JyTlN13C8xf0g04DLxUKMufPem3e3L2JAXR6Z00OWy183Q==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  import-meta-resolve@4.2.0:
-    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
 
   import-without-cache@0.2.5:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
@@ -3061,13 +3211,24 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-subdir@1.2.0:
+    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+    engines: {node: '>=4'}
+
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
     engines: {node: '>=12.13'}
 
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   iso-datestring-validator@2.2.2:
     resolution: {integrity: sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==}
@@ -3076,14 +3237,18 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  jju@1.4.0:
-    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -3102,6 +3267,9 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
@@ -3117,9 +3285,6 @@ packages:
     peerDependencies:
       '@types/node': '>=18'
       typescript: '>=5.0.4 <7'
-
-  launch-editor@2.14.1:
-    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -3197,6 +3362,9 @@ packages:
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
+
+  lodash.startcase@4.4.0:
+    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -3481,6 +3649,15 @@ packages:
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
@@ -3525,8 +3702,15 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  outdent@0.5.0:
+    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
   oxc-resolver@11.17.0:
     resolution: {integrity: sha512-R5P2Tw6th+nQJdNcZGfuppBS/sM0x1EukqYffmlfX2xXLgLGCCPwu4ruEr9Sx29mrpkHgITc130Qps2JR90NdQ==}
+
+  p-filter@2.1.0:
+    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
+    engines: {node: '>=8'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -3540,6 +3724,10 @@ packages:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
 
+  p-map@2.1.0:
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+    engines: {node: '>=6'}
+
   p-queue@9.3.0:
     resolution: {integrity: sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==}
     engines: {node: '>=20'}
@@ -3552,11 +3740,11 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-manager-detector@0.2.11:
+    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
-
-  package-manager-detector@1.8.0:
-    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
   pagefind@1.5.2:
     resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
@@ -3584,8 +3772,16 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3608,11 +3804,25 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
+
   pino-abstract-transport@1.2.0:
     resolution: {integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
   pino-std-serializers@6.2.2:
     resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
 
   pino@8.21.0:
     resolution: {integrity: sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==}
@@ -3643,6 +3853,11 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
@@ -3654,6 +3869,9 @@ packages:
 
   process-warning@3.0.0:
     resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
+
+  process-warning@5.1.0:
+    resolution: {integrity: sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw==}
 
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
@@ -3679,6 +3897,9 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
 
@@ -3694,6 +3915,10 @@ packages:
   rangetouch@2.0.1:
     resolution: {integrity: sha512-sln+pNSc8NGaHoLzwNBssFSf/rSYkqeBXzX1AtJlkJiUaVSJSbRAWJk+4omsXkN+EJalzkZhWQ3th1m0FpR5xA==}
 
+  read-yaml-file@1.1.0:
+    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
+    engines: {node: '>=6'}
+
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3705,6 +3930,9 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  real-require@1.0.0:
+    resolution: {integrity: sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==}
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -3781,6 +4009,10 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -3874,6 +4106,9 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -3884,11 +4119,6 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.5:
-    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3909,9 +4139,13 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
-  shell-quote@1.10.0:
-    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
-    engines: {node: '>= 0.4'}
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   shiki@4.1.0:
     resolution: {integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==}
@@ -3919,6 +4153,10 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -3930,6 +4168,10 @@ packages:
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
   smol-toml@1.6.0:
@@ -3947,6 +4189,9 @@ packages:
   sonic-boom@3.8.1:
     resolution: {integrity: sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3958,9 +4203,15 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  spawndamnit@3.0.1:
+    resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -3984,6 +4235,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
 
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
@@ -4019,6 +4274,10 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  term-size@2.2.1:
+    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -4028,6 +4287,10 @@ packages:
 
   thread-stream@2.7.0:
     resolution: {integrity: sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==}
+
+  thread-stream@4.2.0:
+    resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
+    engines: {node: '>=20'}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -4047,10 +4310,6 @@ packages:
     resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
     engines: {node: '>=18'}
 
-  tinyexec@1.3.0:
-    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
-    engines: {node: '>=18'}
-
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -4058,10 +4317,6 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
-
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
-    engines: {node: '>=14.0.0'}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -4074,6 +4329,9 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4146,6 +4404,9 @@ packages:
   uint8arrays@3.0.0:
     resolution: {integrity: sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==}
 
+  uint8arrays@5.1.1:
+    resolution: {integrity: sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==}
+
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
 
@@ -4211,6 +4472,10 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
 
   unrun@0.2.27:
     resolution: {integrity: sha512-Mmur1UJpIbfxasLOhPRvox/QS4xBiDii71hMP7smfRthGcwFL2OAmYRgduLANOAU4LUkvVamuP+02U+c90jlrw==}
@@ -4502,12 +4767,23 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -4590,11 +4866,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yaml@2.9.0:
-    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
 
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
@@ -4692,12 +4963,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.6(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@astrojs/mdx@5.0.6(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.2
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)(yaml@2.9.0)
+      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -4721,17 +4992,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)(yaml@2.9.0))(typescript@6.0.3)':
+  '@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0))(typescript@6.0.3)':
     dependencies:
       '@astrojs/markdown-remark': 7.1.2
-      '@astrojs/mdx': 5.0.6(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@astrojs/mdx': 5.0.6(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)(yaml@2.9.0)
-      astro-expressive-code: 0.42.0(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)(yaml@2.9.0))
+      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)
+      astro-expressive-code: 0.42.0(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -5011,12 +5282,28 @@ snapshots:
       tlds: 1.261.0
       zod: 3.25.76
 
+  '@atproto/common-web@0.0.0-spaces-alpha-20260818163953':
+    dependencies:
+      '@atproto/lex-data': 0.1.7
+      '@atproto/lex-json': 0.1.6
+      '@atproto/syntax': 0.0.0-spaces-alpha-20260818163953
+      zod: 3.25.76
+
   '@atproto/common-web@0.4.16':
     dependencies:
       '@atproto/lex-data': 0.0.11
       '@atproto/lex-json': 0.0.11
       '@atproto/syntax': 0.4.3
       zod: 3.25.76
+
+  '@atproto/common@0.0.0-spaces-alpha-20260818163953':
+    dependencies:
+      '@atproto/common-web': 0.0.0-spaces-alpha-20260818163953
+      '@atproto/lex-cbor': 0.1.6
+      '@atproto/lex-data': 0.1.7
+      multiformats: 13.4.2
+      pino: 10.3.1
+      varint: 6.0.0
 
   '@atproto/common@0.5.11':
     dependencies:
@@ -5026,6 +5313,12 @@ snapshots:
       iso-datestring-validator: 2.2.2
       multiformats: 9.9.0
       pino: 8.21.0
+
+  '@atproto/crypto@0.0.0-spaces-alpha-20260818163953':
+    dependencies:
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      uint8arrays: 5.1.1
 
   '@atproto/crypto@0.4.5':
     dependencies:
@@ -5041,9 +5334,19 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  '@atproto/jwk-jose@0.2.4':
+    dependencies:
+      '@atproto/jwk': 0.7.4
+      jose: 5.10.0
+
   '@atproto/jwk@0.6.0':
     dependencies:
       multiformats: 9.9.0
+      zod: 3.25.76
+
+  '@atproto/jwk@0.7.4':
+    dependencies:
+      multiformats: 13.4.2
       zod: 3.25.76
 
   '@atproto/lex-cbor@0.0.11':
@@ -5055,6 +5358,12 @@ snapshots:
     dependencies:
       '@atproto/lex-data': 0.0.3
       multiformats: 9.9.0
+      tslib: 2.8.1
+
+  '@atproto/lex-cbor@0.1.6':
+    dependencies:
+      '@atproto/lex-data': 0.1.7
+      cborg: 4.5.8
       tslib: 2.8.1
 
   '@atproto/lex-data@0.0.11':
@@ -5072,9 +5381,20 @@ snapshots:
       uint8arrays: 3.0.0
       unicode-segmenter: 0.14.5
 
+  '@atproto/lex-data@0.1.7':
+    dependencies:
+      multiformats: 13.4.2
+      tslib: 2.8.1
+      unicode-segmenter: 0.14.5
+
   '@atproto/lex-json@0.0.11':
     dependencies:
       '@atproto/lex-data': 0.0.11
+      tslib: 2.8.1
+
+  '@atproto/lex-json@0.1.6':
+    dependencies:
+      '@atproto/lex-data': 0.1.7
       tslib: 2.8.1
 
   '@atproto/lexicon@0.6.1':
@@ -5106,6 +5426,17 @@ snapshots:
       multiformats: 9.9.0
       uint8arrays: 3.0.0
       varint: 6.0.0
+      zod: 3.25.76
+
+  '@atproto/space@0.0.0-spaces-alpha-20260818163953':
+    dependencies:
+      '@atproto/common': 0.0.0-spaces-alpha-20260818163953
+      '@atproto/crypto': 0.0.0-spaces-alpha-20260818163953
+      '@atproto/jwk': 0.7.4
+      '@atproto/lex-cbor': 0.1.6
+      '@atproto/lex-data': 0.1.7
+      '@noble/hashes': 1.8.0
+      jose: 5.10.0
       zod: 3.25.76
 
   '@atproto/syntax@0.0.0-spaces-alpha-20260818163953':
@@ -5216,6 +5547,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.28.6': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -5247,118 +5580,164 @@ snapshots:
     dependencies:
       fontkitten: 1.0.3
 
-  '@changesets/apply-release-plan@8.0.0':
+  '@changesets/apply-release-plan@7.0.14':
     dependencies:
-      '@changesets/config': 4.0.0
-      '@changesets/format': 0.1.2
-      '@changesets/git': 4.0.0
-      '@changesets/should-skip-package': 1.0.0
-      '@changesets/types': 7.0.0
-      import-meta-resolve: 4.2.0
-      jsonc-parser: 3.3.1
-      semver: 7.8.5
+      '@changesets/config': 3.1.2
+      '@changesets/get-version-range-type': 0.4.0
+      '@changesets/git': 3.0.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      detect-indent: 6.1.0
+      fs-extra: 7.0.1
+      lodash.startcase: 4.4.0
+      outdent: 0.5.0
+      prettier: 2.8.8
+      resolve-from: 5.0.0
+      semver: 7.7.4
 
-  '@changesets/assemble-release-plan@7.0.0':
+  '@changesets/assemble-release-plan@6.0.9':
     dependencies:
-      '@changesets/errors': 1.0.0
-      '@changesets/get-dependents-graph': 3.0.0
-      '@changesets/should-skip-package': 1.0.0
-      '@changesets/types': 7.0.0
-      semver: 7.8.5
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      semver: 7.7.4
 
-  '@changesets/changelog-git@1.0.0':
+  '@changesets/changelog-git@0.2.1':
     dependencies:
-      '@changesets/types': 7.0.0
+      '@changesets/types': 6.1.0
 
-  '@changesets/changelog-github@1.0.0':
+  '@changesets/changelog-github@0.5.2':
     dependencies:
-      '@changesets/get-github-info': 1.0.0
-      '@changesets/types': 7.0.0
+      '@changesets/get-github-info': 0.7.0
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
 
-  '@changesets/cli@3.0.1':
+  '@changesets/cli@2.29.8(@types/node@24.10.11)':
     dependencies:
-      '@changesets/apply-release-plan': 8.0.0
-      '@changesets/assemble-release-plan': 7.0.0
-      '@changesets/changelog-git': 1.0.0
-      '@changesets/config': 4.0.0
-      '@changesets/errors': 1.0.0
-      '@changesets/get-dependents-graph': 3.0.0
-      '@changesets/git': 4.0.0
-      '@changesets/pre': 3.0.0
-      '@changesets/read': 1.0.0
-      '@changesets/should-skip-package': 1.0.0
-      '@changesets/types': 7.0.0
-      '@changesets/write': 1.0.1
-      '@clack/prompts': 1.7.0
-      '@manypkg/get-packages': 3.1.0
-      '@pnpm/deps.graph-sequencer': 1100.0.1
-      cac: 7.0.0
-      import-meta-resolve: 4.2.0
-      launch-editor: 2.14.1
-      package-manager-detector: 1.6.0
-      semver: 7.8.5
-      tinyexec: 1.3.0
+      '@changesets/apply-release-plan': 7.0.14
+      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/changelog-git': 0.2.1
+      '@changesets/config': 3.1.2
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/get-release-plan': 4.0.14
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.6
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@changesets/write': 0.4.0
+      '@inquirer/external-editor': 1.0.3(@types/node@24.10.11)
+      '@manypkg/get-packages': 1.1.3
+      ansi-colors: 4.1.3
+      ci-info: 3.9.0
+      enquirer: 2.4.1
+      fs-extra: 7.0.1
+      mri: 1.2.0
+      p-limit: 2.3.0
+      package-manager-detector: 0.2.11
+      picocolors: 1.1.1
+      resolve-from: 5.0.0
+      semver: 7.7.4
+      spawndamnit: 3.0.1
+      term-size: 2.2.1
+    transitivePeerDependencies:
+      - '@types/node'
 
-  '@changesets/config@4.0.0':
+  '@changesets/config@3.1.2':
     dependencies:
-      '@changesets/get-dependents-graph': 3.0.0
-      '@changesets/should-skip-package': 1.0.0
-      '@changesets/types': 7.0.0
-      '@manypkg/get-packages': 3.1.0
-      picomatch: 4.0.4
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.3
+      '@changesets/logger': 0.1.1
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+      micromatch: 4.0.8
 
-  '@changesets/errors@1.0.0': {}
-
-  '@changesets/format@0.1.2':
+  '@changesets/errors@0.2.0':
     dependencies:
-      package-manager-detector: 1.8.0
-      tinyexec: 1.3.0
+      extendable-error: 0.1.7
 
-  '@changesets/get-dependents-graph@3.0.0':
+  '@changesets/get-dependents-graph@2.1.3':
     dependencies:
-      '@changesets/types': 7.0.0
-      semver: 7.8.5
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      picocolors: 1.1.1
+      semver: 7.7.4
 
-  '@changesets/get-github-info@1.0.0':
+  '@changesets/get-github-info@0.7.0':
     dependencies:
-      dataloader: 2.2.3
+      dataloader: 1.4.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
-  '@changesets/git@4.0.0':
+  '@changesets/get-release-plan@4.0.14':
     dependencies:
-      '@changesets/errors': 1.0.0
-      '@changesets/types': 7.0.0
-      '@manypkg/get-packages': 3.1.0
-      picomatch: 4.0.4
-      tinyexec: 1.3.0
+      '@changesets/assemble-release-plan': 6.0.9
+      '@changesets/config': 3.1.2
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.6
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
 
-  '@changesets/parse@1.0.0':
+  '@changesets/get-version-range-type@0.4.0': {}
+
+  '@changesets/git@3.0.4':
     dependencies:
-      '@changesets/types': 7.0.0
-      yaml: 2.9.0
+      '@changesets/errors': 0.2.0
+      '@manypkg/get-packages': 1.1.3
+      is-subdir: 1.2.0
+      micromatch: 4.0.8
+      spawndamnit: 3.0.1
 
-  '@changesets/pre@3.0.0':
+  '@changesets/logger@0.1.1':
     dependencies:
-      '@changesets/errors': 1.0.0
-      '@changesets/types': 7.0.0
-      '@manypkg/get-packages': 3.1.0
+      picocolors: 1.1.1
 
-  '@changesets/read@1.0.0':
+  '@changesets/parse@0.4.2':
     dependencies:
-      '@changesets/git': 4.0.0
-      '@changesets/parse': 1.0.0
-      '@changesets/types': 7.0.0
+      '@changesets/types': 6.1.0
+      js-yaml: 4.1.1
 
-  '@changesets/should-skip-package@1.0.0':
+  '@changesets/pre@2.0.2':
     dependencies:
-      '@changesets/types': 7.0.0
+      '@changesets/errors': 0.2.0
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
 
-  '@changesets/types@7.0.0': {}
-
-  '@changesets/write@1.0.1':
+  '@changesets/read@0.6.6':
     dependencies:
-      '@changesets/format': 0.1.2
-      '@changesets/types': 7.0.0
-      human-id: 4.2.1
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/parse': 0.4.2
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      p-filter: 2.1.0
+      picocolors: 1.1.1
+
+  '@changesets/should-skip-package@0.1.2':
+    dependencies:
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/types@4.1.0': {}
+
+  '@changesets/types@6.1.0': {}
+
+  '@changesets/write@0.4.0':
+    dependencies:
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      human-id: 4.1.3
+      prettier: 2.8.8
 
   '@clack/core@0.5.0':
     dependencies:
@@ -5366,11 +5745,6 @@ snapshots:
       sisteransi: 1.0.5
 
   '@clack/core@1.3.1':
-    dependencies:
-      fast-wrap-ansi: 0.2.2
-      sisteransi: 1.0.5
-
-  '@clack/core@1.4.3':
     dependencies:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
@@ -5384,13 +5758,6 @@ snapshots:
   '@clack/prompts@1.4.0':
     dependencies:
       '@clack/core': 1.3.1
-      fast-string-width: 3.0.2
-      fast-wrap-ansi: 0.2.2
-      sisteransi: 1.0.5
-
-  '@clack/prompts@1.7.0':
-    dependencies:
-      '@clack/core': 1.4.3
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
@@ -5409,12 +5776,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260521.1
 
-  '@cloudflare/vite-plugin@1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))':
+  '@cloudflare/vite-plugin@1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.12.0(unenv@2.0.0-rc.24)(workerd@1.20260521.1)
       miniflare: 4.20260205.0
       unenv: 2.0.0-rc.24
-      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       wrangler: 4.94.0(@cloudflare/workers-types@4.20260524.1)
       ws: 8.18.0
     transitivePeerDependencies:
@@ -5422,14 +5789,14 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vitest-pool-workers@0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@cloudflare/vitest-pool-workers@0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
       cjs-module-lexer: 1.4.3
       esbuild: 0.27.3
       miniflare: 4.20260521.0
-      vitest: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       wrangler: 4.94.0(@cloudflare/workers-types@4.20260524.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -5791,6 +6158,13 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@inquirer/external-editor@1.0.3(@types/node@24.10.11)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 24.10.11
+
   '@ipld/car@5.4.2':
     dependencies:
       '@ipld/dag-cbor': 9.2.5
@@ -5850,20 +6224,21 @@ snapshots:
     dependencies:
       '@braidai/lang': 1.1.2
 
-  '@manypkg/find-root@3.1.0':
+  '@manypkg/find-root@1.1.0':
     dependencies:
-      '@manypkg/tools': 2.1.2
+      '@babel/runtime': 7.28.6
+      '@types/node': 12.20.55
+      find-up: 4.1.0
+      fs-extra: 8.1.0
 
-  '@manypkg/get-packages@3.1.0':
+  '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@manypkg/find-root': 3.1.0
-      '@manypkg/tools': 2.1.2
-
-  '@manypkg/tools@2.1.2':
-    dependencies:
-      jju: 1.4.0
-      tinyglobby: 0.2.16
-      yaml: 2.9.0
+      '@babel/runtime': 7.28.6
+      '@changesets/types': 4.1.0
+      '@manypkg/find-root': 1.1.0
+      fs-extra: 8.1.0
+      globby: 11.1.0
+      read-yaml-file: 1.1.0
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -6118,7 +6493,7 @@ snapshots:
       tslib: 2.8.1
       tsyringe: 4.10.0
 
-  '@pnpm/deps.graph-sequencer@1100.0.1': {}
+  '@pinojs/redact@0.4.0': {}
 
   '@poppinss/colors@4.1.6':
     dependencies:
@@ -6478,12 +6853,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -6550,6 +6925,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@12.20.55': {}
+
   '@types/node@24.10.11':
     dependencies:
       undici-types: 7.16.0
@@ -6579,19 +6956,19 @@ snapshots:
       '@vitest/spy': 4.1.0-beta.1
       '@vitest/utils': 4.1.0-beta.1
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0-beta.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.0-beta.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.0-beta.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.0-beta.1':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -6625,7 +7002,7 @@ snapshots:
   '@vitest/utils@4.1.0-beta.1':
     dependencies:
       '@vitest/pretty-format': 4.1.0-beta.1
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.7':
     dependencies:
@@ -6642,6 +7019,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ansi-colors@4.1.3: {}
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -6666,11 +7045,17 @@ snapshots:
 
   arg@5.0.2: {}
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  array-union@2.1.0: {}
 
   asn1js@3.0.7:
     dependencies:
@@ -6687,12 +7072,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.42.0(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)(yaml@2.9.0)):
+  astro-expressive-code@0.42.0(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)):
     dependencies:
-      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)(yaml@2.9.0)
+      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)
       rehype-expressive-code: 0.42.0
 
-  astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)(yaml@2.9.0):
+  astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.9.1
@@ -6744,8 +7129,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5(idb-keyval@6.2.4)
       vfile: 6.0.3
-      vite: 7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      vite: 7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vitefu: 1.1.3(vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -6823,6 +7208,10 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
+  better-path-resolve@1.0.0:
+    dependencies:
+      is-windows: 1.0.2
+
   birpc@4.0.0: {}
 
   blake3-wasm@2.1.5: {}
@@ -6851,8 +7240,6 @@ snapshots:
       '@types/node': 24.10.11
 
   cac@6.7.14: {}
-
-  cac@7.0.0: {}
 
   camelcase@5.3.1: {}
 
@@ -6885,9 +7272,13 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  chardet@2.1.1: {}
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  ci-info@3.9.0: {}
 
   ci-info@4.4.0: {}
 
@@ -6952,6 +7343,12 @@ snapshots:
 
   core-js@3.49.0: {}
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   crossws@0.3.5:
     dependencies:
       uncrypto: 0.1.3
@@ -6988,7 +7385,7 @@ snapshots:
 
   custom-event-polyfill@1.0.7: {}
 
-  dataloader@2.2.3: {}
+  dataloader@1.4.0: {}
 
   debug@4.4.3:
     dependencies:
@@ -7008,6 +7405,8 @@ snapshots:
 
   destr@2.0.5: {}
 
+  detect-indent@6.1.0: {}
+
   detect-libc@2.1.2: {}
 
   devalue@5.8.1: {}
@@ -7019,6 +7418,10 @@ snapshots:
   diff@8.0.4: {}
 
   dijkstrajs@1.0.3: {}
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
 
   direction@2.0.1: {}
 
@@ -7040,6 +7443,8 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dotenv@8.6.0: {}
+
   dset@3.1.4: {}
 
   dts-resolver@2.1.3(oxc-resolver@11.17.0):
@@ -7058,6 +7463,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
 
   entities@4.5.0: {}
 
@@ -7149,6 +7559,8 @@ snapshots:
 
   esm-env@1.2.2: {}
 
+  esprima@4.0.1: {}
+
   estree-util-attach-comments@3.0.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -7200,6 +7612,8 @@ snapshots:
       '@expressive-code/plugin-text-markers': 0.42.0
 
   extend@3.0.2: {}
+
+  extendable-error@0.1.7: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -7262,6 +7676,18 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
+  fs-extra@7.0.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
   fsevents@2.3.3:
     optional: true
 
@@ -7282,6 +7708,15 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
 
   graceful-fs@4.2.11: {}
 
@@ -7506,17 +7941,21 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
-  human-id@4.2.1: {}
+  human-id@4.1.3: {}
 
   i18next@26.2.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   idb-keyval@6.2.4: {}
 
   ieee754@1.2.1: {}
 
-  import-meta-resolve@4.2.0: {}
+  ignore@5.3.2: {}
 
   import-without-cache@0.2.5: {}
 
@@ -7555,21 +7994,34 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-subdir@1.2.0:
+    dependencies:
+      better-path-resolve: 1.0.0
+
   is-what@4.1.16: {}
+
+  is-windows@1.0.2: {}
 
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
+  isexe@2.0.0: {}
+
   iso-datestring-validator@2.2.2: {}
 
   jiti@2.6.1: {}
 
-  jju@1.4.0: {}
+  jose@5.10.0: {}
 
   jose@6.1.3: {}
 
   js-tokens@4.0.0: {}
+
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -7580,6 +8032,10 @@ snapshots:
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   kleur@4.1.5: {}
 
@@ -7601,11 +8057,6 @@ snapshots:
       strip-json-comments: 5.0.3
       typescript: 5.9.3
       zod: 4.3.6
-
-  launch-editor@2.14.1:
-    dependencies:
-      picocolors: 1.1.1
-      shell-quote: 1.10.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -7661,6 +8112,8 @@ snapshots:
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
+
+  lodash.startcase@4.4.0: {}
 
   longest-streak@3.1.0: {}
 
@@ -8236,6 +8689,10 @@ snapshots:
 
   node-fetch-native@1.6.7: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-gyp-build@4.8.4: {}
 
   node-mock-http@1.0.4: {}
@@ -8272,6 +8729,8 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  outdent@0.5.0: {}
+
   oxc-resolver@11.17.0:
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.17.0
@@ -8295,6 +8754,10 @@ snapshots:
       '@oxc-resolver/binding-win32-ia32-msvc': 11.17.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.17.0
 
+  p-filter@2.1.0:
+    dependencies:
+      p-map: 2.1.0
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -8307,6 +8770,8 @@ snapshots:
     dependencies:
       p-limit: 2.3.0
 
+  p-map@2.1.0: {}
+
   p-queue@9.3.0:
     dependencies:
       eventemitter3: 5.0.4
@@ -8316,9 +8781,11 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  package-manager-detector@1.6.0: {}
+  package-manager-detector@0.2.11:
+    dependencies:
+      quansync: 0.2.11
 
-  package-manager-detector@1.8.0: {}
+  package-manager-detector@1.6.0: {}
 
   pagefind@1.5.2:
     optionalDependencies:
@@ -8363,7 +8830,11 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-key@3.1.1: {}
+
   path-to-regexp@6.3.0: {}
+
+  path-type@4.0.0: {}
 
   pathe@2.0.3: {}
 
@@ -8377,12 +8848,34 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pify@4.0.1: {}
+
   pino-abstract-transport@1.2.0:
     dependencies:
       readable-stream: 4.7.0
       split2: 4.2.0
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
   pino-std-serializers@6.2.2: {}
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.1.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.2.0
 
   pino@8.21.0:
     dependencies:
@@ -8430,11 +8923,15 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prettier@2.8.8: {}
+
   prettier@3.8.1: {}
 
   prismjs@1.30.0: {}
 
   process-warning@3.0.0: {}
+
+  process-warning@5.1.0: {}
 
   process@0.11.10: {}
 
@@ -8459,6 +8956,8 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
+  quansync@0.2.11: {}
+
   quansync@1.0.0: {}
 
   queue-microtask@1.2.3: {}
@@ -8468,6 +8967,13 @@ snapshots:
   radix3@1.1.2: {}
 
   rangetouch@2.0.1: {}
+
+  read-yaml-file@1.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      js-yaml: 3.14.2
+      pify: 4.0.1
+      strip-bom: 3.0.0
 
   readable-stream@4.7.0:
     dependencies:
@@ -8480,6 +8986,8 @@ snapshots:
   readdirp@5.0.0: {}
 
   real-require@0.2.0: {}
+
+  real-require@1.0.0: {}
 
   recma-build-jsx@1.0.0:
     dependencies:
@@ -8624,6 +9132,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-main-filename@2.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -8787,13 +9297,13 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
+  safer-buffer@2.1.2: {}
+
   sax@1.6.0: {}
 
   semver@6.3.1: {}
 
   semver@7.7.4: {}
-
-  semver@7.8.5: {}
 
   seroval-plugins@1.5.4(seroval@1.5.4):
     dependencies:
@@ -8834,7 +9344,11 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
-  shell-quote@1.10.0: {}
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   shiki@4.1.0:
     dependencies:
@@ -8849,6 +9363,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   sisteransi@1.0.5: {}
 
   sitemap@9.0.1:
@@ -8861,6 +9377,8 @@ snapshots:
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
+
+  slash@3.0.0: {}
 
   smol-toml@1.6.0: {}
 
@@ -8883,13 +9401,24 @@ snapshots:
     dependencies:
       atomic-sleep: 1.0.0
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
 
+  spawndamnit@3.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   split2@4.2.0: {}
+
+  sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
 
@@ -8915,6 +9444,8 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-bom@3.0.0: {}
 
   strip-json-comments@5.0.3: {}
 
@@ -8951,6 +9482,8 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  term-size@2.2.1: {}
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -8963,6 +9496,10 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  thread-stream@4.2.0:
+    dependencies:
+      real-require: 1.0.0
+
   tiny-inflate@1.0.3: {}
 
   tinybench@2.9.0: {}
@@ -8972,8 +9509,6 @@ snapshots:
   tinyexec@1.0.2: {}
 
   tinyexec@1.2.2: {}
-
-  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -8985,8 +9520,6 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinyrainbow@3.0.3: {}
-
   tinyrainbow@3.1.0: {}
 
   tlds@1.261.0: {}
@@ -8994,6 +9527,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
 
@@ -9056,6 +9591,10 @@ snapshots:
   uint8arrays@3.0.0:
     dependencies:
       multiformats: 9.9.0
+
+  uint8arrays@5.1.1:
+    dependencies:
+      multiformats: 13.4.2
 
   ultrahtml@1.6.0: {}
 
@@ -9142,6 +9681,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  universalify@0.1.2: {}
+
   unrun@0.2.27:
     dependencies:
       rolldown: 1.0.0-rc.3
@@ -9192,7 +9733,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-solid@2.11.12(solid-js@1.9.13)(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
+  vite-plugin-solid@2.11.12(solid-js@1.9.13)(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -9200,12 +9741,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.13
       solid-refresh: 0.6.3(solid-js@1.9.13)
-      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
+      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
+      vitefu: 1.1.3(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9219,9 +9760,8 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       tsx: 4.21.0
-      yaml: 2.9.0
 
-  vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
+  vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9235,9 +9775,8 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       tsx: 4.21.0
-      yaml: 2.9.0
 
-  vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0):
+  vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -9250,20 +9789,19 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
-      yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)):
     optionalDependencies:
-      vite: 7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
-  vitefu@1.1.3(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)):
     optionalDependencies:
-      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
 
-  vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
+  vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.1.0-beta.1
-      '@vitest/mocker': 4.1.0-beta.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.0-beta.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.0-beta.1
       '@vitest/runner': 4.1.0-beta.1
       '@vitest/snapshot': 4.1.0-beta.1
@@ -9274,13 +9812,13 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.11
@@ -9301,9 +9839,20 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which-module@2.0.1: {}
 
   which-pm-runs@1.1.0: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -9369,8 +9918,6 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
-
-  yaml@2.9.0: {}
 
   yargs-parser@18.1.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     devDependencies:
       '@changesets/changelog-github':
-        specifier: ^0.5.2
-        version: 0.5.2
+        specifier: ^1.0.0
+        version: 1.0.0
       '@changesets/cli':
-        specifier: ^2.29.8
-        version: 2.29.8(@types/node@24.10.11)
+        specifier: ^3.0.1
+        version: 3.0.1
       '@types/node':
         specifier: ^24.10.4
         version: 24.10.11
@@ -28,7 +28,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.0-beta.1
-        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   apps/check:
     dependencies:
@@ -77,7 +77,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
+        version: 4.3.0(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -86,10 +86,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.0.14
-        version: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
+        version: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
       vite-plugin-solid:
         specifier: ^2.11.12
-        version: 2.11.12(solid-js@1.9.13)(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
+        version: 2.11.12(solid-js@1.9.13)(supports-color@10.2.2)(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
       wrangler:
         specifier: ^4.94.0
         version: 4.94.0(@cloudflare/workers-types@4.20260524.1)
@@ -102,10 +102,10 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.17.0
-        version: 1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))
+        version: 1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))
       vite:
         specifier: ^6.4.1
-        version: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+        version: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       wrangler:
         specifier: ^4.93.0
         version: 4.94.0(@cloudflare/workers-types@4.20260524.1)
@@ -114,10 +114,10 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.39.2
-        version: 0.39.2(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0))(typescript@6.0.3)
+        version: 0.39.2(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0))(supports-color@10.2.2)(typescript@5.9.3)
       astro:
         specifier: ^6.3.1
-        version: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)
+        version: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0)
       hls.js:
         specifier: ^1.6.16
         version: 1.6.16
@@ -194,7 +194,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.0-beta.1
-        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/pds:
     dependencies:
@@ -276,10 +276,10 @@ importers:
         version: 0.18.20
       '@cloudflare/vite-plugin':
         specifier: ^1.17.0
-        version: 1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))
+        version: 1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.16.9
-        version: 0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@cloudflare/workers-types':
         specifier: ^4.20260524.1
         version: 4.20260524.1
@@ -306,10 +306,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.1
-        version: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+        version: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 4.1.0-beta.1
-        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       wrangler:
         specifier: ^4.93.0
         version: 4.94.0(@cloudflare/workers-types@4.20260524.1)
@@ -340,7 +340,7 @@ importers:
         version: 0.18.2
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.16.9
-        version: 0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@cloudflare/workers-types':
         specifier: ^4.20260524.1
         version: 4.20260524.1
@@ -355,7 +355,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 4.1.0-beta.1
-        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+        version: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       wrangler:
         specifier: ^4.93.0
         version: 4.94.0(@cloudflare/workers-types@4.20260524.1)
@@ -722,10 +722,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -749,66 +745,74 @@ packages:
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
 
-  '@changesets/apply-release-plan@7.0.14':
-    resolution: {integrity: sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==}
+  '@changesets/apply-release-plan@8.0.0':
+    resolution: {integrity: sha512-kUd2pbf1w5/AYmBMb0Tt+rkIPCjFJdT0SZMrkOjJT/WV/QbtmvkyB5jkV0oaNPheavprZk+SfUiozUti7TIL2w==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/assemble-release-plan@6.0.9':
-    resolution: {integrity: sha512-tPgeeqCHIwNo8sypKlS3gOPmsS3wP0zHt67JDuL20P4QcXiw/O4Hl7oXiuLnP9yg+rXLQ2sScdV1Kkzde61iSQ==}
+  '@changesets/assemble-release-plan@7.0.0':
+    resolution: {integrity: sha512-oEW8BxdA604kGGtDSCiHr5w9Tv4UWe9I2k61IBNZzCOE1kbYaJj4v+lFQNgcEZFkUc2pV/+hASErGDvpJOZCTg==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/changelog-git@0.2.1':
-    resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
+  '@changesets/changelog-git@1.0.0':
+    resolution: {integrity: sha512-3Dst2Ime2Op5nd4XmWJLPIgp11ZFqJqSkVug9izK6TDcIV4YlhPS4ECbEVR+eGI0bk0r1ItogD4j2Oli87bJrA==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/changelog-github@0.5.2':
-    resolution: {integrity: sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==}
+  '@changesets/changelog-github@1.0.0':
+    resolution: {integrity: sha512-PNCSH5CGJrqOKxRjrMp2NLhceQv2QBs6HkjrLvYQqsEE2/ItN5R8GD/mskZZluoNWYvjPYFsY9T6swXfp5E0UA==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/cli@2.29.8':
-    resolution: {integrity: sha512-1weuGZpP63YWUYjay/E84qqwcnt5yJMM0tep10Up7Q5cS/DGe2IZ0Uj3HNMxGhCINZuR7aO9WBMdKnPit5ZDPA==}
+  '@changesets/cli@3.0.1':
+    resolution: {integrity: sha512-3IVpRSgiKDj2aRbBHKtWTXSRH2/iR3bWxau9iQUoEsZjDhRIj9nhl90k7FWMxZAJvLgJBbgMq8+qS0xQsenYsQ==}
+    engines: {node: ^22.11 || ^24 || >=26, npm: '>=10.9.0', pnpm: '>=10.0.0', yarn: '>=4.5.2'}
     hasBin: true
 
-  '@changesets/config@3.1.2':
-    resolution: {integrity: sha512-CYiRhA4bWKemdYi/uwImjPxqWNpqGPNbEBdX1BdONALFIDK7MCUj6FPkzD+z9gJcvDFUQJn9aDVf4UG7OT6Kog==}
+  '@changesets/config@4.0.0':
+    resolution: {integrity: sha512-mw95/YrkOuhZZxfnVAA4bSXOFUi+KlhzOBTM8C4x777NhUU6HWIl9Z+K+nME+E4PVsv5NQVQwTfiHihAS1A/ow==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/errors@0.2.0':
-    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+  '@changesets/errors@1.0.0':
+    resolution: {integrity: sha512-ElN/mEzn6zmETgjwf5MclCMa9ef59sAR0lfO8VSYIsiRvbC2FbLB/92EoYw10Sl0kGixxHFiJZUSv7dA+YpR8g==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/get-dependents-graph@2.1.3':
-    resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+  '@changesets/format@0.1.2':
+    resolution: {integrity: sha512-Caez5XtNXCFS/G5bwyav3wuXL0tMxVd2ZGbaumWbzN08tyzO21asCw7JZhNtVsAZDCvDRUzZN+Iit9SyRITSYA==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/get-github-info@0.7.0':
-    resolution: {integrity: sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==}
+  '@changesets/get-dependents-graph@3.0.0':
+    resolution: {integrity: sha512-ji/t5wFA1zREKXRUePE6Qi+Qu2UgxCeSSGQrphezwvQZrp49B7sJ+8+wvM0tA7zPeSxYKCojDy3WWgrl+s+awg==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/get-release-plan@4.0.14':
-    resolution: {integrity: sha512-yjZMHpUHgl4Xl5gRlolVuxDkm4HgSJqT93Ri1Uz8kGrQb+5iJ8dkXJ20M2j/Y4iV5QzS2c5SeTxVSKX+2eMI0g==}
+  '@changesets/get-github-info@1.0.0':
+    resolution: {integrity: sha512-nf5zPSqEKW0eXiJ4ltbjyIQ/srUHfxbghkLCjKdOLI3LehKXhiqxXcpja39eGPaj6qqGx2lFCrLJ7VWYUf9H2w==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/get-version-range-type@0.4.0':
-    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+  '@changesets/git@4.0.0':
+    resolution: {integrity: sha512-uIEswpPUgzBBqrC0qg13byNaPorzhf05LE2T+gRizEKCXvMsJC6NPJp5iNDSV/gYj4Viqh09UiOF5E7XWeH5lQ==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/git@3.0.4':
-    resolution: {integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==}
+  '@changesets/parse@1.0.0':
+    resolution: {integrity: sha512-P0iaMb9p9CRYZiTgAllEIF9AUMQHIy1G72tKlcIqJp61icZSsKQNiOPdxAMZG8m/DvZwt/oz5xEbTpike//dWg==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/logger@0.1.1':
-    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
+  '@changesets/pre@3.0.0':
+    resolution: {integrity: sha512-Zm/6YliV/a2oeWTqHJf6KxLrQwgcK1i/BRDl2m0EKZvbnxV5fG9QRhwJJGshjsZTUTS6dkfURQ2K6aAvgNw/3Q==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/parse@0.4.2':
-    resolution: {integrity: sha512-Uo5MC5mfg4OM0jU3up66fmSn6/NE9INK+8/Vn/7sMVcdWg46zfbvvUSjD9EMonVqPi9fbrJH9SXHn48Tr1f2yA==}
+  '@changesets/read@1.0.0':
+    resolution: {integrity: sha512-8TdE2PwG6yArPt5Ozej83Z6iHz1G8BDBKvIEKZ455MccR4K3GNbLR2XqjBxa+5yLFnEd3xAOPXYboBg1pt8stQ==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/pre@2.0.2':
-    resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
+  '@changesets/should-skip-package@1.0.0':
+    resolution: {integrity: sha512-pwqoJmbONn1XgXmZXPEExgAaT+HdZLjALFTDgIm+PnS5KeO2nLtzA2/Q+4aMFY14kFMuXKG30MObhvDzWgzDgg==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/read@0.6.6':
-    resolution: {integrity: sha512-P5QaN9hJSQQKJShzzpBT13FzOSPyHbqdoIBUd2DJdgvnECCyO6LmAOWSV+O8se2TaZJVwSXjL+v9yhb+a9JeJg==}
+  '@changesets/types@7.0.0':
+    resolution: {integrity: sha512-c5GoiQyt3pxiXjrWSNoP8/GRf4kG+VnKzovx1OQM8dYYALlSwgedmkPmJ+ZqGxqwg9D3Bkj85Uo4KLd5BN3A0w==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
-  '@changesets/should-skip-package@0.1.2':
-    resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
-
-  '@changesets/types@4.1.0':
-    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
-
-  '@changesets/types@6.1.0':
-    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
-
-  '@changesets/write@0.4.0':
-    resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+  '@changesets/write@1.0.1':
+    resolution: {integrity: sha512-q/ThtP9gcnEP6xlv7LrY26C2mHqdGBti/MmOVngt/M/oIGYkssmQGxPK9WzBNt2juVcH/vml2WQ+ra8LXYOTaA==}
+    engines: {node: ^22.11 || ^24 || >=26}
 
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
@@ -817,11 +821,19 @@ packages:
     resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
     engines: {node: '>= 20.12.0'}
 
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@clack/prompts@1.4.0':
     resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
   '@cloudflare/kv-asset-handler@0.5.0':
@@ -1312,89 +1324,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1418,15 +1446,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
-
-  '@inquirer/external-editor@1.0.3':
-    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
 
   '@ipld/car@5.4.2':
     resolution: {integrity: sha512-gfyrJvePyXnh2Fbj8mPg4JYvEZ3izhk8C9WgAle7xIYbrJNSXmNQ6BxAls8Gof97vvGbCROdxbTWRmHJtTCbcg==}
@@ -1471,11 +1490,17 @@ packages:
   '@loaderkit/resolve@1.0.4':
     resolution: {integrity: sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A==}
 
-  '@manypkg/find-root@1.1.0':
-    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+  '@manypkg/find-root@3.1.0':
+    resolution: {integrity: sha512-BcSqCyKhBVZ5YkSzOiheMCV41kqAFptW6xGqYSTjkVTl9XQpr+pqHhwgGCOHQtjDCv7Is6EFyA14Sm5GVbVABA==}
+    engines: {node: '>=20.0.0'}
 
-  '@manypkg/get-packages@1.1.3':
-    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+  '@manypkg/get-packages@3.1.0':
+    resolution: {integrity: sha512-0TbBVyvPrP7xGYBI/cP8UP+yl/z+HtbTttAD7FMAJgn/kXOTwh5/60TsqP9ZYY710forNfyV0N8P/IE/ujGZJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@manypkg/tools@2.1.2':
+    resolution: {integrity: sha512-6QEf6yqFbETdwGITKq57aYoPfX/3K8XFNwsAlx0C1M7o8cb79sv1M3w+tWuWvIcSbNqrLF7OD7YpZMVVz335hQ==}
+    engines: {node: '>=20.0.0'}
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
@@ -1563,41 +1588,49 @@ packages:
     resolution: {integrity: sha512-wdcQ7Niad9JpjZIGEeqKJnTvczVunqlZ/C06QzR5zOQNeLVRScQ9S5IesKWUAPsJQDizV+teQX53nTK+Z5Iy+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.17.0':
     resolution: {integrity: sha512-65B2/t39HQN5AEhkLsC+9yBD1iRUkKOIhfmJEJ7g6wQ9kylra7JRmNmALFjbsj0VJsoSQkpM8K07kUZuNJ9Kxw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.17.0':
     resolution: {integrity: sha512-kExgm3TLK21dNMmcH+xiYGbc6BUWvT03PUZ2aYn8mUzGPeeORklBhg3iYcaBI3ZQHB25412X1Z6LLYNjt4aIaA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.17.0':
     resolution: {integrity: sha512-1utUJC714/ydykZQE8c7QhpEyM4SaslMfRXxN9G61KYazr6ndt85LaubK3EZCSD50vVEfF4PVwFysCSO7LN9uA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.17.0':
     resolution: {integrity: sha512-mayiYOl3LMmtO2CLn4I5lhanfxEo0LAqlT/EQyFbu1ZN3RS+Xa7Q3JEM0wBpVIyfO/pqFrjvC5LXw/mHNDEL7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.17.0':
     resolution: {integrity: sha512-Ow/yI+CrUHxIIhn/Y1sP/xoRKbCC3x9O1giKr3G/pjMe+TCJ5ZmfqVWU61JWwh1naC8X5Xa7uyLnbzyYqPsHfg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.17.0':
     resolution: {integrity: sha512-Z4J7XlPMQOLPANyu6y3B3V417Md4LKH5bV6bhqgaG99qLHmU5LV2k9ErV14fSqoRc/GU/qOpqMdotxiJqN/YWg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.17.0':
     resolution: {integrity: sha512-0effK+8lhzXsgsh0Ny2ngdnTPF30v6QQzVFApJ1Ctk315YgpGkghkelvrLYYgtgeFJFrzwmOJ2nDvCrUFKsS2Q==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.17.0':
     resolution: {integrity: sha512-kFB48dRUW6RovAICZaxHKdtZe+e94fSTNA2OedXokzMctoU54NPZcv0vUX5PMqyikLIKJBIlW7laQidnAzNrDA==}
@@ -1701,6 +1734,10 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@pnpm/deps.graph-sequencer@1100.0.1':
+    resolution: {integrity: sha512-pOr5+q1fLYKwFN3LAJuGZEnfXDcQ73zqgDHMtGy+K+uIoUqyY+6MeDCWFwfu+4EFuq76I5EPFofoNAI+Bmmq4A==}
+    engines: {node: '>=22.13'}
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -1813,84 +1850,98 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.2':
     resolution: {integrity: sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.57':
     resolution: {integrity: sha512-d0kIVezTQtazpyWjiJIn5to8JlwfKITDqwsFv0Xc6s31N16CD2PC/Pl2OtKgS7n8WLOJbfqgIp5ixYzTAxCqMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
     resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.57':
     resolution: {integrity: sha512-E199LPijo98yrLjPCmETx8EF43sZf9t3guSrLee/ej1rCCc3zDVTR4xFfN9BRAapGVl7/8hYqbbiQPTkv73kUg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.3':
     resolution: {integrity: sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.57':
     resolution: {integrity: sha512-++EQDpk/UJ33kY/BNsh7A7/P1sr/jbMuQ8cE554ZIy+tCUWCivo9zfyjDUoiMdnxqX6HLJEqqGnbGQOvzm2OMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.3':
     resolution: {integrity: sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.57':
     resolution: {integrity: sha512-voDEBcNqxbUv/GeXKFtxXVWA+H45P/8Dec4Ii/SbyJyGvCqV1j+nNHfnFUIiRQ2Q40DwPe/djvgYBs9PpETiMA==}
@@ -2013,66 +2064,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -2191,24 +2255,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -2294,9 +2362,6 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
-  '@types/node@12.20.55':
-    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
   '@types/node@24.10.11':
     resolution: {integrity: sha512-/Af7O8r1frCVgOz0I62jWUtMohJ0/ZQU/ZoketltOJPZpnb17yoNc9BSoVuV9qlaIXJiPNOpsfq4ByFajSArNQ==}
 
@@ -2373,10 +2438,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ansi-colors@4.1.3:
-    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
-    engines: {node: '>=6'}
-
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -2407,9 +2468,6 @@ packages:
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2419,10 +2477,6 @@ packages:
 
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
-
-  array-union@2.1.0:
-    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
-    engines: {node: '>=8'}
 
   asn1js@3.0.7:
     resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
@@ -2496,10 +2550,6 @@ packages:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
-  better-path-resolve@1.0.0:
-    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
-    engines: {node: '>=4'}
-
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
@@ -2527,6 +2577,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
 
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -2578,16 +2632,9 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
-  chardet@2.1.1:
-    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
-
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
-
-  ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -2660,10 +2707,6 @@ packages:
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
-
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
@@ -2700,8 +2743,8 @@ packages:
   custom-event-polyfill@1.0.7:
     resolution: {integrity: sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==}
 
-  dataloader@1.4.0:
-    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+  dataloader@2.2.3:
+    resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2732,10 +2775,6 @@ packages:
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
-  detect-indent@6.1.0:
-    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
-    engines: {node: '>=8'}
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -2753,10 +2792,6 @@ packages:
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
-  dir-glob@3.0.1:
-    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
-    engines: {node: '>=8'}
-
   direction@2.0.1:
     resolution: {integrity: sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==}
     hasBin: true
@@ -2773,10 +2808,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  dotenv@8.6.0:
-    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
-    engines: {node: '>=10'}
 
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
@@ -2807,10 +2838,6 @@ packages:
   enhanced-resolve@5.22.0:
     resolution: {integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==}
     engines: {node: '>=10.13.0'}
-
-  enquirer@2.4.1:
-    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
-    engines: {node: '>=8.6'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -2860,11 +2887,6 @@ packages:
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
 
@@ -2909,9 +2931,6 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-
-  extendable-error@0.1.7:
-    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -2972,14 +2991,6 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
-  fs-extra@7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
-    engines: {node: '>=6 <7 || >=8'}
-
-  fs-extra@8.1.0:
-    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
-    engines: {node: '>=6 <7 || >=8'}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3006,10 +3017,6 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
-
-  globby@11.1.0:
-    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
-    engines: {node: '>=10'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -3109,8 +3116,8 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
-  human-id@4.1.3:
-    resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
+  human-id@4.2.1:
+    resolution: {integrity: sha512-zPGsiS+dWoTZtZ4AtpA9Y+BdSFSNWvnouNlWNoUFyAM6xHOHmdCvqO3k8AIbdamCOv4gUFUVNPf6rJFfc4UiJw==}
     hasBin: true
 
   i18next@26.2.0:
@@ -3121,19 +3128,14 @@ packages:
       typescript:
         optional: true
 
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
-
   idb-keyval@6.2.4:
     resolution: {integrity: sha512-D/NzHWUmYJGXi++z67aMSrnisb9A3621CyRK5G89JyTlN13C8xf0g04DLxUKMufPem3e3L2JAXR6Z00OWy183Q==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  ignore@5.3.2:
-    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
-    engines: {node: '>= 4'}
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   import-without-cache@0.2.5:
     resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
@@ -3192,24 +3194,13 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  is-subdir@1.2.0:
-    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
-    engines: {node: '>=4'}
-
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
     engines: {node: '>=12.13'}
 
-  is-windows@1.0.2:
-    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
-    engines: {node: '>=0.10.0'}
-
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
-
-  isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   iso-datestring-validator@2.2.2:
     resolution: {integrity: sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==}
@@ -3217,6 +3208,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
   jose@5.10.0:
     resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
@@ -3226,10 +3220,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -3248,9 +3238,6 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
-  jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
-
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
@@ -3266,6 +3253,9 @@ packages:
     peerDependencies:
       '@types/node': '>=18'
       typescript: '>=5.0.4 <7'
+
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -3302,24 +3292,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3344,15 +3338,8 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
-  lodash.startcase@4.4.0:
-    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-
-  lru-cache@11.2.5:
-    resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
-    engines: {node: 20 || >=22}
 
   lru-cache@11.5.0:
     resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
@@ -3630,15 +3617,6 @@ packages:
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
@@ -3683,15 +3661,8 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
-  outdent@0.5.0:
-    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
-
   oxc-resolver@11.17.0:
     resolution: {integrity: sha512-R5P2Tw6th+nQJdNcZGfuppBS/sM0x1EukqYffmlfX2xXLgLGCCPwu4ruEr9Sx29mrpkHgITc130Qps2JR90NdQ==}
-
-  p-filter@2.1.0:
-    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
-    engines: {node: '>=8'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -3705,10 +3676,6 @@ packages:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
 
-  p-map@2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
-    engines: {node: '>=6'}
-
   p-queue@9.3.0:
     resolution: {integrity: sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==}
     engines: {node: '>=20'}
@@ -3721,11 +3688,11 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  package-manager-detector@0.2.11:
-    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
-
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
   pagefind@1.5.2:
     resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
@@ -3753,16 +3720,8 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
-    engines: {node: '>=8'}
-
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
-
-  path-type@4.0.0:
-    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
-    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3784,10 +3743,6 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
-
-  pify@4.0.1:
-    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
-    engines: {node: '>=6'}
 
   pino-abstract-transport@1.2.0:
     resolution: {integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==}
@@ -3834,11 +3789,6 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-
   prettier@3.8.1:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
@@ -3878,9 +3828,6 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  quansync@0.2.11:
-    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
-
   quansync@1.0.0:
     resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
 
@@ -3895,10 +3842,6 @@ packages:
 
   rangetouch@2.0.1:
     resolution: {integrity: sha512-sln+pNSc8NGaHoLzwNBssFSf/rSYkqeBXzX1AtJlkJiUaVSJSbRAWJk+4omsXkN+EJalzkZhWQ3th1m0FpR5xA==}
-
-  read-yaml-file@1.1.0:
-    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
-    engines: {node: '>=6'}
 
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
@@ -3990,10 +3933,6 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
-
-  resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -4087,9 +4026,6 @@ packages:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
 
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -4100,6 +4036,11 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -4120,13 +4061,9 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
-
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
+    engines: {node: '>= 0.4'}
 
   shiki@4.1.0:
     resolution: {integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==}
@@ -4134,10 +4071,6 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -4149,10 +4082,6 @@ packages:
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
-    engines: {node: '>=8'}
-
-  slash@3.0.0:
-    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
   smol-toml@1.6.0:
@@ -4184,15 +4113,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
-  spawndamnit@3.0.1:
-    resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
-
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
-
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -4216,10 +4139,6 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
-
-  strip-bom@3.0.0:
-    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
-    engines: {node: '>=4'}
 
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
@@ -4255,10 +4174,6 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  term-size@2.2.1:
-    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
-    engines: {node: '>=8'}
-
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -4291,6 +4206,10 @@ packages:
     resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
     engines: {node: '>=18'}
 
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -4298,6 +4217,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -4310,9 +4233,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4453,10 +4373,6 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
-
-  universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
 
   unrun@0.2.27:
     resolution: {integrity: sha512-Mmur1UJpIbfxasLOhPRvox/QS4xBiDii71hMP7smfRthGcwFL2OAmYRgduLANOAU4LUkvVamuP+02U+c90jlrw==}
@@ -4748,23 +4664,12 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
-
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
-    hasBin: true
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -4848,6 +4753,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -4907,8 +4817,8 @@ snapshots:
       '@loaderkit/resolve': 1.0.4
       cjs-module-lexer: 1.4.3
       fflate: 0.8.2
-      lru-cache: 11.2.5
-      semver: 7.7.4
+      lru-cache: 11.5.0
+      semver: 7.8.5
       typescript: 5.6.1-rc
       validate-npm-package-name: 5.0.1
 
@@ -4918,7 +4828,7 @@ snapshots:
     dependencies:
       picomatch: 4.0.4
 
-  '@astrojs/markdown-remark@7.1.2':
+  '@astrojs/markdown-remark@7.1.2(supports-color@10.2.2)':
     dependencies:
       '@astrojs/internal-helpers': 0.9.1
       '@astrojs/prism': 4.0.2
@@ -4929,8 +4839,8 @@ snapshots:
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
+      remark-gfm: 4.0.1(supports-color@10.2.2)
+      remark-parse: 11.0.0(supports-color@10.2.2)
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
       retext-smartypants: 6.2.0
@@ -4944,18 +4854,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.6(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0))':
+  '@astrojs/mdx@5.0.6(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0))(supports-color@10.2.2)':
     dependencies:
-      '@astrojs/markdown-remark': 7.1.2
-      '@mdx-js/mdx': 3.1.1
+      '@astrojs/markdown-remark': 7.1.2(supports-color@10.2.2)
+      '@mdx-js/mdx': 3.1.1(supports-color@10.2.2)
       acorn: 8.16.0
-      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)
+      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
       piccolore: 0.1.3
       rehype-raw: 7.0.0
-      remark-gfm: 4.0.1
+      remark-gfm: 4.0.1(supports-color@10.2.2)
       remark-smartypants: 3.0.2
       source-map: 0.7.6
       unist-util-visit: 5.1.0
@@ -4973,33 +4883,33 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0))(typescript@6.0.3)':
+  '@astrojs/starlight@0.39.2(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0))(supports-color@10.2.2)(typescript@5.9.3)':
     dependencies:
-      '@astrojs/markdown-remark': 7.1.2
-      '@astrojs/mdx': 5.0.6(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0))
+      '@astrojs/markdown-remark': 7.1.2(supports-color@10.2.2)
+      '@astrojs/mdx': 5.0.6(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0))(supports-color@10.2.2)
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)
-      astro-expressive-code: 0.42.0(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0))
+      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0)
+      astro-expressive-code: 0.42.0(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
-      i18next: 26.2.0(typescript@6.0.3)
+      i18next: 26.2.0(typescript@5.9.3)
       js-yaml: 4.1.1
       klona: 2.0.6
       magic-string: 0.30.21
-      mdast-util-directive: 3.1.0
+      mdast-util-directive: 3.1.0(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       mdast-util-to-string: 4.0.0
       pagefind: 1.5.2
       rehype: 13.0.2
       rehype-format: 5.0.1
-      remark-directive: 4.0.0
+      remark-directive: 4.0.0(supports-color@10.2.2)
       ultrahtml: 1.6.0
       unified: 11.0.5
       unist-util-visit: 5.1.0
@@ -5439,20 +5349,20 @@ snapshots:
 
   '@babel/compat-data@7.29.3': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.0(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helpers': 7.29.2
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@10.2.2)
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5481,19 +5391,19 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/helper-module-imports@7.28.6':
+  '@babel/helper-module-imports@7.28.6(supports-color@10.2.2)':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@10.2.2)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.28.6(supports-color@10.2.2)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5518,12 +5428,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/runtime@7.28.6': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5531,7 +5439,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.29.0(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -5539,7 +5447,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5556,164 +5464,118 @@ snapshots:
     dependencies:
       fontkitten: 1.0.3
 
-  '@changesets/apply-release-plan@7.0.14':
+  '@changesets/apply-release-plan@8.0.0':
     dependencies:
-      '@changesets/config': 3.1.2
-      '@changesets/get-version-range-type': 0.4.0
-      '@changesets/git': 3.0.4
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
-      detect-indent: 6.1.0
-      fs-extra: 7.0.1
-      lodash.startcase: 4.4.0
-      outdent: 0.5.0
-      prettier: 2.8.8
-      resolve-from: 5.0.0
-      semver: 7.7.4
+      '@changesets/config': 4.0.0
+      '@changesets/format': 0.1.2
+      '@changesets/git': 4.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      import-meta-resolve: 4.2.0
+      jsonc-parser: 3.3.1
+      semver: 7.8.5
 
-  '@changesets/assemble-release-plan@6.0.9':
+  '@changesets/assemble-release-plan@7.0.0':
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
-      semver: 7.7.4
+      '@changesets/errors': 1.0.0
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      semver: 7.8.5
 
-  '@changesets/changelog-git@0.2.1':
+  '@changesets/changelog-git@1.0.0':
     dependencies:
-      '@changesets/types': 6.1.0
+      '@changesets/types': 7.0.0
 
-  '@changesets/changelog-github@0.5.2':
+  '@changesets/changelog-github@1.0.0':
     dependencies:
-      '@changesets/get-github-info': 0.7.0
-      '@changesets/types': 6.1.0
-      dotenv: 8.6.0
-    transitivePeerDependencies:
-      - encoding
+      '@changesets/get-github-info': 1.0.0
+      '@changesets/types': 7.0.0
 
-  '@changesets/cli@2.29.8(@types/node@24.10.11)':
+  '@changesets/cli@3.0.1':
     dependencies:
-      '@changesets/apply-release-plan': 7.0.14
-      '@changesets/assemble-release-plan': 6.0.9
-      '@changesets/changelog-git': 0.2.1
-      '@changesets/config': 3.1.2
-      '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/get-release-plan': 4.0.14
-      '@changesets/git': 3.0.4
-      '@changesets/logger': 0.1.1
-      '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.6
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@24.10.11)
-      '@manypkg/get-packages': 1.1.3
-      ansi-colors: 4.1.3
-      ci-info: 3.9.0
-      enquirer: 2.4.1
-      fs-extra: 7.0.1
-      mri: 1.2.0
-      p-limit: 2.3.0
-      package-manager-detector: 0.2.11
-      picocolors: 1.1.1
-      resolve-from: 5.0.0
-      semver: 7.7.4
-      spawndamnit: 3.0.1
-      term-size: 2.2.1
-    transitivePeerDependencies:
-      - '@types/node'
+      '@changesets/apply-release-plan': 8.0.0
+      '@changesets/assemble-release-plan': 7.0.0
+      '@changesets/changelog-git': 1.0.0
+      '@changesets/config': 4.0.0
+      '@changesets/errors': 1.0.0
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/git': 4.0.0
+      '@changesets/pre': 3.0.0
+      '@changesets/read': 1.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      '@changesets/write': 1.0.1
+      '@clack/prompts': 1.7.0
+      '@manypkg/get-packages': 3.1.0
+      '@pnpm/deps.graph-sequencer': 1100.0.1
+      cac: 7.0.0
+      import-meta-resolve: 4.2.0
+      launch-editor: 2.14.1
+      package-manager-detector: 1.6.0
+      semver: 7.8.5
+      tinyexec: 1.3.0
 
-  '@changesets/config@3.1.2':
+  '@changesets/config@4.0.0':
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.3
-      '@changesets/logger': 0.1.1
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
-      fs-extra: 7.0.1
-      micromatch: 4.0.8
+      '@changesets/get-dependents-graph': 3.0.0
+      '@changesets/should-skip-package': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+      picomatch: 4.0.4
 
-  '@changesets/errors@0.2.0':
+  '@changesets/errors@1.0.0': {}
+
+  '@changesets/format@0.1.2':
     dependencies:
-      extendable-error: 0.1.7
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.0
 
-  '@changesets/get-dependents-graph@2.1.3':
+  '@changesets/get-dependents-graph@3.0.0':
     dependencies:
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
-      picocolors: 1.1.1
-      semver: 7.7.4
+      '@changesets/types': 7.0.0
+      semver: 7.8.5
 
-  '@changesets/get-github-info@0.7.0':
+  '@changesets/get-github-info@1.0.0':
     dependencies:
-      dataloader: 1.4.0
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
+      dataloader: 2.2.3
 
-  '@changesets/get-release-plan@4.0.14':
+  '@changesets/git@4.0.0':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.9
-      '@changesets/config': 3.1.2
-      '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.6
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
+      '@changesets/errors': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
+      picomatch: 4.0.4
+      tinyexec: 1.3.0
 
-  '@changesets/get-version-range-type@0.4.0': {}
-
-  '@changesets/git@3.0.4':
+  '@changesets/parse@1.0.0':
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@manypkg/get-packages': 1.1.3
-      is-subdir: 1.2.0
-      micromatch: 4.0.8
-      spawndamnit: 3.0.1
+      '@changesets/types': 7.0.0
+      yaml: 2.9.0
 
-  '@changesets/logger@0.1.1':
+  '@changesets/pre@3.0.0':
     dependencies:
-      picocolors: 1.1.1
+      '@changesets/errors': 1.0.0
+      '@changesets/types': 7.0.0
+      '@manypkg/get-packages': 3.1.0
 
-  '@changesets/parse@0.4.2':
+  '@changesets/read@1.0.0':
     dependencies:
-      '@changesets/types': 6.1.0
-      js-yaml: 4.1.1
+      '@changesets/git': 4.0.0
+      '@changesets/parse': 1.0.0
+      '@changesets/types': 7.0.0
 
-  '@changesets/pre@2.0.2':
+  '@changesets/should-skip-package@1.0.0':
     dependencies:
-      '@changesets/errors': 0.2.0
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
-      fs-extra: 7.0.1
+      '@changesets/types': 7.0.0
 
-  '@changesets/read@0.6.6':
+  '@changesets/types@7.0.0': {}
+
+  '@changesets/write@1.0.1':
     dependencies:
-      '@changesets/git': 3.0.4
-      '@changesets/logger': 0.1.1
-      '@changesets/parse': 0.4.2
-      '@changesets/types': 6.1.0
-      fs-extra: 7.0.1
-      p-filter: 2.1.0
-      picocolors: 1.1.1
-
-  '@changesets/should-skip-package@0.1.2':
-    dependencies:
-      '@changesets/types': 6.1.0
-      '@manypkg/get-packages': 1.1.3
-
-  '@changesets/types@4.1.0': {}
-
-  '@changesets/types@6.1.0': {}
-
-  '@changesets/write@0.4.0':
-    dependencies:
-      '@changesets/types': 6.1.0
-      fs-extra: 7.0.1
-      human-id: 4.1.3
-      prettier: 2.8.8
+      '@changesets/format': 0.1.2
+      '@changesets/types': 7.0.0
+      human-id: 4.2.1
 
   '@clack/core@0.5.0':
     dependencies:
@@ -5721,6 +5583,11 @@ snapshots:
       sisteransi: 1.0.5
 
   '@clack/core@1.3.1':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/core@1.4.3':
     dependencies:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
@@ -5734,6 +5601,13 @@ snapshots:
   '@clack/prompts@1.4.0':
     dependencies:
       '@clack/core': 1.3.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
@@ -5752,12 +5626,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260521.1
 
-  '@cloudflare/vite-plugin@1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))':
+  '@cloudflare/vite-plugin@1.23.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))(workerd@1.20260521.1)(wrangler@4.94.0(@cloudflare/workers-types@4.20260524.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.12.0(unenv@2.0.0-rc.24)(workerd@1.20260521.1)
       miniflare: 4.20260205.0
       unenv: 2.0.0-rc.24
-      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       wrangler: 4.94.0(@cloudflare/workers-types@4.20260524.1)
       ws: 8.18.0
     transitivePeerDependencies:
@@ -5765,14 +5639,14 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vitest-pool-workers@0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+  '@cloudflare/vitest-pool-workers@0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
       cjs-module-lexer: 1.4.3
       esbuild: 0.27.3
       miniflare: 4.20260521.0
-      vitest: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vitest: 4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       wrangler: 4.94.0(@cloudflare/workers-types@4.20260524.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -6134,13 +6008,6 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@24.10.11)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      '@types/node': 24.10.11
-
   '@ipld/car@5.4.2':
     dependencies:
       '@ipld/dag-cbor': 9.2.5
@@ -6200,23 +6067,22 @@ snapshots:
     dependencies:
       '@braidai/lang': 1.1.2
 
-  '@manypkg/find-root@1.1.0':
+  '@manypkg/find-root@3.1.0':
     dependencies:
-      '@babel/runtime': 7.28.6
-      '@types/node': 12.20.55
-      find-up: 4.1.0
-      fs-extra: 8.1.0
+      '@manypkg/tools': 2.1.2
 
-  '@manypkg/get-packages@1.1.3':
+  '@manypkg/get-packages@3.1.0':
     dependencies:
-      '@babel/runtime': 7.28.6
-      '@changesets/types': 4.1.0
-      '@manypkg/find-root': 1.1.0
-      fs-extra: 8.1.0
-      globby: 11.1.0
-      read-yaml-file: 1.1.0
+      '@manypkg/find-root': 3.1.0
+      '@manypkg/tools': 2.1.2
 
-  '@mdx-js/mdx@3.1.1':
+  '@manypkg/tools@2.1.2':
+    dependencies:
+      jju: 1.4.0
+      tinyglobby: 0.2.16
+      yaml: 2.9.0
+
+  '@mdx-js/mdx@3.1.1(supports-color@10.2.2)':
     dependencies:
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
@@ -6228,14 +6094,14 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0
-      remark-mdx: 3.1.1
-      remark-parse: 11.0.0
+      rehype-recma: 1.0.0(supports-color@10.2.2)
+      remark-mdx: 3.1.1(supports-color@10.2.2)
+      remark-parse: 11.0.0(supports-color@10.2.2)
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -6336,9 +6202,12 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.17.0':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.17.0':
+  '@oxc-resolver/binding-wasm32-wasi@11.17.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@oxc-resolver/binding-win32-arm64-msvc@11.17.0':
@@ -6470,6 +6339,8 @@ snapshots:
       tsyringe: 4.10.0
 
   '@pinojs/redact@0.4.0': {}
+
+  '@pnpm/deps.graph-sequencer@1100.0.1': {}
 
   '@poppinss/colors@4.1.6':
     dependencies:
@@ -6829,12 +6700,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -6901,8 +6772,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/node@12.20.55': {}
-
   '@types/node@24.10.11':
     dependencies:
       undici-types: 7.16.0
@@ -6932,19 +6801,19 @@ snapshots:
       '@vitest/spy': 4.1.0-beta.1
       '@vitest/utils': 4.1.0-beta.1
       chai: 6.2.2
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.1.0-beta.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.0-beta.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.0-beta.1
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.0-beta.1':
     dependencies:
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.0.3
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -6978,7 +6847,7 @@ snapshots:
   '@vitest/utils@4.1.0-beta.1':
     dependencies:
       '@vitest/pretty-format': 4.1.0-beta.1
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.0.3
 
   '@vitest/utils@4.1.7':
     dependencies:
@@ -6995,8 +6864,6 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
-
-  ansi-colors@4.1.3: {}
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -7021,17 +6888,11 @@ snapshots:
 
   arg@5.0.2: {}
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
-
-  array-union@2.1.0: {}
 
   asn1js@3.0.7:
     dependencies:
@@ -7048,16 +6909,16 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.42.0(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)):
+  astro-expressive-code@0.42.0(astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0)
+      astro: 6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0)
       rehype-expressive-code: 0.42.0
 
-  astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(tsx@4.21.0):
+  astro@6.3.7(@types/node@24.10.11)(idb-keyval@6.2.4)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.57.1)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.9.1
-      '@astrojs/markdown-remark': 7.1.2
+      '@astrojs/markdown-remark': 7.1.2(supports-color@10.2.2)
       '@astrojs/telemetry': 3.3.2
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.4.0
@@ -7105,8 +6966,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5(idb-keyval@6.2.4)
       vfile: 6.0.3
-      vite: 7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
-      vitefu: 1.1.3(vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      vite: 7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
@@ -7152,19 +7013,19 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.0):
+  babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.29.0(supports-color@10.2.2)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))
       '@babel/types': 7.29.0
       html-entities: 2.3.3
       parse5: 7.3.0
 
-  babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@1.9.13):
+  babel-preset-solid@1.9.12(@babel/core@7.29.0(supports-color@10.2.2))(solid-js@1.9.13):
     dependencies:
-      '@babel/core': 7.29.0
-      babel-plugin-jsx-dom-expressions: 0.40.7(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      babel-plugin-jsx-dom-expressions: 0.40.7(@babel/core@7.29.0(supports-color@10.2.2))
     optionalDependencies:
       solid-js: 1.9.13
 
@@ -7183,10 +7044,6 @@ snapshots:
       is-decimal: 2.0.1
 
   bcryptjs@3.0.3: {}
-
-  better-path-resolve@1.0.0:
-    dependencies:
-      is-windows: 1.0.2
 
   birpc@4.0.0: {}
 
@@ -7216,6 +7073,8 @@ snapshots:
       '@types/node': 24.10.11
 
   cac@6.7.14: {}
+
+  cac@7.0.0: {}
 
   camelcase@5.3.1: {}
 
@@ -7248,13 +7107,9 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  chardet@2.1.1: {}
-
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
-
-  ci-info@3.9.0: {}
 
   ci-info@4.4.0: {}
 
@@ -7319,12 +7174,6 @@ snapshots:
 
   core-js@3.49.0: {}
 
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
-
   crossws@0.3.5:
     dependencies:
       uncrypto: 0.1.3
@@ -7361,11 +7210,13 @@ snapshots:
 
   custom-event-polyfill@1.0.7: {}
 
-  dataloader@1.4.0: {}
+  dataloader@2.2.3: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   decamelize@1.2.0: {}
 
@@ -7381,8 +7232,6 @@ snapshots:
 
   destr@2.0.5: {}
 
-  detect-indent@6.1.0: {}
-
   detect-libc@2.1.2: {}
 
   devalue@5.8.1: {}
@@ -7394,10 +7243,6 @@ snapshots:
   diff@8.0.4: {}
 
   dijkstrajs@1.0.3: {}
-
-  dir-glob@3.0.1:
-    dependencies:
-      path-type: 4.0.0
 
   direction@2.0.1: {}
 
@@ -7419,13 +7264,11 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
-  dotenv@8.6.0: {}
-
   dset@3.1.4: {}
 
   dts-resolver@2.1.3(oxc-resolver@11.17.0):
     optionalDependencies:
-      oxc-resolver: 11.17.0
+      oxc-resolver: 11.17.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
 
   electron-to-chromium@1.5.361: {}
 
@@ -7439,11 +7282,6 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
-
-  enquirer@2.4.1:
-    dependencies:
-      ansi-colors: 4.1.3
-      strip-ansi: 6.0.1
 
   entities@4.5.0: {}
 
@@ -7535,8 +7373,6 @@ snapshots:
 
   esm-env@1.2.2: {}
 
-  esprima@4.0.1: {}
-
   estree-util-attach-comments@3.0.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -7588,8 +7424,6 @@ snapshots:
       '@expressive-code/plugin-text-markers': 0.42.0
 
   extend@3.0.2: {}
-
-  extendable-error@0.1.7: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -7652,18 +7486,6 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
-  fs-extra@7.0.1:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-
-  fs-extra@8.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
-
   fsevents@2.3.3:
     optional: true
 
@@ -7684,15 +7506,6 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
-
-  globby@11.1.0:
-    dependencies:
-      array-union: 2.1.0
-      dir-glob: 3.0.1
-      fast-glob: 3.3.3
-      ignore: 5.3.2
-      merge2: 1.4.1
-      slash: 3.0.0
 
   graceful-fs@4.2.11: {}
 
@@ -7811,7 +7624,7 @@ snapshots:
       unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
-  hast-util-to-estree@3.1.3:
+  hast-util-to-estree@3.1.3(supports-color@10.2.2):
     dependencies:
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
@@ -7821,9 +7634,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -7846,7 +7659,7 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
-  hast-util-to-jsx-runtime@2.3.6:
+  hast-util-to-jsx-runtime@2.3.6(supports-color@10.2.2):
     dependencies:
       '@types/estree': 1.0.8
       '@types/hast': 3.0.4
@@ -7855,9 +7668,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -7917,21 +7730,17 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
-  human-id@4.1.3: {}
+  human-id@4.2.1: {}
 
-  i18next@26.2.0(typescript@6.0.3):
+  i18next@26.2.0(typescript@5.9.3):
     optionalDependencies:
-      typescript: 6.0.3
-
-  iconv-lite@0.7.2:
-    dependencies:
-      safer-buffer: 2.1.2
+      typescript: 5.9.3
 
   idb-keyval@6.2.4: {}
 
   ieee754@1.2.1: {}
 
-  ignore@5.3.2: {}
+  import-meta-resolve@4.2.0: {}
 
   import-without-cache@0.2.5: {}
 
@@ -7970,34 +7779,23 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-subdir@1.2.0:
-    dependencies:
-      better-path-resolve: 1.0.0
-
   is-what@4.1.16: {}
-
-  is-windows@1.0.2: {}
 
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
-  isexe@2.0.0: {}
-
   iso-datestring-validator@2.2.2: {}
 
   jiti@2.6.1: {}
+
+  jju@1.4.0: {}
 
   jose@5.10.0: {}
 
   jose@6.1.3: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@3.14.2:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -8008,10 +7806,6 @@ snapshots:
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
-
-  jsonfile@4.0.0:
-    optionalDependencies:
-      graceful-fs: 4.2.11
 
   kleur@4.1.5: {}
 
@@ -8026,13 +7820,21 @@ snapshots:
       jiti: 2.6.1
       js-yaml: 4.1.1
       minimist: 1.2.8
-      oxc-resolver: 11.17.0
+      oxc-resolver: 11.17.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       picocolors: 1.1.1
       picomatch: 4.0.3
       smol-toml: 1.6.0
       strip-json-comments: 5.0.3
       typescript: 5.9.3
       zod: 4.3.6
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  launch-editor@2.14.1:
+    dependencies:
+      picocolors: 1.1.1
+      shell-quote: 1.10.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -8089,11 +7891,7 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
-  lodash.startcase@4.4.0: {}
-
   longest-streak@3.1.0: {}
-
-  lru-cache@11.2.5: {}
 
   lru-cache@11.5.0: {}
 
@@ -8134,13 +7932,13 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-visit: 5.1.0
 
-  mdast-util-directive@3.1.0:
+  mdast-util-directive@3.1.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -8155,14 +7953,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@10.2.2)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -8180,67 +7978,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@10.2.2):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@10.2.2)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-table: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1:
+  mdast-util-mdx-expression@2.0.1(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0:
+  mdast-util-mdx-jsx@3.2.0(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
@@ -8248,7 +8046,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -8257,23 +8055,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0:
+  mdast-util-mdx@3.0.0(supports-color@10.2.2):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1:
+  mdast-util-mdxjs-esm@2.0.1(supports-color@10.2.2):
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8573,10 +8371,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@10.2.2):
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -8665,10 +8463,6 @@ snapshots:
 
   node-fetch-native@1.6.7: {}
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   node-gyp-build@4.8.4: {}
 
   node-mock-http@1.0.4: {}
@@ -8705,9 +8499,7 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  outdent@0.5.0: {}
-
-  oxc-resolver@11.17.0:
+  oxc-resolver@11.17.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.17.0
       '@oxc-resolver/binding-android-arm64': 11.17.0
@@ -8725,14 +8517,13 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.17.0
       '@oxc-resolver/binding-linux-x64-musl': 11.17.0
       '@oxc-resolver/binding-openharmony-arm64': 11.17.0
-      '@oxc-resolver/binding-wasm32-wasi': 11.17.0
+      '@oxc-resolver/binding-wasm32-wasi': 11.17.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.17.0
       '@oxc-resolver/binding-win32-ia32-msvc': 11.17.0
       '@oxc-resolver/binding-win32-x64-msvc': 11.17.0
-
-  p-filter@2.1.0:
-    dependencies:
-      p-map: 2.1.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   p-limit@2.3.0:
     dependencies:
@@ -8746,8 +8537,6 @@ snapshots:
     dependencies:
       p-limit: 2.3.0
 
-  p-map@2.1.0: {}
-
   p-queue@9.3.0:
     dependencies:
       eventemitter3: 5.0.4
@@ -8757,11 +8546,9 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  package-manager-detector@0.2.11:
-    dependencies:
-      quansync: 0.2.11
-
   package-manager-detector@1.6.0: {}
+
+  package-manager-detector@1.8.0: {}
 
   pagefind@1.5.2:
     optionalDependencies:
@@ -8806,11 +8593,7 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-key@3.1.1: {}
-
   path-to-regexp@6.3.0: {}
-
-  path-type@4.0.0: {}
 
   pathe@2.0.3: {}
 
@@ -8823,8 +8606,6 @@ snapshots:
   picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
-
-  pify@4.0.1: {}
 
   pino-abstract-transport@1.2.0:
     dependencies:
@@ -8899,8 +8680,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prettier@2.8.8: {}
-
   prettier@3.8.1: {}
 
   prismjs@1.30.0: {}
@@ -8932,8 +8711,6 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  quansync@0.2.11: {}
-
   quansync@1.0.0: {}
 
   queue-microtask@1.2.3: {}
@@ -8943,13 +8720,6 @@ snapshots:
   radix3@1.1.2: {}
 
   rangetouch@2.0.1: {}
-
-  read-yaml-file@1.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      js-yaml: 3.14.2
-      pify: 4.0.1
-      strip-bom: 3.0.0
 
   readable-stream@4.7.0:
     dependencies:
@@ -9027,11 +8797,11 @@ snapshots:
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
-  rehype-recma@1.0.0:
+  rehype-recma@1.0.0(supports-color@10.2.2):
     dependencies:
       '@types/estree': 1.0.8
       '@types/hast': 3.0.4
-      hast-util-to-estree: 3.1.3
+      hast-util-to-estree: 3.1.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -9048,37 +8818,37 @@ snapshots:
       rehype-stringify: 10.0.1
       unified: 11.0.5
 
-  remark-directive@4.0.0:
+  remark-directive@4.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-directive: 3.1.0
+      mdast-util-directive: 3.1.0(supports-color@10.2.2)
       micromark-extension-directive: 4.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-gfm@4.0.1:
+  remark-gfm@4.0.1(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0
+      mdast-util-gfm: 3.1.0(supports-color@10.2.2)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@10.2.2)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-mdx@3.1.1:
+  remark-mdx@3.1.1(supports-color@10.2.2):
     dependencies:
-      mdast-util-mdx: 3.0.0
+      mdast-util-mdx: 3.0.0(supports-color@10.2.2)
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9108,8 +8878,6 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-main-filename@2.0.0: {}
-
-  resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -9273,13 +9041,13 @@ snapshots:
 
   safe-stable-stringify@2.5.0: {}
 
-  safer-buffer@2.1.2: {}
-
   sax@1.6.0: {}
 
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.5: {}
 
   seroval-plugins@1.5.4(seroval@1.5.4):
     dependencies:
@@ -9320,11 +9088,7 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
+  shell-quote@1.10.0: {}
 
   shiki@4.1.0:
     dependencies:
@@ -9339,8 +9103,6 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@4.1.0: {}
-
   sisteransi@1.0.5: {}
 
   sitemap@9.0.1:
@@ -9354,8 +9116,6 @@ snapshots:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
 
-  slash@3.0.0: {}
-
   smol-toml@1.6.0: {}
 
   solid-js@1.9.13:
@@ -9364,10 +9124,10 @@ snapshots:
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
 
-  solid-refresh@0.6.3(solid-js@1.9.13):
+  solid-refresh@0.6.3(solid-js@1.9.13)(supports-color@10.2.2):
     dependencies:
       '@babel/generator': 7.29.1
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.28.6(supports-color@10.2.2)
       '@babel/types': 7.29.0
       solid-js: 1.9.13
     transitivePeerDependencies:
@@ -9387,14 +9147,7 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  spawndamnit@3.0.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   split2@4.2.0: {}
-
-  sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
 
@@ -9420,8 +9173,6 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-
-  strip-bom@3.0.0: {}
 
   strip-json-comments@5.0.3: {}
 
@@ -9458,8 +9209,6 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  term-size@2.2.1: {}
-
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -9486,6 +9235,8 @@ snapshots:
 
   tinyexec@1.2.2: {}
 
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9496,6 +9247,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyrainbow@3.0.3: {}
+
   tinyrainbow@3.1.0: {}
 
   tlds@1.261.0: {}
@@ -9503,8 +9256,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  tr46@0.0.3: {}
 
   tree-kill@1.2.2: {}
 
@@ -9657,8 +9408,6 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  universalify@0.1.2: {}
-
   unrun@0.2.27:
     dependencies:
       rolldown: 1.0.0-rc.3
@@ -9709,20 +9458,20 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-solid@2.11.12(solid-js@1.9.13)(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)):
+  vite-plugin-solid@2.11.12(solid-js@1.9.13)(supports-color@10.2.2)(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@10.2.2)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 1.9.12(@babel/core@7.29.0)(solid-js@1.9.13)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.0(supports-color@10.2.2))(solid-js@1.9.13)
       merge-anything: 5.1.7
       solid-js: 1.9.13
-      solid-refresh: 0.6.3(solid-js@1.9.13)
-      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
-      vitefu: 1.1.3(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
+      solid-refresh: 0.6.3(solid-js@1.9.13)(supports-color@10.2.2)
+      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
+  vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9736,8 +9485,9 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       tsx: 4.21.0
+      yaml: 2.9.0
 
-  vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
+  vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9751,8 +9501,9 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       tsx: 4.21.0
+      yaml: 2.9.0
 
-  vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0):
+  vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -9765,19 +9516,20 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.21.0
+      yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)):
+  vitefu@1.1.3(vite@7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 7.3.3(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitefu@1.1.3(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)):
+  vitefu@1.1.3(vite@8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
+      vite: 8.0.14(@types/node@24.10.11)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
+  vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.1.0-beta.1
-      '@vitest/mocker': 4.1.0-beta.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.0-beta.1(vite@6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.0-beta.1
       '@vitest/runner': 4.1.0-beta.1
       '@vitest/snapshot': 4.1.0-beta.1
@@ -9788,13 +9540,13 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.3
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 1.2.2
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 6.4.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.11
@@ -9815,20 +9567,9 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
-
   which-module@2.0.1: {}
 
   which-pm-runs@1.1.0: {}
-
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -9894,6 +9635,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@18.1.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,9 +319,6 @@ importers:
 
   packages/spaces:
     dependencies:
-      '@atcute/cid':
-        specifier: ^2.3.0
-        version: 2.4.1
       '@atcute/lexicons':
         specifier: ^1.2.6
         version: 1.3.0
@@ -334,25 +331,13 @@ importers:
       '@atproto/lex-cbor':
         specifier: ^0.1.6
         version: 0.1.6
-      '@atproto/lex-data':
-        specifier: ^0.1.7
-        version: 0.1.7
-      '@atproto/lex-json':
-        specifier: ^0.0.11
-        version: 0.0.11
       '@atproto/space':
         specifier: 0.0.0-spaces-alpha-20260818163953
         version: 0.0.0-spaces-alpha-20260818163953
-      hono:
-        specifier: ^4.11.3
-        version: 4.11.8
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
         version: 0.18.2
-      '@atproto/jwk-jose':
-        specifier: ^0.2.1
-        version: 0.2.4
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.16.9
         version: 0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
@@ -596,10 +581,6 @@ packages:
 
   '@atproto/did@0.5.4':
     resolution: {integrity: sha512-BlnwQ+obL+4ZA71KH/EzZ3TY+cpSxnLiUI85mjBJIQwvDF/oN2sQA18wIj9jpduviIt2b/cMtlJuzHjzBkfXvw==}
-    engines: {node: '>=22'}
-
-  '@atproto/jwk-jose@0.2.4':
-    resolution: {integrity: sha512-gzDoA0JTwnc0ZJOBLM7WX9xFxtynRS2K1Bofb8epzoMWDQvyvfbPcfkdPrKFM7NXCFUVpGpBnsCB8KFPTf1rCg==}
     engines: {node: '>=22'}
 
   '@atproto/jwk@0.6.0':
@@ -5333,11 +5314,6 @@ snapshots:
   '@atproto/did@0.5.4':
     dependencies:
       zod: 3.25.76
-
-  '@atproto/jwk-jose@0.2.4':
-    dependencies:
-      '@atproto/jwk': 0.7.4
-      jose: 5.10.0
 
   '@atproto/jwk@0.6.0':
     dependencies:


### PR DESCRIPTION
The Durable Object core for atproto spaces (proposal 0016, alpha):

- SpaceDurableObject: one per space URI. Holds the operator's
  permissioned repo (records, oplog, 2048-byte LtHash state persisted
  per write batch, blob references) and, for hosted spaces, the
  simplespace config, member list, writer set, notification
  registrations and outbound notify queue with bounded-retry alarm
  delivery. Replay table for DPoP proofs and delegation tokens.
- SpaceIndexDurableObject: singleton registry with pending/active/
  deleted lifecycle; two-step creation with alarm cleanup of stale
  pending entries. Reads never depend on it.
- Schema versioning: a version mismatch puts the DO into a refusing
  state (SpacesSchemaOutdated) — alpha policy is wipe, not migrate.
- Oplog compaction (30 days / 10,000 ops) since DO SQLite is billed
  and capped; the reference has none yet.
- Space URI parsing, spaceId (base32 sha-256) R2 key helpers, service
  JWT signing for fan-out, rev/TID helpers.
- Host identity comes from an abstract getHostConfig() — the engine
  never reads env.DID, so the same class can serve a dedicated
  authority DID with no account attached (S9).

Commits are signed in the Worker, never here; R2 I/O never happens
here. All state is isolated from the public repository so alpha
breaking changes are absorbed by 'pds spaces reset' alone.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>