### PR TITLE
feat(spaces): protocol auth and route factory

### DIFF
--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@getcirrus/spaces",
 	"version": "0.1.0",
-	"description": "Atproto spaces engine (alpha) for Cloudflare Workers \u2013 permissioned repos, space hosting and credentials",
+	"description": "Atproto spaces engine (alpha) for Cloudflare Workers – permissioned repos, space hosting and credentials",
 	"type": "module",
 	"main": "dist/index.js",
 	"files": [
@@ -17,16 +17,22 @@
 		"check": "publint && attw --pack --ignore-rules=cjs-resolves-to-esm"
 	},
 	"dependencies": {
+		"@atcute/cid": "^2.3.0",
 		"@atproto/crypto": "^0.4.5",
 		"@atproto/lex-cbor": "^0.1.6",
+		"@atproto/lex-data": "^0.1.7",
+		"@atproto/lex-json": "^0.1.6",
 		"@atproto/space": "0.0.0-spaces-alpha-20260818163953",
 		"@atcute/tid": "^1.1.1",
-		"@atcute/lexicons": "^1.2.6"
+		"hono": "^4.11.3",
+		"@atcute/lexicons": "^1.2.6",
+		"jose": "^5.2.0"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.18.2",
 		"@cloudflare/vitest-pool-workers": "^0.16.9",
 		"@cloudflare/workers-types": "^4.20260524.1",
+		"@atproto/jwk-jose": "^0.2.1",
 		"publint": "^0.3.16",
 		"tsdown": "^0.18.3",
 		"typescript": "^5.9.3",

--- a/packages/spaces/src/attestation.ts
+++ b/packages/spaces/src/attestation.ts
@@ -1,0 +1,106 @@
+/**
+ * Client attestation verification (app-identity gating, `allowList` app
+ * access). The attestation is a short-lived JWT signed by the OAuth
+ * client's published JWKS key, with `iss` = `sub` = client_id and `aud`
+ * the space host. Verified against the client's `client-metadata.json`.
+ */
+
+import { createLocalJWKSet, createRemoteJWKSet, jwtVerify } from "jose";
+import { SPACE_TOKEN_TYPES, parseSpaceToken } from "@atproto/space";
+import { SpaceError } from "./errors.js";
+import type { CheckReplay } from "./auth.js";
+
+export interface VerifyAttestationOpts {
+	/** Expected audience: `spaceHostAud(authorityDid)`. */
+	expectedAud: string;
+	checkReplay: CheckReplay;
+	/** Fetch override for tests. */
+	fetch?: typeof fetch;
+}
+
+/**
+ * Verify a client attestation and return the attested client_id.
+ * Single-use by `(clientId, jti)`.
+ */
+export async function verifyClientAttestation(
+	attestation: string,
+	opts: VerifyAttestationOpts,
+): Promise<string> {
+	let parsed;
+	try {
+		parsed = parseSpaceToken("clientAttestation", attestation);
+	} catch (err) {
+		throw invalid(err);
+	}
+	const clientId = parsed.payload.iss;
+	if (parsed.payload.aud !== opts.expectedAud) {
+		throw new SpaceError(
+			"InvalidClientAttestation",
+			"Attestation audience does not match this space host",
+		);
+	}
+
+	const doFetch = opts.fetch ?? fetch;
+	let metadata: { jwks?: unknown; jwks_uri?: string };
+	try {
+		const res = await doFetch(clientId, {
+			headers: { Accept: "application/json" },
+		});
+		if (!res.ok) {
+			throw new Error(`client metadata fetch returned ${res.status}`);
+		}
+		metadata = (await res.json()) as typeof metadata;
+	} catch {
+		throw new SpaceError(
+			"InvalidClientAttestation",
+			"Could not resolve client metadata",
+		);
+	}
+
+	const keySet = metadata.jwks
+		? createLocalJWKSet(metadata.jwks as Parameters<typeof createLocalJWKSet>[0])
+		: metadata.jwks_uri
+			? createRemoteJWKSet(new URL(metadata.jwks_uri), {
+					[Symbol.for("jose.jwks.fetch")]: doFetch,
+				} as never)
+			: null;
+	if (!keySet) {
+		throw new SpaceError(
+			"InvalidClientAttestation",
+			"Client metadata declares no JWKS",
+		);
+	}
+
+	try {
+		await jwtVerify(attestation, keySet, {
+			issuer: clientId,
+			subject: clientId,
+			audience: opts.expectedAud,
+			typ: SPACE_TOKEN_TYPES.clientAttestation.typ,
+			requiredClaims: ["jti", "exp"],
+			clockTolerance: 5,
+		});
+	} catch (err) {
+		throw invalid(err);
+	}
+
+	const fresh = await opts.checkReplay(
+		"attestation",
+		`${clientId}:${parsed.payload.jti}`,
+		parsed.payload.exp,
+	);
+	if (!fresh) {
+		throw new SpaceError(
+			"InvalidClientAttestation",
+			"Client attestation has already been used",
+		);
+	}
+	return clientId;
+}
+
+function invalid(err: unknown): SpaceError {
+	return new SpaceError(
+		"InvalidClientAttestation",
+		err instanceof Error ? err.message : "Invalid client attestation",
+	);
+}

--- a/packages/spaces/src/attestation.ts
+++ b/packages/spaces/src/attestation.ts
@@ -3,16 +3,33 @@
  * access). The attestation is a short-lived JWT signed by the OAuth
  * client's published JWKS key, with `iss` = `sub` = client_id and `aud`
  * the space host. Verified against the client's `client-metadata.json`.
+ *
+ * The client_id in the payload is attacker-controlled until the signature
+ * verifies, so nothing is fetched before it has been validated as an
+ * https client-metadata URL and checked against the caller's allow-list —
+ * a space gated on an allow-list never performs network I/O for a client
+ * that could not be authorized anyway. All fetches are bounded by a
+ * timeout.
  */
 
-import { createLocalJWKSet, createRemoteJWKSet, jwtVerify } from "jose";
+import { createLocalJWKSet, jwtVerify } from "jose";
 import { SPACE_TOKEN_TYPES, parseSpaceToken } from "@atproto/space";
 import { SpaceError } from "./errors.js";
 import type { CheckReplay } from "./auth.js";
 
+/** Upper bound for each outbound metadata/JWKS fetch. */
+const FETCH_TIMEOUT_MS = 5000;
+
 export interface VerifyAttestationOpts {
 	/** Expected audience: `spaceHostAud(authorityDid)`. */
 	expectedAud: string;
+	/**
+	 * When set, an (unverified) client_id outside this list is rejected
+	 * before any network I/O. The membership check runs regardless of
+	 * signature state because the caller re-derives authorization from the
+	 * returned client_id after full verification.
+	 */
+	allowedClientIds?: readonly string[];
 	checkReplay: CheckReplay;
 	/** Fetch override for tests. */
 	fetch?: typeof fetch;
@@ -40,16 +57,47 @@ export async function verifyClientAttestation(
 		);
 	}
 
-	const doFetch = opts.fetch ?? fetch;
-	let metadata: { jwks?: unknown; jwks_uri?: string };
+	// Everything below this point costs network I/O, so gate on what can be
+	// decided statically first: the client_id must be a plausible https
+	// client-metadata URL, and must be one the space could authorize at all.
+	let clientUrl: URL;
 	try {
-		const res = await doFetch(clientId, {
+		clientUrl = new URL(clientId);
+	} catch {
+		throw new SpaceError(
+			"InvalidClientAttestation",
+			"Attestation client_id is not a URL",
+		);
+	}
+	if (clientUrl.protocol !== "https:" || clientUrl.username || clientUrl.password) {
+		throw new SpaceError(
+			"InvalidClientAttestation",
+			"Attestation client_id must be a plain https URL",
+		);
+	}
+	if (opts.allowedClientIds && !opts.allowedClientIds.includes(clientId)) {
+		throw new SpaceError(
+			"AppNotAuthorized",
+			"App is not authorized for this space",
+		);
+	}
+
+	const doFetch = opts.fetch ?? fetch;
+	const boundedJson = async (url: string): Promise<unknown> => {
+		const res = await doFetch(url, {
 			headers: { Accept: "application/json" },
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			redirect: "error",
 		});
 		if (!res.ok) {
-			throw new Error(`client metadata fetch returned ${res.status}`);
+			throw new Error(`fetch of ${url} returned ${res.status}`);
 		}
-		metadata = (await res.json()) as typeof metadata;
+		return res.json();
+	};
+
+	let metadata: { jwks?: unknown; jwks_uri?: string };
+	try {
+		metadata = (await boundedJson(clientId)) as typeof metadata;
 	} catch {
 		throw new SpaceError(
 			"InvalidClientAttestation",
@@ -57,14 +105,30 @@ export async function verifyClientAttestation(
 		);
 	}
 
-	const keySet = metadata.jwks
-		? createLocalJWKSet(metadata.jwks as Parameters<typeof createLocalJWKSet>[0])
-		: metadata.jwks_uri
-			? createRemoteJWKSet(new URL(metadata.jwks_uri), {
-					[Symbol.for("jose.jwks.fetch")]: doFetch,
-				} as never)
-			: null;
-	if (!keySet) {
+	let jwks = metadata.jwks;
+	if (!jwks && typeof metadata.jwks_uri === "string") {
+		let jwksUrl: URL;
+		try {
+			jwksUrl = new URL(metadata.jwks_uri);
+		} catch {
+			jwksUrl = null as never;
+		}
+		if (!jwksUrl || jwksUrl.protocol !== "https:") {
+			throw new SpaceError(
+				"InvalidClientAttestation",
+				"Client metadata jwks_uri must be an https URL",
+			);
+		}
+		try {
+			jwks = await boundedJson(metadata.jwks_uri);
+		} catch {
+			throw new SpaceError(
+				"InvalidClientAttestation",
+				"Could not resolve client JWKS",
+			);
+		}
+	}
+	if (!jwks) {
 		throw new SpaceError(
 			"InvalidClientAttestation",
 			"Client metadata declares no JWKS",
@@ -72,6 +136,9 @@ export async function verifyClientAttestation(
 	}
 
 	try {
+		const keySet = createLocalJWKSet(
+			jwks as Parameters<typeof createLocalJWKSet>[0],
+		);
 		await jwtVerify(attestation, keySet, {
 			issuer: clientId,
 			subject: clientId,

--- a/packages/spaces/src/auth.ts
+++ b/packages/spaces/src/auth.ts
@@ -1,0 +1,224 @@
+/**
+ * Worker-side verification of space credentials and delegation tokens.
+ *
+ * Everything here is stateless except the replay checks, which are one RPC
+ * to the space DO's `replay` table. Key resolution goes through the host's
+ * DID resolver with a forced refresh on signature failure (handled inside
+ * `verifySpaceToken`) so key rotation doesn't strand callers.
+ */
+
+import {
+	DpopProofError,
+	SPACE_TOKEN_TYPES,
+	SpaceTokenError,
+	spaceHostAud,
+	verifyDpopProof,
+	verifySpaceToken,
+} from "@atproto/space";
+import { SpaceError } from "./errors.js";
+import type { SpaceRef } from "./space-uri.js";
+
+/** Resolve an issuer DID (+ key id) to a did:key string. */
+export type GetSigningKey = (
+	iss: string,
+	kid: string | undefined,
+	forceRefresh: boolean,
+) => Promise<string>;
+
+/** Record a single-use key; false when it was already seen. */
+export type CheckReplay = (
+	kind: string,
+	key: string,
+	expiresAtSec: number,
+) => Promise<boolean>;
+
+/**
+ * Peek at an unverified JWT's `typ` header. Used only for routing between
+ * authentication schemes — safe because neither token type verifies as the
+ * other.
+ */
+export function unverifiedJwtTyp(token: string): string | null {
+	const dot = token.indexOf(".");
+	if (dot <= 0) return null;
+	try {
+		const header = JSON.parse(
+			atob(token.slice(0, dot).replace(/-/g, "+").replace(/_/g, "/")),
+		) as { typ?: unknown };
+		return typeof header.typ === "string" ? header.typ : null;
+	} catch {
+		return null;
+	}
+}
+
+/** Whether an Authorization header carries a space credential. */
+export function isSpaceCredentialAuth(authorization: string | undefined): boolean {
+	if (!authorization?.startsWith("DPoP ")) return false;
+	return (
+		unverifiedJwtTyp(authorization.slice(5)) ===
+		SPACE_TOKEN_TYPES.credential.typ
+	);
+}
+
+export interface VerifyRequestOpts {
+	/** HTTP method of the request. */
+	htm: string;
+	/** Request URL; its path is combined with `publicOrigin` for htu. */
+	url: string;
+	/**
+	 * The origin clients see (`https://host`). The Worker may be behind a
+	 * proxy, so htu is reconstructed from this rather than trusted from the
+	 * incoming URL.
+	 */
+	publicOrigin: string;
+	dpopProof: string | undefined;
+	getSigningKey: GetSigningKey;
+	checkReplay: CheckReplay;
+}
+
+function htuFor(opts: VerifyRequestOpts): string {
+	return `${opts.publicOrigin}${new URL(opts.url).pathname}`;
+}
+
+const nowSec = () => Math.floor(Date.now() / 1000);
+
+export interface SpaceCredentialResult {
+	kind: "credential";
+	/** The credential issuer — the space's authority DID. */
+	iss: string;
+}
+
+/**
+ * Verify a space credential (`Authorization: DPoP <jwt>` + `DPoP` proof)
+ * presented against `space`. Checks, per the proposal: signature against
+ * the issuer's `#atproto_space` / `#atproto` key, `sub` equal to the
+ * requested space, `iss` equal to the space's authority, `cnf.jkt` equal
+ * to the proof key's thumbprint, proof `htm`/`htu`/`ath`/`iat` valid and
+ * proof `jti` unseen.
+ */
+export async function verifySpaceCredentialAuth(
+	credential: string,
+	space: SpaceRef,
+	opts: VerifyRequestOpts,
+): Promise<SpaceCredentialResult> {
+	let payload;
+	try {
+		({ payload } = await verifySpaceToken("credential", credential, {
+			getSigningKey: opts.getSigningKey,
+			sub: space.uri,
+		}));
+	} catch (err) {
+		throw invalidCredential(err);
+	}
+	if (payload.iss !== space.authority) {
+		throw new SpaceError(
+			"InvalidCredential",
+			"Space credential issuer is not the space authority",
+		);
+	}
+	const jkt = payload.cnf?.jkt;
+	if (!jkt) {
+		throw new SpaceError(
+			"InvalidCredential",
+			"Space credential is missing its cnf.jkt binding",
+		);
+	}
+	if (!opts.dpopProof) {
+		throw new SpaceError("InvalidCredential", "Missing DPoP proof");
+	}
+	let proof;
+	try {
+		proof = await verifyDpopProof(opts.dpopProof, {
+			htm: opts.htm,
+			htu: htuFor(opts),
+			credential,
+			jkt,
+		});
+	} catch (err) {
+		throw invalidCredential(err);
+	}
+	const fresh = await opts.checkReplay(
+		"dpop",
+		proof.jti,
+		nowSec() + 300,
+	);
+	if (!fresh) {
+		throw new SpaceError("InvalidCredential", "DPoP proof replayed");
+	}
+	return { kind: "credential", iss: payload.iss };
+}
+
+export interface DelegationResult {
+	/** The user the delegation token vouches for. */
+	userDid: string;
+	/** Thumbprint of the DPoP key the credential must be bound to. */
+	dpopJkt: string;
+}
+
+/**
+ * Verify a delegation token (`Authorization: Bearer <jwt>` on
+ * getSpaceCredential) plus its DPoP proof (no `ath` when obtaining a
+ * credential). Single use by `(iss, jti)`.
+ */
+export async function verifyDelegationAuth(
+	token: string,
+	space: SpaceRef,
+	opts: VerifyRequestOpts,
+): Promise<DelegationResult> {
+	let payload;
+	try {
+		({ payload } = await verifySpaceToken("delegation", token, {
+			getSigningKey: opts.getSigningKey,
+			aud: spaceHostAud(space.authority),
+			sub: space.uri,
+		}));
+	} catch (err) {
+		throw invalidDelegation(err);
+	}
+	if (!payload.iss.startsWith("did:")) {
+		throw new SpaceError(
+			"InvalidDelegationToken",
+			"Delegation token issuer is not a DID",
+		);
+	}
+	if (!opts.dpopProof) {
+		throw new SpaceError("InvalidDelegationToken", "Missing DPoP proof");
+	}
+	let proof;
+	try {
+		proof = await verifyDpopProof(opts.dpopProof, {
+			htm: opts.htm,
+			htu: htuFor(opts),
+		});
+	} catch (err) {
+		throw invalidDelegation(err);
+	}
+	const fresh = await opts.checkReplay(
+		"delegation",
+		`${payload.iss}:${payload.jti}`,
+		payload.exp,
+	);
+	if (!fresh) {
+		throw new SpaceError(
+			"InvalidDelegationToken",
+			"Delegation token has already been used",
+		);
+	}
+	return { userDid: payload.iss, dpopJkt: proof.jkt };
+}
+
+function invalidCredential(err: unknown): SpaceError {
+	return new SpaceError("InvalidCredential", authErrorMessage(err));
+}
+
+function invalidDelegation(err: unknown): SpaceError {
+	return new SpaceError("InvalidDelegationToken", authErrorMessage(err));
+}
+
+function authErrorMessage(err: unknown): string {
+	if (err instanceof SpaceTokenError || err instanceof DpopProofError) {
+		return err.message;
+	}
+	// DID resolution failures and other infrastructure errors must surface
+	// as 401s, never 500s — but without leaking internals.
+	return "Token verification failed";
+}

--- a/packages/spaces/src/blob-keys.ts
+++ b/packages/spaces/src/blob-keys.ts
@@ -10,6 +10,15 @@
 
 import { spaceId } from "./space-uri.js";
 
+/**
+ * Key for a staged (uploaded, not yet referenced) blob. Must match the
+ * host's public blob layout: uploads land here and are promoted to their
+ * serving key when a record write references them.
+ */
+export function stagedBlobKey(did: string, cid: string): string {
+	return `${did}/staged/${cid}`;
+}
+
 /** Prefix holding every space blob for the account. */
 export function spaceBlobRootPrefix(did: string): string {
 	return `${did}/space/`;

--- a/packages/spaces/src/commit.ts
+++ b/packages/spaces/src/commit.ts
@@ -1,0 +1,55 @@
+/**
+ * Commit signing.
+ *
+ * Signing happens in the Worker, never in the Durable Object. The proposal
+ * requires a fresh `ikm` per reader, so a signature is never stored — each
+ * response that carries a commit signs the persisted LtHash state anew with
+ * the account keypair the Worker already holds.
+ */
+
+import { RepoCommit } from "@atproto/space";
+import type { SignedCommit } from "@atproto/space";
+import type { Keypair } from "@atproto/crypto";
+import { toBase64 } from "@atproto/lex-data";
+import type { RepoState } from "./types.js";
+
+export interface SignCommitParams {
+	spaceUri: string;
+	/** The repo author (the operator DID for every repo Cirrus serves). */
+	author: string;
+	state: RepoState;
+}
+
+export async function signCommit(
+	params: SignCommitParams,
+	keypair: Keypair,
+): Promise<SignedCommit> {
+	return RepoCommit.fromState(params.state.setHash).sign(
+		{
+			space: params.spaceUri,
+			author: params.author,
+			rev: params.state.rev,
+		},
+		keypair,
+	);
+}
+
+/**
+ * Lexicon JSON form of a signed commit (`com.atproto.space.defs#signedCommit`):
+ * bytes fields encode as `{"$bytes": "<base64>"}`.
+ */
+export function commitToJson(commit: SignedCommit): Record<string, unknown> {
+	return {
+		ver: commit.ver,
+		hash: { $bytes: toBase64(commit.hash) },
+		ikm: { $bytes: toBase64(commit.ikm) },
+		sig: { $bytes: toBase64(commit.sig) },
+		mac: { $bytes: toBase64(commit.mac) },
+		rev: commit.rev,
+	};
+}
+
+/** Lexicon JSON form of a bare bytes value. */
+export function bytesToJson(bytes: Uint8Array): { $bytes: string } {
+	return { $bytes: toBase64(bytes) };
+}

--- a/packages/spaces/src/errors.ts
+++ b/packages/spaces/src/errors.ts
@@ -85,15 +85,21 @@ export function parseSpaceErrorCode(
 		return { code: err.code, message: err.detail };
 	}
 	if (err instanceof Error) {
-		const colon = err.message.indexOf(": ");
-		if (colon > 0) {
-			const code = err.message.slice(0, colon);
+		// Durable Object RPC re-throws errors with the class name folded into
+		// the message ("SpaceError: RecordNotFound: ..."), so scan the first
+		// few prefix segments for a known code.
+		let message = err.message;
+		for (let hop = 0; hop < 3; hop++) {
+			const colon = message.indexOf(": ");
+			if (colon <= 0) break;
+			const code = message.slice(0, colon);
 			if (CODE_SET.has(code)) {
 				return {
 					code: code as SpaceErrorCode,
-					message: err.message.slice(colon + 2),
+					message: message.slice(colon + 2),
 				};
 			}
+			message = message.slice(colon + 2);
 		}
 	}
 	return null;

--- a/packages/spaces/src/index.ts
+++ b/packages/spaces/src/index.ts
@@ -32,7 +32,32 @@ export {
 	spaceBlobKeyForUri,
 	spaceBlobPrefix,
 	spaceBlobRootPrefix,
+	stagedBlobKey,
 } from "./blob-keys.js";
+
+export { createSpaceRoutes } from "./routes.js";
+export type {
+	SpaceRoutesHost,
+	SpaceScopeMatch,
+	SpaceSessionAuth,
+	SpaceStub,
+	SpaceIndexStub,
+} from "./routes.js";
+
+export {
+	isSpaceCredentialAuth,
+	unverifiedJwtTyp,
+	verifyDelegationAuth,
+	verifySpaceCredentialAuth,
+} from "./auth.js";
+export type { CheckReplay, GetSigningKey } from "./auth.js";
+
+export { verifyClientAttestation } from "./attestation.js";
+
+export { signCommit, commitToJson, bytesToJson } from "./commit.js";
+
+export { prepareRecord, recordBytesToJson } from "./records.js";
+export type { PreparedRecord } from "./records.js";
 
 export {
 	SPACE_SCHEMA_VERSION,

--- a/packages/spaces/src/records.ts
+++ b/packages/spaces/src/records.ts
@@ -1,0 +1,40 @@
+/**
+ * Record preparation and serialization for the Worker side of the write
+ * and read paths. Records are stored as dag-cbor bytes with their CID,
+ * computed here — the same encoding path the reference uses.
+ */
+
+import { encode, decode, cidForLex } from "@atproto/lex-cbor";
+import { enumBlobRefs, getBlobCidString } from "@atproto/lex-data";
+import type { LexValue } from "@atproto/lex-data";
+import { jsonToLex, lexToJson } from "@atproto/lex-json";
+import type { JsonValue } from "@atproto/lex-json";
+
+export interface PreparedRecord {
+	cid: string;
+	bytes: Uint8Array;
+	blobCids: string[];
+	/** The lex-normalised record, for echoing back in responses. */
+	json: unknown;
+}
+
+/**
+ * Convert a client-supplied JSON record into its stored form: lex value →
+ * dag-cbor bytes → CID, with blob references enumerated for the space's
+ * blob tracking.
+ */
+export async function prepareRecord(record: unknown): Promise<PreparedRecord> {
+	const lex = jsonToLex(record as JsonValue) as LexValue;
+	const bytes = encode(lex);
+	const cid = await cidForLex(lex);
+	const blobCids: string[] = [];
+	for (const ref of enumBlobRefs(lex)) {
+		blobCids.push(getBlobCidString(ref));
+	}
+	return { cid: cid.toString(), bytes, blobCids, json: lexToJson(lex) };
+}
+
+/** Decode stored record bytes back into response JSON. */
+export function recordBytesToJson(bytes: Uint8Array): unknown {
+	return lexToJson(decode(bytes));
+}

--- a/packages/spaces/src/routes.ts
+++ b/packages/spaces/src/routes.ts
@@ -366,7 +366,14 @@ export function createSpaceRoutes(host: SpaceRoutesHost): Hono {
 		hash: Uint8Array,
 	): Promise<void> {
 		if (ref.authority === host.operatorDid) {
-			await stub.rpcRecordWriter(host.operatorDid, rev, hash);
+			const { advanced } = await stub.rpcRecordWriter(
+				host.operatorDid,
+				rev,
+				hash,
+			);
+			// Own writes always advance in practice; guard anyway so a
+			// re-ordered background task never fans out stale state.
+			if (!advanced) return;
 			const registrations = await stub.rpcGetActiveRegistrations();
 			if (registrations.length === 0) return;
 			const body = {
@@ -925,13 +932,62 @@ export function createSpaceRoutes(host: SpaceRoutesHost): Hono {
 
 			const stub = host.getSpaceDO(ref.uri);
 			await requireRepoExists(stub, ref);
-			const state = await stub.rpcGetRepoState();
-			if (!state) {
-				throw new SpaceError(
-					"RepoNotFound",
-					`Could not find repo for space: ${ref.uri}`,
+
+			// The commit signs one revision, so every record page must belong
+			// to it: each page reports the rev it was read at, and a page from
+			// a different rev restarts the export. Records are collected
+			// before signing (serializeRepo buffers anyway — see spec open
+			// questions), so the CAR always matches its commit.
+			let state: Awaited<ReturnType<typeof stub.rpcGetRepoState>> = null;
+			let records: SerializedRecord[] | null = null;
+			for (let attempt = 0; attempt < 3 && !records; attempt++) {
+				state = await stub.rpcGetRepoState();
+				if (!state) {
+					throw new SpaceError(
+						"RepoNotFound",
+						`Could not find repo for space: ${ref.uri}`,
+					);
+				}
+				const collected: SerializedRecord[] = [];
+				let after: { collection: string; rkey: string } | undefined;
+				let fenced = true;
+				for (;;) {
+					const page = await stub.rpcListRecords({
+						limit: 500,
+						after,
+						reverse: true, // ascending
+						excludeValues: false,
+					});
+					if (page.rev !== state.rev) {
+						// A write landed mid-export; retry from a fresh head.
+						fenced = false;
+						break;
+					}
+					for (const record of page.records) {
+						collected.push({
+							collection: record.collection,
+							rkey: record.rkey,
+							cid: parseCid(record.cid),
+							bytes: new Uint8Array(record.bytes!),
+						});
+					}
+					const last = page.records[page.records.length - 1];
+					if (!page.hasMore || !last) break;
+					after = { collection: last.collection, rkey: last.rkey };
+				}
+				if (fenced) records = collected;
+			}
+			if (!records || !state) {
+				return c.json(
+					{
+						error: "ConcurrentModification",
+						message:
+							"The repo changed repeatedly during export; retry getRepo",
+					},
+					409,
 				);
 			}
+
 			const keypair = await host.getKeypair();
 			const commit = await signCommit(
 				{
@@ -945,33 +1001,7 @@ export function createSpaceRoutes(host: SpaceRoutesHost): Hono {
 				keypair,
 			);
 
-			// Records are pulled from the DO in pages. serializeRepo collects
-			// them before writing, so the whole repo passes through Worker
-			// memory — acceptable for the alpha (see spec open questions).
-			async function* records(): AsyncIterable<SerializedRecord> {
-				let after: { collection: string; rkey: string } | undefined;
-				for (;;) {
-					const page = await stub.rpcListRecords({
-						limit: 500,
-						after,
-						reverse: true, // ascending
-						excludeValues: false,
-					});
-					for (const record of page.records) {
-						yield {
-							collection: record.collection,
-							rkey: record.rkey,
-							cid: parseCid(record.cid),
-							bytes: new Uint8Array(record.bytes!),
-						};
-					}
-					const last = page.records[page.records.length - 1];
-					if (!page.hasMore || !last) return;
-					after = { collection: last.collection, rkey: last.rkey };
-				}
-			}
-
-			const car = serializeRepo(commit, records(), { excludeValues });
+			const car = serializeRepo(commit, records, { excludeValues });
 			const stream = new ReadableStream<Uint8Array>({
 				async start(controller) {
 					try {
@@ -1113,6 +1143,9 @@ export function createSpaceRoutes(host: SpaceRoutesHost): Hono {
 				}
 				clientId = await verifyClientAttestation(body.clientAttestation, {
 					expectedAud: spaceHostAud(ref.authority),
+					// Checked pre-verification inside so a non-allowlisted
+					// client never triggers network I/O.
+					allowedClientIds: config.appAccess.allowed,
 					checkReplay: replayChecker(stub),
 					fetch: host.outboundFetch,
 				});
@@ -1328,7 +1361,16 @@ export function createSpaceRoutes(host: SpaceRoutesHost): Hono {
 			}
 
 			const hash = fromBase64(body.hash.$bytes);
-			await stub.rpcRecordWriter(body.repo!, body.rev!, hash);
+			const { advanced } = await stub.rpcRecordWriter(
+				body.repo!,
+				body.rev!,
+				hash,
+			);
+			// A delayed or replayed notification carrying an older rev did not
+			// change the writer set; do not fan stale state out again.
+			if (!advanced) {
+				return c.json({});
+			}
 
 			// Fan out to every registration except the sender.
 			const registrations = await stub.rpcGetActiveRegistrations();
@@ -1383,6 +1425,23 @@ export function createSpaceRoutes(host: SpaceRoutesHost): Hono {
 					{
 						error: "Forbidden",
 						message: "notifySpaceDeleted iss is not the space authority",
+					},
+					403,
+				);
+			}
+			// And only when the notification was addressed to us: without the
+			// audience check, an authority-signed token minted for a different
+			// service could be replayed here to tombstone our repo and delete
+			// its blobs. Registrations use service identifiers, so accept the
+			// bare DID or any of our own #fragment forms.
+			if (
+				serviceAuth.aud !== host.operatorDid &&
+				!serviceAuth.aud.startsWith(`${host.operatorDid}#`)
+			) {
+				return c.json(
+					{
+						error: "Forbidden",
+						message: "notifySpaceDeleted aud does not match this service",
 					},
 					403,
 				);

--- a/packages/spaces/src/routes.ts
+++ b/packages/spaces/src/routes.ts
@@ -1,0 +1,1842 @@
+/**
+ * Hono route factory for `com.atproto.space.*` and
+ * `com.atproto.simplespace.*`.
+ *
+ * The factory is host-agnostic: everything account-specific — session
+ * authentication, DID resolution, record validation, the operator identity
+ * — arrives through {@link SpaceRoutesHost}. The host mounts the returned
+ * app behind its feature flag.
+ */
+
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { createSpaceToken, serializeRepo, spaceHostAud } from "@atproto/space";
+import type { SerializedRecord } from "@atproto/space";
+import type { Keypair } from "@atproto/crypto";
+import { fromBase64, parseCid } from "@atproto/lex-data";
+import { now as tidNow } from "@atcute/tid";
+import {
+	isSpaceCredentialAuth,
+	verifyDelegationAuth,
+	verifySpaceCredentialAuth,
+	type CheckReplay,
+	type GetSigningKey,
+} from "./auth.js";
+import { verifyClientAttestation } from "./attestation.js";
+import { bytesToJson, commitToJson, signCommit } from "./commit.js";
+import { SpaceError, parseSpaceErrorCode, spaceErrorStatus } from "./errors.js";
+import { prepareRecord, recordBytesToJson } from "./records.js";
+import { createServiceJwt } from "./service-jwt.js";
+import { spaceBlobPrefix, spaceBlobKey, stagedBlobKey } from "./blob-keys.js";
+import { requireSpaceUri, spaceId, spaceRecordUri } from "./space-uri.js";
+import type { SpaceRef } from "./space-uri.js";
+import type { SpaceDurableObject } from "./space-do.js";
+import type { SpaceIndexDurableObject } from "./index-do.js";
+import type {
+	NotifyItem,
+	PreparedSpaceWrite,
+	SpaceAppAccess,
+	SpaceConfig,
+	SpacePolicy,
+} from "./types.js";
+
+const NOTIFY_WRITE_LXM = "com.atproto.space.notifyWrite";
+const SPACE_DELETED_LXM = "com.atproto.space.notifySpaceDeleted";
+const CHECK_USER_ACCESS_LXM = "com.atproto.simplespace.checkUserAccess";
+/** A managing app that doesn't answer within this window denies access. */
+const CHECK_USER_ACCESS_TIMEOUT_MS = 5000;
+
+export type SpaceStub = DurableObjectStub<SpaceDurableObject>;
+export type SpaceIndexStub = DurableObjectStub<SpaceIndexDurableObject>;
+
+/** The operation shapes checked against a session's `space:` grants. */
+export type SpaceScopeMatch = { type: string; authority: string; skey: string } & (
+	| { action: "read" | "read_self" }
+	| { action: "create" | "update" | "delete"; collection: string }
+	| { manage: "create" | "update" | "delete" }
+);
+
+/**
+ * A host session (OAuth token with `space:` grants, or a fully-trusted
+ * operator session). App passwords are excluded in the alpha — the host's
+ * authenticate() must not produce one of these for them.
+ */
+export interface SpaceSessionAuth {
+	did: string;
+	/** Fully-trusted operator session: skips scope checks. */
+	fullTrust: boolean;
+	allowsSpace(match: SpaceScopeMatch): boolean;
+}
+
+export interface SpaceRoutesHost {
+	operatorDid: string;
+	/** Public origin clients address, e.g. `https://pds.example.com`. */
+	publicOrigin: string;
+	/** R2 bucket for blobs; space blob endpoints 503 without it. */
+	blobs?: R2Bucket;
+	getKeypair(): Promise<Keypair>;
+	/** DID-doc signing key resolution for foreign issuers. */
+	getSigningKey: GetSigningKey;
+	/**
+	 * Resolve a service identifier (`did` or `did#fragment`) to an HTTPS
+	 * endpoint, or null when unresolvable.
+	 */
+	resolveServiceEndpoint(service: string): Promise<string | null>;
+	/**
+	 * Resolve a space authority's host endpoint: try
+	 * `#atproto_space_host`, fall back to `#atproto_pds`.
+	 */
+	resolveAuthorityEndpoint(did: string): Promise<string | null>;
+	/** Verify an inbound service-auth JWT bound to `lxm`. */
+	verifyServiceJwt(
+		token: string,
+		lxm: string,
+	): Promise<{ iss: string; aud: string }>;
+	/**
+	 * Host session authentication (OAuth / operator sessions). Returns a
+	 * Response for authentication failures.
+	 */
+	authenticate(c: Context): Promise<SpaceSessionAuth | Response>;
+	/**
+	 * Lexicon validation with the host's validator. Throws on invalid
+	 * records; the thrown message is surfaced as an InvalidRecord error.
+	 */
+	validateRecord(input: {
+		collection: string;
+		record: unknown;
+		rkey: string;
+		validate?: boolean;
+	}): { record: unknown; status?: "valid" | "unknown" };
+	getSpaceDO(uri: string): SpaceStub;
+	getIndexDO(): SpaceIndexStub;
+	/** Fetch override for outbound calls (tests). */
+	outboundFetch?: typeof fetch;
+}
+
+// ---------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------
+
+function errorResponse(c: Context, err: unknown): Response {
+	const parsed = parseSpaceErrorCode(err);
+	if (parsed) {
+		return c.json(
+			{ error: parsed.code, message: parsed.message },
+			spaceErrorStatus(parsed.code) as 400,
+		);
+	}
+	throw err;
+}
+
+function waitUntil(c: Context, promise: Promise<unknown>): void {
+	try {
+		c.executionCtx.waitUntil(promise);
+	} catch {
+		// No execution context (tests): let it float.
+		void promise.catch((err) => console.warn("background task failed", err));
+	}
+}
+
+function replayChecker(stub: SpaceStub): CheckReplay {
+	return (kind, key, expiresAtSec) => stub.rpcCheckReplay(kind, key, expiresAtSec);
+}
+
+interface AuthedRead {
+	kind: "credential" | "session";
+}
+
+export function createSpaceRoutes(host: SpaceRoutesHost): Hono {
+	const app = new Hono();
+	const doFetch: typeof fetch = host.outboundFetch ?? fetch;
+
+	/** The `repo` param on every repo-host method must be the operator DID. */
+	function requireRepoParam(repo: unknown): void {
+		if (repo !== host.operatorDid) {
+			throw new SpaceError(
+				"RepoNotFound",
+				`Repository not found: ${String(repo)}`,
+			);
+		}
+	}
+
+	const verifyOpts = (c: Context, stub: SpaceStub) => ({
+		htm: c.req.method,
+		url: c.req.url,
+		publicOrigin: host.publicOrigin,
+		dpopProof: c.req.header("DPoP"),
+		getSigningKey: host.getSigningKey,
+		checkReplay: replayChecker(stub),
+	});
+
+	/**
+	 * Authenticate a read: a space credential for the requested space, or a
+	 * host session covering `read_self` on it. The `repo` param on every
+	 * repo-host method must be the operator DID — anything else is
+	 * RepoNotFound, deliberately indistinguishable from an absent repo.
+	 */
+	async function readAuth(
+		c: Context,
+		ref: SpaceRef,
+		repo: string | undefined,
+	): Promise<AuthedRead | Response> {
+		if (repo !== host.operatorDid) {
+			throw new SpaceError("RepoNotFound", `Repository not found: ${repo}`);
+		}
+		const authHeader = c.req.header("Authorization");
+		if (isSpaceCredentialAuth(authHeader)) {
+			const stub = host.getSpaceDO(ref.uri);
+			await verifySpaceCredentialAuth(
+				authHeader!.slice(5),
+				ref,
+				verifyOpts(c, stub),
+			);
+			return { kind: "credential" };
+		}
+		const session = await host.authenticate(c);
+		if (session instanceof Response) return session;
+		if (!session.fullTrust) {
+			const allowed = session.allowsSpace({
+				type: ref.type,
+				authority: ref.authority,
+				skey: ref.skey,
+				action: "read_self",
+			});
+			if (!allowed) {
+				return c.json(
+					{
+						error: "InsufficientScope",
+						message: "Token does not cover reading this space",
+					},
+					403,
+				);
+			}
+		}
+		return { kind: "session" };
+	}
+
+	/** Session-only auth for writes and management. */
+	async function sessionAuth(
+		c: Context,
+	): Promise<SpaceSessionAuth | Response> {
+		return host.authenticate(c);
+	}
+
+	function assertScope(
+		c: Context,
+		session: SpaceSessionAuth,
+		match: SpaceScopeMatch,
+	): Response | null {
+		if (session.fullTrust) return null;
+		if (session.allowsSpace(match)) return null;
+		return c.json(
+			{
+				error: "InsufficientScope",
+				message: "Token does not cover this space operation",
+			},
+			403,
+		);
+	}
+
+	/** The operator hosts this space, or SpaceNotFound. */
+	function assertSpaceHost(ref: SpaceRef): void {
+		if (ref.authority !== host.operatorDid) {
+			throw new SpaceError("SpaceNotFound", `Space not found: ${ref.uri}`);
+		}
+	}
+
+	/**
+	 * The simplespace user-access policy, applied at credential mint and to
+	 * inbound notifyWrite writers. The authority itself always passes; a
+	 * managing app that errors or times out denies.
+	 */
+	async function authorizeUser(
+		config: SpaceConfig,
+		ref: SpaceRef,
+		userDid: string,
+		clientId: string | undefined,
+		stub: SpaceStub,
+	): Promise<boolean> {
+		if (userDid === ref.authority) return true;
+		switch (config.policy.kind) {
+			case "public":
+				return true;
+			case "member-list":
+				return stub.rpcIsMember(userDid);
+			case "managing-app": {
+				const managingApp = config.policy.managingApp;
+				try {
+					const endpoint = await host.resolveServiceEndpoint(managingApp);
+					if (!endpoint) return false;
+					const keypair = await host.getKeypair();
+					const token = await createServiceJwt(
+						{
+							iss: host.operatorDid,
+							aud: managingApp,
+							lxm: CHECK_USER_ACCESS_LXM,
+						},
+						keypair,
+					);
+					const url = new URL(`${endpoint}/xrpc/${CHECK_USER_ACCESS_LXM}`);
+					url.searchParams.set("space", ref.uri);
+					url.searchParams.set("user", userDid);
+					if (clientId) url.searchParams.set("clientId", clientId);
+					const res = await doFetch(url.toString(), {
+						headers: { Authorization: `Bearer ${token}` },
+						signal: AbortSignal.timeout(CHECK_USER_ACCESS_TIMEOUT_MS),
+					});
+					if (!res.ok) return false;
+					const body = (await res.json()) as { authorized?: unknown };
+					return body.authorized === true;
+				} catch {
+					// No decision caching in the alpha; unreachable app denies.
+					return false;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Ensure the space DO exists for a write. First write into a foreign
+	 * space registers it `pending` in the index, initialises the DO as
+	 * repo-host, then activates the entry. Spaces under the operator's own
+	 * authority must have been created via simplespace first.
+	 */
+	async function ensureSpaceForWrite(ref: SpaceRef, stub: SpaceStub): Promise<void> {
+		const meta = await stub.rpcGetMeta();
+		if (meta && !meta.deletedAt) return;
+		if (ref.authority === host.operatorDid) {
+			throw new SpaceError(
+				"SpaceNotFound",
+				`Space not found: ${ref.uri}. Create it with com.atproto.simplespace.createSpace.`,
+			);
+		}
+		const index = host.getIndexDO();
+		await index.rpcRegister({
+			uri: ref.uri,
+			authority: ref.authority,
+			type: ref.type,
+			skey: ref.skey,
+			isAuthority: false,
+		});
+		await stub.rpcInit({
+			uri: ref.uri,
+			authority: ref.authority,
+			type: ref.type,
+			skey: ref.skey,
+			isAuthority: false,
+		});
+		await index.rpcActivate(ref.uri);
+	}
+
+	/**
+	 * Promote staged blobs to the space's R2 prefix. Runs before the DO
+	 * commit so nothing reacting to the commit sees a 404. Idempotent per
+	 * CID; CIDs that are neither staged nor at the destination are skipped.
+	 */
+	async function promoteSpaceBlobs(
+		ref: SpaceRef,
+		blobCids: string[],
+	): Promise<void> {
+		if (!host.blobs || blobCids.length === 0) return;
+		const id = await spaceId(ref.uri);
+		await Promise.all(
+			blobCids.map(async (cid) => {
+				const destKey = spaceBlobKey(host.operatorDid, id, cid);
+				if (await host.blobs!.head(destKey)) return;
+				const staged = await host.blobs!.get(
+					stagedBlobKey(host.operatorDid, cid),
+				);
+				if (!staged) return;
+				await host.blobs!.put(destKey, staged.body, {
+					httpMetadata: staged.httpMetadata,
+				});
+			}),
+		);
+	}
+
+	/**
+	 * Step 8 of the write path: after the commit is applied, record the
+	 * writer and fan out (own authority) or send one best-effort
+	 * notifyWrite to the space's authority (foreign space).
+	 */
+	async function postWrite(
+		ref: SpaceRef,
+		stub: SpaceStub,
+		rev: string,
+		hash: Uint8Array,
+	): Promise<void> {
+		if (ref.authority === host.operatorDid) {
+			await stub.rpcRecordWriter(host.operatorDid, rev, hash);
+			const registrations = await stub.rpcGetActiveRegistrations();
+			if (registrations.length === 0) return;
+			const body = {
+				space: ref.uri,
+				repo: host.operatorDid,
+				rev,
+				hash: bytesToJson(hash),
+			};
+			const items: NotifyItem[] = registrations.map((registration) => ({
+				service: registration.service,
+				endpoint: registration.endpoint,
+				lxm: NOTIFY_WRITE_LXM,
+				body,
+			}));
+			await stub.rpcEnqueueNotify(items);
+			return;
+		}
+		// One attempt, logged on failure: notifications are best-effort and
+		// syncers self-heal, so a retry queue for the writer role is not
+		// worth its complexity.
+		try {
+			const endpoint = await host.resolveAuthorityEndpoint(ref.authority);
+			if (!endpoint) {
+				console.warn(`notifyWrite: no endpoint for ${ref.authority}`);
+				return;
+			}
+			const keypair = await host.getKeypair();
+			const token = await createServiceJwt(
+				{ iss: host.operatorDid, aud: ref.authority, lxm: NOTIFY_WRITE_LXM },
+				keypair,
+			);
+			const res = await doFetch(`${endpoint}/xrpc/${NOTIFY_WRITE_LXM}`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${token}`,
+				},
+				body: JSON.stringify({
+					space: ref.uri,
+					repo: host.operatorDid,
+					rev,
+					hash: bytesToJson(hash),
+				}),
+			});
+			if (!res.ok) {
+				console.warn(
+					`notifyWrite to ${ref.authority} failed: ${res.status}`,
+				);
+			}
+		} catch (err) {
+			console.warn(`notifyWrite to ${ref.authority} errored:`, err);
+		}
+	}
+
+	interface WriteInput {
+		action: "create" | "update" | "delete";
+		collection: string;
+		rkey?: string;
+		value?: unknown;
+	}
+
+	/**
+	 * Common write pipeline for createRecord/putRecord/deleteRecord and
+	 * applyWrites: validate, prepare bytes and CIDs, promote blobs, ensure
+	 * the space DO, apply the batch, notify in the background.
+	 */
+	async function runWrites(
+		c: Context,
+		ref: SpaceRef,
+		session: SpaceSessionAuth,
+		writes: WriteInput[],
+		validate: boolean | undefined,
+	): Promise<
+		| Response
+		| {
+				rev: string;
+				results: Array<{
+					action: string;
+					collection: string;
+					rkey: string;
+					cid: string | null;
+					validationStatus?: string;
+				}>;
+		  }
+	> {
+		const prepared: PreparedSpaceWrite[] = [];
+		const statuses: Array<string | undefined> = [];
+		const blobCids = new Set<string>();
+
+		for (const write of writes) {
+			const scopeError = assertScope(c, session, {
+				type: ref.type,
+				authority: ref.authority,
+				skey: ref.skey,
+				action: write.action,
+				collection: write.collection,
+			});
+			if (scopeError) return scopeError;
+
+			if (write.action === "delete") {
+				prepared.push({
+					action: "delete",
+					collection: write.collection,
+					rkey: write.rkey!,
+				});
+				statuses.push(undefined);
+				continue;
+			}
+
+			const rkey = write.rkey ?? tidNow();
+			let validated;
+			try {
+				validated = host.validateRecord({
+					collection: write.collection,
+					record: write.value,
+					rkey,
+					validate,
+				});
+			} catch (err) {
+				return c.json(
+					{
+						error: "InvalidRecord",
+						message: err instanceof Error ? err.message : String(err),
+					},
+					400,
+				);
+			}
+			const preparedRecord = await prepareRecord(validated.record);
+			for (const cid of preparedRecord.blobCids) blobCids.add(cid);
+			prepared.push({
+				action: write.action,
+				collection: write.collection,
+				rkey,
+				cid: preparedRecord.cid,
+				bytes: preparedRecord.bytes,
+				blobCids: preparedRecord.blobCids,
+			});
+			statuses.push(validated.status);
+		}
+
+		// The copy completes before the DO commit is applied, so a relay or
+		// syncer reacting to the commit never sees a 404.
+		await promoteSpaceBlobs(ref, Array.from(blobCids));
+
+		const stub = host.getSpaceDO(ref.uri);
+		await ensureSpaceForWrite(ref, stub);
+		const result = await stub.rpcApplyWrites(prepared);
+
+		waitUntil(c, postWrite(ref, stub, result.rev, result.hash));
+
+		return {
+			rev: result.rev,
+			results: result.results.map((r, i) => ({
+				...r,
+				...(statuses[i] !== undefined
+					? { validationStatus: statuses[i] }
+					: {}),
+			})),
+		};
+	}
+
+	// ---------------------------------------------------------------
+	// Write endpoints (repo host, session auth)
+	// ---------------------------------------------------------------
+
+	app.post("/xrpc/com.atproto.space.createRecord", async (c) => {
+		try {
+			const body = await c.req.json<{
+				space?: string;
+				repo?: string;
+				collection?: string;
+				rkey?: string;
+				validate?: boolean;
+				record?: unknown;
+			}>();
+			const ref = requireSpaceUri(body.space);
+			requireRepoParam(body.repo);
+			requireString(body.collection, "collection");
+			const session = await sessionAuth(c);
+			if (session instanceof Response) return session;
+			const result = await runWrites(
+				c,
+				ref,
+				session,
+				[
+					{
+						action: "create",
+						collection: body.collection!,
+						rkey: body.rkey,
+						value: body.record,
+					},
+				],
+				body.validate,
+			);
+			if (result instanceof Response) return result;
+			const write = result.results[0]!;
+			return c.json({
+				uri: spaceRecordUri(
+					ref.uri,
+					host.operatorDid,
+					write.collection,
+					write.rkey,
+				),
+				cid: write.cid,
+				...(write.validationStatus
+					? { validationStatus: write.validationStatus }
+					: {}),
+			});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.post("/xrpc/com.atproto.space.putRecord", async (c) => {
+		try {
+			const body = await c.req.json<{
+				space?: string;
+				repo?: string;
+				collection?: string;
+				rkey?: string;
+				validate?: boolean;
+				record?: unknown;
+			}>();
+			const ref = requireSpaceUri(body.space);
+			requireRepoParam(body.repo);
+			requireString(body.collection, "collection");
+			requireString(body.rkey, "rkey");
+			const session = await sessionAuth(c);
+			if (session instanceof Response) return session;
+
+			// Upsert: the scope asserted is the operation actually performed.
+			const stub = host.getSpaceDO(ref.uri);
+			const meta = await stub.rpcGetMeta();
+			const exists =
+				meta && !meta.deletedAt
+					? (await stub.rpcGetRecord(body.collection!, body.rkey!)) !== null
+					: false;
+
+			const result = await runWrites(
+				c,
+				ref,
+				session,
+				[
+					{
+						action: exists ? "update" : "create",
+						collection: body.collection!,
+						rkey: body.rkey,
+						value: body.record,
+					},
+				],
+				body.validate,
+			);
+			if (result instanceof Response) return result;
+			const write = result.results[0]!;
+			return c.json({
+				uri: spaceRecordUri(
+					ref.uri,
+					host.operatorDid,
+					write.collection,
+					write.rkey,
+				),
+				cid: write.cid,
+				...(write.validationStatus
+					? { validationStatus: write.validationStatus }
+					: {}),
+			});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.post("/xrpc/com.atproto.space.deleteRecord", async (c) => {
+		try {
+			const body = await c.req.json<{
+				space?: string;
+				repo?: string;
+				collection?: string;
+				rkey?: string;
+			}>();
+			const ref = requireSpaceUri(body.space);
+			requireRepoParam(body.repo);
+			requireString(body.collection, "collection");
+			requireString(body.rkey, "rkey");
+			const session = await sessionAuth(c);
+			if (session instanceof Response) return session;
+			const result = await runWrites(
+				c,
+				ref,
+				session,
+				[
+					{
+						action: "delete",
+						collection: body.collection!,
+						rkey: body.rkey,
+					},
+				],
+				undefined,
+			);
+			if (result instanceof Response) return result;
+			return c.json({});
+		} catch (err) {
+			// Deleting an absent record succeeds: nothing committed, nothing
+			// notified.
+			if (parseSpaceErrorCode(err)?.code === "RecordNotFound") {
+				return c.json({});
+			}
+			return errorResponse(c, err);
+		}
+	});
+
+	app.post("/xrpc/com.atproto.space.applyWrites", async (c) => {
+		try {
+			const body = await c.req.json<{
+				space?: string;
+				repo?: string;
+				validate?: boolean;
+				writes?: Array<{
+					$type?: string;
+					collection?: string;
+					rkey?: string;
+					value?: unknown;
+				}>;
+			}>();
+			const ref = requireSpaceUri(body.space);
+			requireRepoParam(body.repo);
+			if (!Array.isArray(body.writes)) {
+				throw new SpaceError("InvalidRequest", "writes must be an array");
+			}
+			if (body.writes.length > 200) {
+				throw new SpaceError("InvalidRequest", "Too many writes. Max: 200");
+			}
+			const session = await sessionAuth(c);
+			if (session instanceof Response) return session;
+
+			const inputs: WriteInput[] = body.writes.map((write, i) => {
+				const action =
+					write.$type === "com.atproto.space.applyWrites#create"
+						? ("create" as const)
+						: write.$type === "com.atproto.space.applyWrites#update"
+							? ("update" as const)
+							: write.$type === "com.atproto.space.applyWrites#delete"
+								? ("delete" as const)
+								: null;
+				if (!action || !write.collection) {
+					throw new SpaceError(
+						"InvalidRequest",
+						`Write ${i}: unknown $type or missing collection`,
+					);
+				}
+				if (action !== "create" && !write.rkey) {
+					throw new SpaceError(
+						"InvalidRequest",
+						`Write ${i}: ${action} requires rkey`,
+					);
+				}
+				return {
+					action,
+					collection: write.collection,
+					rkey: write.rkey,
+					value: write.value,
+				};
+			});
+
+			const result = await runWrites(c, ref, session, inputs, body.validate);
+			if (result instanceof Response) return result;
+			return c.json({
+				results: result.results.map((write) => {
+					if (write.action === "delete") {
+						return { $type: "com.atproto.space.applyWrites#deleteResult" };
+					}
+					return {
+						$type: `com.atproto.space.applyWrites#${write.action}Result`,
+						uri: spaceRecordUri(
+							ref.uri,
+							host.operatorDid,
+							write.collection,
+							write.rkey,
+						),
+						cid: write.cid,
+						...(write.validationStatus
+							? { validationStatus: write.validationStatus }
+							: {}),
+					};
+				}),
+			});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	// ---------------------------------------------------------------
+	// Read and sync endpoints (credential or session auth)
+	// ---------------------------------------------------------------
+
+	app.get("/xrpc/com.atproto.space.getRecord", async (c) => {
+		try {
+			const ref = requireSpaceUri(c.req.query("space"));
+			const auth = await readAuth(c, ref, c.req.query("repo"));
+			if (auth instanceof Response) return auth;
+			const collection = c.req.query("collection");
+			const rkey = c.req.query("rkey");
+			requireString(collection, "collection");
+			requireString(rkey, "rkey");
+
+			const stub = host.getSpaceDO(ref.uri);
+			await requireRepoExists(stub, ref);
+			const record = await stub.rpcGetRecord(collection!, rkey!);
+			const uri = spaceRecordUri(ref.uri, host.operatorDid, collection!, rkey!);
+			if (!record) {
+				throw new SpaceError(
+					"RecordNotFound",
+					`Could not locate record: ${uri}`,
+				);
+			}
+			return c.json({
+				uri,
+				cid: record.cid,
+				value: recordBytesToJson(record.bytes),
+			});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.get("/xrpc/com.atproto.space.listRecords", async (c) => {
+		try {
+			const ref = requireSpaceUri(c.req.query("space"));
+			const auth = await readAuth(c, ref, c.req.query("repo"));
+			if (auth instanceof Response) return auth;
+			const collection = c.req.query("collection");
+			const limit = clampLimit(c.req.query("limit"), 50, 1000);
+			const reverse = c.req.query("reverse") === "true";
+			const excludeValues = c.req.query("excludeValues") === "true";
+			const after = parseRecordCursor(c.req.query("cursor"));
+
+			const stub = host.getSpaceDO(ref.uri);
+			await requireRepoExists(stub, ref);
+			const page = await stub.rpcListRecords({
+				collection,
+				limit,
+				after,
+				reverse,
+				excludeValues,
+			});
+			const records = page.records.map((record) => ({
+				collection: record.collection,
+				rkey: record.rkey,
+				cid: record.cid,
+				...(record.bytes
+					? { value: recordBytesToJson(new Uint8Array(record.bytes)) }
+					: {}),
+			}));
+			const last = page.records[page.records.length - 1];
+			return c.json({
+				records,
+				...(page.hasMore && last
+					? { cursor: `${last.collection}/${last.rkey}` }
+					: {}),
+			});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.get("/xrpc/com.atproto.space.getLatestCommit", async (c) => {
+		try {
+			const ref = requireSpaceUri(c.req.query("space"));
+			const auth = await readAuth(c, ref, c.req.query("repo"));
+			if (auth instanceof Response) return auth;
+			const stub = host.getSpaceDO(ref.uri);
+			await requireRepoExists(stub, ref);
+			const state = await stub.rpcGetRepoState();
+			if (!state) {
+				throw new SpaceError(
+					"RepoNotFound",
+					`Could not find repo for space: ${ref.uri}`,
+				);
+			}
+			const keypair = await host.getKeypair();
+			const commit = await signCommit(
+				{
+					spaceUri: ref.uri,
+					author: host.operatorDid,
+					state: {
+						setHash: new Uint8Array(state.setHash),
+						rev: state.rev,
+					},
+				},
+				keypair,
+			);
+			return c.json({ commit: commitToJson(commit) });
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.get("/xrpc/com.atproto.space.listRepoOps", async (c) => {
+		try {
+			const ref = requireSpaceUri(c.req.query("space"));
+			const auth = await readAuth(c, ref, c.req.query("repo"));
+			if (auth instanceof Response) return auth;
+			const limit = clampLimit(c.req.query("limit"), 100, 1000);
+			const since = c.req.query("since");
+			const excludeValues = c.req.query("excludeValues") === "true";
+			const after = parseOpsCursor(c.req.query("cursor"));
+
+			const stub = host.getSpaceDO(ref.uri);
+			await requireRepoExists(stub, ref);
+			const page = await stub.rpcListRepoOps({
+				since,
+				after,
+				limit,
+				excludeValues,
+			});
+			const ops = page.ops.map((op) => ({
+				rev: op.rev,
+				collection: op.collection,
+				rkey: op.rkey,
+				cid: op.cid,
+				prev: op.prev,
+				...(op.bytes
+					? { value: recordBytesToJson(new Uint8Array(op.bytes)) }
+					: {}),
+			}));
+			if (!page.head) {
+				const last = page.ops[page.ops.length - 1];
+				return c.json({
+					ops,
+					...(last ? { cursor: `${last.rev}/${last.idx}` } : {}),
+				});
+			}
+			const keypair = await host.getKeypair();
+			const commit = await signCommit(
+				{
+					spaceUri: ref.uri,
+					author: host.operatorDid,
+					state: {
+						setHash: new Uint8Array(page.head.setHash),
+						rev: page.head.rev,
+					},
+				},
+				keypair,
+			);
+			return c.json({ ops, commit: commitToJson(commit) });
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.get("/xrpc/com.atproto.space.getRepo", async (c) => {
+		try {
+			const ref = requireSpaceUri(c.req.query("space"));
+			const auth = await readAuth(c, ref, c.req.query("repo"));
+			if (auth instanceof Response) return auth;
+			const excludeValues = c.req.query("excludeValues") === "true";
+
+			const stub = host.getSpaceDO(ref.uri);
+			await requireRepoExists(stub, ref);
+			const state = await stub.rpcGetRepoState();
+			if (!state) {
+				throw new SpaceError(
+					"RepoNotFound",
+					`Could not find repo for space: ${ref.uri}`,
+				);
+			}
+			const keypair = await host.getKeypair();
+			const commit = await signCommit(
+				{
+					spaceUri: ref.uri,
+					author: host.operatorDid,
+					state: {
+						setHash: new Uint8Array(state.setHash),
+						rev: state.rev,
+					},
+				},
+				keypair,
+			);
+
+			// Records are pulled from the DO in pages. serializeRepo collects
+			// them before writing, so the whole repo passes through Worker
+			// memory — acceptable for the alpha (see spec open questions).
+			async function* records(): AsyncIterable<SerializedRecord> {
+				let after: { collection: string; rkey: string } | undefined;
+				for (;;) {
+					const page = await stub.rpcListRecords({
+						limit: 500,
+						after,
+						reverse: true, // ascending
+						excludeValues: false,
+					});
+					for (const record of page.records) {
+						yield {
+							collection: record.collection,
+							rkey: record.rkey,
+							cid: parseCid(record.cid),
+							bytes: new Uint8Array(record.bytes!),
+						};
+					}
+					const last = page.records[page.records.length - 1];
+					if (!page.hasMore || !last) return;
+					after = { collection: last.collection, rkey: last.rkey };
+				}
+			}
+
+			const car = serializeRepo(commit, records(), { excludeValues });
+			const stream = new ReadableStream<Uint8Array>({
+				async start(controller) {
+					try {
+						for await (const chunk of car) {
+							controller.enqueue(chunk);
+						}
+						controller.close();
+					} catch (err) {
+						controller.error(err);
+					}
+				},
+			});
+			return new Response(stream, {
+				status: 200,
+				headers: { "Content-Type": "application/vnd.ipld.car" },
+			});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.get("/xrpc/com.atproto.space.listBlobs", async (c) => {
+		try {
+			const ref = requireSpaceUri(c.req.query("space"));
+			const auth = await readAuth(c, ref, c.req.query("repo"));
+			if (auth instanceof Response) return auth;
+			const limit = clampLimit(c.req.query("limit"), 500, 1000);
+			const since = c.req.query("since");
+			const afterCid = c.req.query("cursor");
+
+			const stub = host.getSpaceDO(ref.uri);
+			await requireRepoExists(stub, ref);
+			const page = await stub.rpcListBlobs({ since, limit, afterCid });
+			const last = page.cids[page.cids.length - 1];
+			return c.json({
+				cids: page.cids,
+				...(page.hasMore && last ? { cursor: last } : {}),
+			});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.get("/xrpc/com.atproto.space.getBlob", async (c) => {
+		try {
+			const ref = requireSpaceUri(c.req.query("space"));
+			const auth = await readAuth(c, ref, c.req.query("repo"));
+			if (auth instanceof Response) return auth;
+			const cid = c.req.query("cid");
+			requireString(cid, "cid");
+			if (!host.blobs) {
+				return c.json(
+					{
+						error: "ServiceUnavailable",
+						message: "Blob storage is not configured",
+					},
+					503,
+				);
+			}
+
+			const stub = host.getSpaceDO(ref.uri);
+			await requireRepoExists(stub, ref);
+			// Refuse before touching the blobstore: do not reveal whether an
+			// unreferenced blob exists.
+			if (!(await stub.rpcHasSpaceBlob(cid!))) {
+				throw new SpaceError("BlobNotFound", `Blob not found: ${cid}`);
+			}
+			const key = spaceBlobKey(host.operatorDid, await spaceId(ref.uri), cid!);
+			const blob = await host.blobs.get(key);
+			if (!blob) {
+				throw new SpaceError("BlobNotFound", `Blob not found: ${cid}`);
+			}
+			return new Response(blob.body, {
+				status: 200,
+				headers: {
+					"Content-Type":
+						blob.httpMetadata?.contentType ?? "application/octet-stream",
+					"Content-Length": blob.size.toString(),
+					// A shared cache in front of the PDS must never store a
+					// response whose authorisation was per-credential.
+					"Cache-Control": "private, no-store",
+					Vary: "Authorization, DPoP",
+					"X-Content-Type-Options": "nosniff",
+					"Content-Disposition": `attachment; filename="${cid}"`,
+					"Content-Security-Policy": "default-src 'none'; sandbox",
+				},
+			});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	// ---------------------------------------------------------------
+	// Space host endpoints (authority role)
+	// ---------------------------------------------------------------
+
+	app.post("/xrpc/com.atproto.space.getSpaceCredential", async (c) => {
+		try {
+			const body = await c.req.json<{
+				space?: string;
+				clientAttestation?: string;
+			}>();
+			const ref = requireSpaceUri(body.space);
+			assertSpaceHost(ref);
+
+			const authHeader = c.req.header("Authorization");
+			if (!authHeader?.startsWith("Bearer ")) {
+				throw new SpaceError(
+					"InvalidDelegationToken",
+					"Expected a Bearer delegation token",
+				);
+			}
+			const stub = host.getSpaceDO(ref.uri);
+			const delegation = await verifyDelegationAuth(
+				authHeader.slice(7),
+				ref,
+				verifyOpts(c, stub),
+			);
+
+			const { meta, config } = await stub.rpcGetAuthorityState();
+			if (meta?.deletedAt) {
+				// The durable signal that a space is gone: a syncer that missed
+				// notifySpaceDeleted learns to drop its copy here.
+				throw new SpaceError("SpaceDeleted", `Space deleted: ${ref.uri}`);
+			}
+			if (!meta || !config) {
+				throw new SpaceError("SpaceNotFound", `Space not found: ${ref.uri}`);
+			}
+
+			// App perimeter first, so a refused app is never disclosed to a
+			// third-party managing app.
+			let clientId: string | undefined;
+			if (config.appAccess.kind === "allowList") {
+				if (!body.clientAttestation) {
+					throw new SpaceError(
+						"AppNotAuthorized",
+						"This space requires a client attestation",
+					);
+				}
+				clientId = await verifyClientAttestation(body.clientAttestation, {
+					expectedAud: spaceHostAud(ref.authority),
+					checkReplay: replayChecker(stub),
+					fetch: host.outboundFetch,
+				});
+				if (!config.appAccess.allowed.includes(clientId)) {
+					throw new SpaceError(
+						"AppNotAuthorized",
+						"App is not authorized for this space",
+					);
+				}
+			}
+
+			const authorized = await authorizeUser(
+				config,
+				ref,
+				delegation.userDid,
+				clientId,
+				stub,
+			);
+			if (!authorized) {
+				throw new SpaceError(
+					"UserNotAuthorized",
+					"User is not authorized for this space",
+				);
+			}
+
+			const keypair = await host.getKeypair();
+			const credential = await createSpaceToken(
+				"credential",
+				{
+					iss: host.operatorDid,
+					sub: ref.uri,
+					dpopJkt: delegation.dpopJkt,
+				},
+				keypair,
+			);
+			return c.json({ credential });
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.get("/xrpc/com.atproto.space.listRepos", async (c) => {
+		try {
+			const ref = requireSpaceUri(c.req.query("space"));
+			assertSpaceHost(ref);
+			const authHeader = c.req.header("Authorization");
+			if (!isSpaceCredentialAuth(authHeader)) {
+				throw new SpaceError(
+					"InvalidCredential",
+					"listRepos requires a space credential",
+				);
+			}
+			const stub = host.getSpaceDO(ref.uri);
+			await verifySpaceCredentialAuth(
+				authHeader!.slice(5),
+				ref,
+				verifyOpts(c, stub),
+			);
+			const limit = clampLimit(c.req.query("limit"), 100, 1000);
+			const page = await stub.rpcListWriters({
+				limit,
+				afterDid: c.req.query("cursor"),
+			});
+			const last = page.repos[page.repos.length - 1];
+			return c.json({
+				repos: page.repos.map((repo) => ({
+					did: repo.did,
+					rev: repo.rev,
+					hash: bytesToJson(new Uint8Array(repo.hash)),
+				})),
+				...(page.hasMore && last ? { cursor: last.did } : {}),
+			});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.post("/xrpc/com.atproto.space.registerNotify", async (c) => {
+		try {
+			const body = await c.req.json<{ space?: string; service?: string }>();
+			const ref = requireSpaceUri(body.space);
+			assertSpaceHost(ref);
+			requireString(body.service, "service");
+			const authHeader = c.req.header("Authorization");
+			if (!isSpaceCredentialAuth(authHeader)) {
+				throw new SpaceError(
+					"InvalidCredential",
+					"registerNotify requires a space credential",
+				);
+			}
+			const stub = host.getSpaceDO(ref.uri);
+			await verifySpaceCredentialAuth(
+				authHeader!.slice(5),
+				ref,
+				verifyOpts(c, stub),
+			);
+			// Resolve now and store both, so fan-out never resolves DIDs.
+			const endpoint = await host.resolveServiceEndpoint(body.service!);
+			if (!endpoint) {
+				throw new SpaceError(
+					"ServiceNotResolvable",
+					`Could not resolve service: ${body.service}`,
+				);
+			}
+			const result = await stub.rpcRegisterNotify(body.service!, endpoint);
+			return c.json({ expiresAt: result.expiresAt });
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.post("/xrpc/com.atproto.space.unregisterNotify", async (c) => {
+		try {
+			const body = await c.req.json<{ space?: string; service?: string }>();
+			const ref = requireSpaceUri(body.space);
+			assertSpaceHost(ref);
+			requireString(body.service, "service");
+			const authHeader = c.req.header("Authorization");
+			if (!isSpaceCredentialAuth(authHeader)) {
+				throw new SpaceError(
+					"InvalidCredential",
+					"unregisterNotify requires a space credential",
+				);
+			}
+			const stub = host.getSpaceDO(ref.uri);
+			await verifySpaceCredentialAuth(
+				authHeader!.slice(5),
+				ref,
+				verifyOpts(c, stub),
+			);
+			// No endpoint resolution: a subscriber whose DID doc changed must
+			// still be able to withdraw. Idempotent.
+			await stub.rpcUnregisterNotify(body.service!);
+			return c.json({});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.post("/xrpc/com.atproto.space.notifyWrite", async (c) => {
+		try {
+			const body = await c.req.json<{
+				space?: string;
+				repo?: string;
+				rev?: string;
+				hash?: { $bytes?: string };
+			}>();
+			const ref = requireSpaceUri(body.space);
+			assertSpaceHost(ref);
+			requireString(body.repo, "repo");
+			requireString(body.rev, "rev");
+			if (typeof body.hash?.$bytes !== "string") {
+				throw new SpaceError("InvalidRequest", "Missing hash bytes");
+			}
+
+			const authHeader = c.req.header("Authorization");
+			if (!authHeader?.startsWith("Bearer ")) {
+				return c.json(
+					{
+						error: "AuthenticationRequired",
+						message: "Service auth required",
+					},
+					401,
+				);
+			}
+			const serviceAuth = await host.verifyServiceJwt(
+				authHeader.slice(7),
+				NOTIFY_WRITE_LXM,
+			);
+			if (serviceAuth.iss !== body.repo) {
+				return c.json(
+					{
+						error: "Forbidden",
+						message: "notifyWrite iss does not match claimed writer",
+					},
+					403,
+				);
+			}
+			// The reference checks the bare DID as audience, not the
+			// #atproto_space_host fragment, and we match it.
+			if (serviceAuth.aud !== host.operatorDid) {
+				return c.json(
+					{
+						error: "Forbidden",
+						message: "notifyWrite aud does not match the space authority",
+					},
+					403,
+				);
+			}
+
+			const stub = host.getSpaceDO(ref.uri);
+			const { meta, config } = await stub.rpcGetAuthorityState();
+			if (!meta || meta.deletedAt || !config) {
+				// Silently ignore notifications for spaces this host does not
+				// (or no longer) governs.
+				return c.json({});
+			}
+			const authorized = await authorizeUser(
+				config,
+				ref,
+				body.repo!,
+				undefined,
+				stub,
+			);
+			if (!authorized) {
+				return c.json(
+					{
+						error: "Forbidden",
+						message: "notifyWrite writer is not authorized",
+					},
+					403,
+				);
+			}
+
+			const hash = fromBase64(body.hash.$bytes);
+			await stub.rpcRecordWriter(body.repo!, body.rev!, hash);
+
+			// Fan out to every registration except the sender.
+			const registrations = await stub.rpcGetActiveRegistrations();
+			const senderDid = body.repo!;
+			const targets = registrations.filter(
+				(registration) => registration.service.split("#")[0] !== senderDid,
+			);
+			if (targets.length > 0) {
+				const notifyBody = {
+					space: ref.uri,
+					repo: body.repo!,
+					rev: body.rev!,
+					hash: body.hash,
+				};
+				await stub.rpcEnqueueNotify(
+					targets.map((registration) => ({
+						service: registration.service,
+						endpoint: registration.endpoint,
+						lxm: NOTIFY_WRITE_LXM,
+						body: notifyBody,
+					})),
+				);
+			}
+			return c.json({});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.post("/xrpc/com.atproto.space.notifySpaceDeleted", async (c) => {
+		try {
+			const body = await c.req.json<{ space?: string }>();
+			const ref = requireSpaceUri(body.space);
+
+			const authHeader = c.req.header("Authorization");
+			if (!authHeader?.startsWith("Bearer ")) {
+				return c.json(
+					{
+						error: "AuthenticationRequired",
+						message: "Service auth required",
+					},
+					401,
+				);
+			}
+			const serviceAuth = await host.verifyServiceJwt(
+				authHeader.slice(7),
+				SPACE_DELETED_LXM,
+			);
+			// Only the space's authority may tell us to drop our copy.
+			if (serviceAuth.iss !== ref.authority) {
+				return c.json(
+					{
+						error: "Forbidden",
+						message: "notifySpaceDeleted iss is not the space authority",
+					},
+					403,
+				);
+			}
+			if (ref.authority === host.operatorDid) {
+				// We are the authority; nothing to drop from elsewhere.
+				return c.json({});
+			}
+
+			const stub = host.getSpaceDO(ref.uri);
+			const meta = await stub.rpcGetMeta();
+			if (meta && !meta.deletedAt) {
+				await stub.rpcDeleteSpace();
+				await host.getIndexDO().rpcMarkDeleted(ref.uri);
+				if (host.blobs) {
+					waitUntil(
+						c,
+						deleteR2Prefix(
+							host.blobs,
+							spaceBlobPrefix(host.operatorDid, await spaceId(ref.uri)),
+						),
+					);
+				}
+			}
+			return c.json({});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	// ---------------------------------------------------------------
+	// simplespace management (authority role, session auth)
+	// ---------------------------------------------------------------
+
+	app.post("/xrpc/com.atproto.simplespace.createSpace", async (c) => {
+		try {
+			const body = await c.req.json<{
+				type?: string;
+				skey?: string;
+				policy?: unknown;
+				appAccess?: unknown;
+			}>();
+			requireString(body.type, "type");
+			const skey = body.skey ?? tidNow();
+			const session = await sessionAuth(c);
+			if (session instanceof Response) return session;
+			const scopeError = assertScope(c, session, {
+				type: body.type!,
+				authority: host.operatorDid,
+				skey,
+				manage: "create",
+			});
+			if (scopeError) return scopeError;
+
+			const config: SpaceConfig = {
+				policy: parsePolicy(body.policy),
+				appAccess: parseAppAccess(body.appAccess),
+			};
+			const uri = `at://${host.operatorDid}/space/${body.type}/${skey}`;
+			const ref = requireSpaceUri(uri);
+
+			// Two-step creation: index entry `pending`, then the DO, then
+			// `active`. Reads never depend on the index, so a crash between
+			// steps leaves only a pending entry for the alarm to reap.
+			const index = host.getIndexDO();
+			await index.rpcRegister({
+				uri: ref.uri,
+				authority: ref.authority,
+				type: ref.type,
+				skey: ref.skey,
+				isAuthority: true,
+			});
+			const stub = host.getSpaceDO(ref.uri);
+			await stub.rpcInit({
+				uri: ref.uri,
+				authority: ref.authority,
+				type: ref.type,
+				skey: ref.skey,
+				isAuthority: true,
+				config,
+			});
+			await index.rpcActivate(ref.uri);
+			return c.json({ uri: ref.uri });
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.post("/xrpc/com.atproto.simplespace.updateSpace", async (c) => {
+		try {
+			const body = await c.req.json<{
+				space?: string;
+				policy?: unknown;
+				appAccess?: unknown;
+			}>();
+			const ref = requireSpaceUri(body.space);
+			const session = await sessionAuth(c);
+			if (session instanceof Response) return session;
+			assertOwner(ref, session);
+			const scopeError = assertScope(c, session, {
+				type: ref.type,
+				authority: ref.authority,
+				skey: ref.skey,
+				manage: "update",
+			});
+			if (scopeError) return scopeError;
+			const stub = host.getSpaceDO(ref.uri);
+			await stub.rpcUpdateConfig({
+				...(body.policy !== undefined
+					? { policy: parsePolicy(body.policy) }
+					: {}),
+				...(body.appAccess !== undefined
+					? { appAccess: parseAppAccess(body.appAccess) }
+					: {}),
+			});
+			return c.json({});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.post("/xrpc/com.atproto.simplespace.deleteSpace", async (c) => {
+		try {
+			const body = await c.req.json<{ space?: string }>();
+			const ref = requireSpaceUri(body.space);
+			const session = await sessionAuth(c);
+			if (session instanceof Response) return session;
+			assertOwner(ref, session);
+			const scopeError = assertScope(c, session, {
+				type: ref.type,
+				authority: ref.authority,
+				skey: ref.skey,
+				manage: "delete",
+			});
+			if (scopeError) return scopeError;
+
+			const stub = host.getSpaceDO(ref.uri);
+			const { registrations } = await stub.rpcDeleteSpace();
+			await host.getIndexDO().rpcMarkDeleted(ref.uri);
+			// Stop credential issuance happened with the tombstone; tell every
+			// registered syncer to drop its copy, then reap the blob prefix.
+			if (registrations.length > 0) {
+				await stub.rpcEnqueueNotify(
+					registrations.map((registration) => ({
+						service: registration.service,
+						endpoint: registration.endpoint,
+						lxm: SPACE_DELETED_LXM,
+						body: { space: ref.uri },
+					})),
+				);
+			}
+			if (host.blobs) {
+				waitUntil(
+					c,
+					deleteR2Prefix(
+						host.blobs,
+						spaceBlobPrefix(host.operatorDid, await spaceId(ref.uri)),
+					),
+				);
+			}
+			return c.json({});
+		} catch (err) {
+			// deleteSpace is idempotent: a second delete of a tombstoned space
+			// (or a never-created one) reports SpaceNotFound per the lexicon.
+			return errorResponse(c, err);
+		}
+	});
+
+	app.post("/xrpc/com.atproto.simplespace.addMember", async (c) => {
+		return memberChange(c, "add");
+	});
+
+	app.post("/xrpc/com.atproto.simplespace.removeMember", async (c) => {
+		return memberChange(c, "remove");
+	});
+
+	async function memberChange(
+		c: Context,
+		op: "add" | "remove",
+	): Promise<Response> {
+		try {
+			const body = await c.req.json<{ space?: string; did?: string }>();
+			const ref = requireSpaceUri(body.space);
+			requireString(body.did, "did");
+			const session = await sessionAuth(c);
+			if (session instanceof Response) return session;
+			assertOwner(ref, session);
+			const scopeError = assertScope(c, session, {
+				type: ref.type,
+				authority: ref.authority,
+				skey: ref.skey,
+				manage: "update",
+			});
+			if (scopeError) return scopeError;
+			const stub = host.getSpaceDO(ref.uri);
+			await requireConfigured(stub, ref);
+			if (op === "add") {
+				await stub.rpcAddMember(body.did!);
+			} else {
+				await stub.rpcRemoveMember(body.did!);
+			}
+			return c.json({});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	}
+
+	app.get("/xrpc/com.atproto.simplespace.getSpace", async (c) => {
+		try {
+			const ref = requireSpaceUri(c.req.query("space"));
+			assertSpaceHost(ref);
+			const stub = host.getSpaceDO(ref.uri);
+
+			const authHeader = c.req.header("Authorization");
+			if (isSpaceCredentialAuth(authHeader)) {
+				await verifySpaceCredentialAuth(
+					authHeader!.slice(5),
+					ref,
+					verifyOpts(c, stub),
+				);
+			} else {
+				const session = await sessionAuth(c);
+				if (session instanceof Response) return session;
+				const scopeError = assertScope(c, session, {
+					type: ref.type,
+					authority: ref.authority,
+					skey: ref.skey,
+					action: "read_self",
+				});
+				if (scopeError) return scopeError;
+			}
+
+			const config = await requireConfigured(stub, ref);
+			return c.json({
+				uri: ref.uri,
+				policy: policyToJson(config.policy),
+				appAccess: appAccessToJson(config.appAccess),
+			});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	app.get("/xrpc/com.atproto.simplespace.listMembers", async (c) => {
+		try {
+			const ref = requireSpaceUri(c.req.query("space"));
+			const session = await sessionAuth(c);
+			if (session instanceof Response) return session;
+			assertOwner(ref, session);
+			const scopeError = assertScope(c, session, {
+				type: ref.type,
+				authority: ref.authority,
+				skey: ref.skey,
+				action: "read_self",
+			});
+			if (scopeError) return scopeError;
+			const stub = host.getSpaceDO(ref.uri);
+			await requireConfigured(stub, ref);
+			const limit = clampLimit(c.req.query("limit"), 100, 1000);
+			const page = await stub.rpcListMembers({
+				limit,
+				afterDid: c.req.query("cursor"),
+			});
+			const last = page.dids[page.dids.length - 1];
+			return c.json({
+				members: page.dids.map((did) => ({ did })),
+				...(page.hasMore && last ? { cursor: last } : {}),
+			});
+		} catch (err) {
+			return errorResponse(c, err);
+		}
+	});
+
+	function assertOwner(ref: SpaceRef, session: SpaceSessionAuth): void {
+		assertSpaceHost(ref);
+		if (session.did !== ref.authority) {
+			throw new SpaceError(
+				"NotSpaceOwner",
+				"Only the space owner may manage the space",
+			);
+		}
+	}
+
+	async function requireConfigured(
+		stub: SpaceStub,
+		ref: SpaceRef,
+	): Promise<SpaceConfig> {
+		const { meta, config } = await stub.rpcGetAuthorityState();
+		if (!meta || meta.deletedAt || !config) {
+			throw new SpaceError("SpaceNotFound", `Space not found: ${ref.uri}`);
+		}
+		return config;
+	}
+
+	/**
+	 * A repo exists in a space once the operator has written into it (or
+	 * the space was created here). RepoNotFound deliberately covers both
+	 * "no such repo" and "space unknown to this host".
+	 */
+	async function requireRepoExists(
+		stub: SpaceStub,
+		ref: SpaceRef,
+	): Promise<void> {
+		const meta = await stub.rpcGetMeta();
+		if (meta?.deletedAt) {
+			// After deletion, reads against the space fail with SpaceNotFound.
+			throw new SpaceError("SpaceNotFound", `Space not found: ${ref.uri}`);
+		}
+		if (!meta) {
+			throw new SpaceError(
+				"RepoNotFound",
+				`Could not find repo for space: ${ref.uri}`,
+			);
+		}
+	}
+
+	return app;
+}
+
+// ---------------------------------------------------------------------
+// Small parsing helpers
+// ---------------------------------------------------------------------
+
+function requireString(
+	value: unknown,
+	name: string,
+): asserts value is string {
+	if (typeof value !== "string" || value.length === 0) {
+		throw new SpaceError("InvalidRequest", `Missing required parameter: ${name}`);
+	}
+}
+
+function clampLimit(
+	raw: string | undefined,
+	fallback: number,
+	max: number,
+): number {
+	const parsed = raw ? Number.parseInt(raw, 10) : fallback;
+	if (Number.isNaN(parsed) || parsed < 1) return fallback;
+	return Math.min(parsed, max);
+}
+
+function parseRecordCursor(
+	cursor: string | undefined,
+): { collection: string; rkey: string } | undefined {
+	if (!cursor) return undefined;
+	const slash = cursor.lastIndexOf("/");
+	if (slash <= 0 || slash === cursor.length - 1) {
+		throw new SpaceError("MalformedCursor", `Malformed cursor: ${cursor}`);
+	}
+	return {
+		collection: cursor.slice(0, slash),
+		rkey: cursor.slice(slash + 1),
+	};
+}
+
+function parseOpsCursor(
+	cursor: string | undefined,
+): { rev: string; idx: number } | undefined {
+	if (!cursor) return undefined;
+	const slash = cursor.indexOf("/");
+	const idx = slash === -1 ? NaN : Number.parseInt(cursor.slice(slash + 1), 10);
+	if (slash <= 0 || Number.isNaN(idx)) {
+		throw new SpaceError("MalformedCursor", `Malformed cursor: ${cursor}`);
+	}
+	return { rev: cursor.slice(0, slash), idx };
+}
+
+const POLICY_PREFIX = "com.atproto.simplespace.defs#";
+
+function parsePolicy(input: unknown): SpacePolicy {
+	const type = (input as { $type?: string } | undefined)?.$type;
+	switch (type) {
+		case `${POLICY_PREFIX}publicPolicy`:
+			return { kind: "public" };
+		case `${POLICY_PREFIX}memberListPolicy`:
+			return { kind: "member-list" };
+		case `${POLICY_PREFIX}managingAppPolicy`: {
+			const managingApp = (input as { managingApp?: unknown }).managingApp;
+			if (typeof managingApp !== "string" || !managingApp.startsWith("did:")) {
+				throw new SpaceError(
+					"UnsupportedPolicy",
+					"managingApp must be a DID service identifier",
+				);
+			}
+			return { kind: "managing-app", managingApp };
+		}
+		default:
+			throw new SpaceError(
+				"UnsupportedPolicy",
+				`Unsupported policy: ${String(type)}`,
+			);
+	}
+}
+
+function policyToJson(policy: SpacePolicy): Record<string, unknown> {
+	switch (policy.kind) {
+		case "public":
+			return { $type: `${POLICY_PREFIX}publicPolicy` };
+		case "member-list":
+			return { $type: `${POLICY_PREFIX}memberListPolicy` };
+		case "managing-app":
+			return {
+				$type: `${POLICY_PREFIX}managingAppPolicy`,
+				managingApp: policy.managingApp,
+			};
+	}
+}
+
+function appAccessToJson(appAccess: SpaceAppAccess): Record<string, unknown> {
+	switch (appAccess.kind) {
+		case "open":
+			return { $type: `${POLICY_PREFIX}open` };
+		case "allowList":
+			return {
+				$type: `${POLICY_PREFIX}allowList`,
+				allowed: appAccess.allowed,
+			};
+	}
+}
+
+function parseAppAccess(input: unknown): SpaceAppAccess {
+	const type = (input as { $type?: string } | undefined)?.$type;
+	switch (type) {
+		case `${POLICY_PREFIX}open`:
+			return { kind: "open" };
+		case `${POLICY_PREFIX}allowList`: {
+			const allowed = (input as { allowed?: unknown }).allowed;
+			if (
+				!Array.isArray(allowed) ||
+				allowed.some((entry) => typeof entry !== "string")
+			) {
+				throw new SpaceError(
+					"UnsupportedAppAccess",
+					"allowList requires an array of client IDs",
+				);
+			}
+			return { kind: "allowList", allowed: allowed as string[] };
+		}
+		default:
+			throw new SpaceError(
+				"UnsupportedAppAccess",
+				`Unsupported appAccess: ${String(type)}`,
+			);
+	}
+}
+
+async function deleteR2Prefix(bucket: R2Bucket, prefix: string): Promise<void> {
+	let cursor: string | undefined;
+	do {
+		const listed = await bucket.list({ prefix, cursor, limit: 500 });
+		if (listed.objects.length > 0) {
+			await bucket.delete(listed.objects.map((object) => object.key));
+		}
+		cursor = listed.truncated ? listed.cursor : undefined;
+	} while (cursor);
+}

--- a/packages/spaces/test/fixtures/spaces-worker/worker-configuration.d.ts
+++ b/packages/spaces/test/fixtures/spaces-worker/worker-configuration.d.ts
@@ -8,5 +8,6 @@ declare global {
 	interface Env {
 		SPACES: DurableObjectNamespace<TestSpaceDurableObject>;
 		SPACES_INDEX: DurableObjectNamespace<TestSpaceIndexDurableObject>;
+		BLOBS: R2Bucket;
 	}
 }

--- a/packages/spaces/test/fixtures/spaces-worker/wrangler.jsonc
+++ b/packages/spaces/test/fixtures/spaces-worker/wrangler.jsonc
@@ -25,4 +25,10 @@
 			],
 		},
 	],
+	"r2_buckets": [
+		{
+			"binding": "BLOBS",
+			"bucket_name": "test-blobs",
+		},
+	],
 }

--- a/packages/spaces/test/routes.test.ts
+++ b/packages/spaces/test/routes.test.ts
@@ -560,7 +560,7 @@ describe("space routes: credentials (S5)", () => {
 	it("gates on the app allowList with client attestations", async () => {
 		const clientId = "https://app.test/client-metadata.json";
 		const clientKey = await JoseKey.generate(["ES256"], "client-key-1");
-		const { host: attHost, setOutboundResponse } = makeHost();
+		const { host: attHost, outbound, setOutboundResponse } = makeHost();
 		// Publish a clean JWKS entry (kty/crv/x/y/kid/alg): key_ops from the
 		// generated key would be rejected by workerd's ECDSA import.
 		const clientJwk = {
@@ -650,7 +650,9 @@ describe("space routes: credentials (S5)", () => {
 		const granted = await requestCredential(await makeAttestation(clientId));
 		expect(granted.status).toBe(200);
 
-		// An attested client that is not on the list is refused.
+		// An attested client that is not on the list is refused before any
+		// network I/O for it happens — the unverified client_id must never
+		// become an outbound-fetch target.
 		const otherId = "https://other.test/client-metadata.json";
 		setOutboundResponse((url) =>
 			url === otherId || url === clientId
@@ -664,6 +666,16 @@ describe("space routes: credentials (S5)", () => {
 		expect(((await wrongClient.json()) as { error: string }).error).toBe(
 			"AppNotAuthorized",
 		);
+		expect(outbound.some((o) => o.url.startsWith(otherId))).toBe(false);
+
+		// A non-https client_id is rejected outright, also without a fetch.
+		const httpId = "http://evil.internal/metadata.json";
+		const badScheme = await requestCredential(await makeAttestation(httpId));
+		expect(badScheme.status).toBe(401);
+		expect(((await badScheme.json()) as { error: string }).error).toBe(
+			"InvalidClientAttestation",
+		);
+		expect(outbound.some((o) => o.url.startsWith(httpId))).toBe(false);
 	});
 
 	it("consults the managing app and denies on failure", async () => {
@@ -873,6 +885,141 @@ describe("space routes: sync (S2-S4)", () => {
 		const dids = reposBody.repos.map((r) => r.did);
 		expect(dids).toContain(BOB);
 		expect(dids).toContain(OPERATOR);
+	});
+
+	it("ignores stale notifyWrite revisions and does not fan them out", async () => {
+		const space = await createSpace({
+			$type: "com.atproto.simplespace.defs#publicPolicy",
+		});
+		await createRecord(space, { $type: "app.bsky.feed.post", text: "s" }, "st");
+
+		const serviceJwt = (iss: string, lxm: string) => {
+			const enc = (o: unknown) =>
+				btoa(JSON.stringify(o))
+					.replace(/\+/g, "-")
+					.replace(/\//g, "_")
+					.replace(/=+$/, "");
+			return `${enc({ alg: "ES256K", typ: "JWT" })}.${enc({ iss, aud: OPERATOR, lxm })}.sig`;
+		};
+		const notify = async (rev: string, fill: number) =>
+			app.request("/xrpc/com.atproto.space.notifyWrite", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${serviceJwt(BOB, "com.atproto.space.notifyWrite")}`,
+				},
+				body: JSON.stringify({
+					space,
+					repo: BOB,
+					rev,
+					hash: {
+						$bytes: btoa(
+							String.fromCharCode(...new Uint8Array(32).fill(fill)),
+						),
+					},
+				}),
+			});
+
+		// A syncer registration to fan out to (bob is the sender and is
+		// excluded, so this is the only target).
+		const granted = await obtainCredential(space, bobKeypair, BOB);
+		expect(granted.status).toBe(200);
+		const regProof = await createDpopProof(granted.dpopKey, {
+			htm: "POST",
+			htu: `${ORIGIN}/xrpc/com.atproto.space.registerNotify`,
+			credential: granted.credential,
+		});
+		const registered = await app.request(
+			"/xrpc/com.atproto.space.registerNotify",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `DPoP ${granted.credential}`,
+					DPoP: regProof,
+				},
+				body: JSON.stringify({ space, service: "did:web:syncer.test" }),
+			},
+		);
+		expect(registered.status).toBe(200);
+
+		const stub = env.SPACES.get(env.SPACES.idFromName(space));
+		const queuedBefore = (await stub.rpcStatus()).queuedNotifications;
+
+		expect((await notify("3kzzzzzzzzzz2", 1)).status).toBe(200);
+		const afterFresh = await stub.rpcStatus();
+		expect(afterFresh.queuedNotifications).toBe(queuedBefore + 1);
+
+		// An older (delayed or replayed) revision succeeds quietly, but
+		// neither regresses the writer set nor enqueues fan-out.
+		expect((await notify("3kaaaaaaaaaa2", 2)).status).toBe(200);
+		const afterStale = await stub.rpcStatus();
+		expect(afterStale.queuedNotifications).toBe(afterFresh.queuedNotifications);
+
+		const writers = await stub.rpcListWriters({ limit: 10 });
+		const bob = writers.repos.find((r) => r.did === BOB);
+		expect(bob?.rev).toBe("3kzzzzzzzzzz2");
+		expect(new Uint8Array(bob!.hash)).toEqual(new Uint8Array(32).fill(1));
+	});
+
+	it("requires notifySpaceDeleted to be addressed to this service", async () => {
+		const authority = "did:web:elsewhere.test";
+		const foreignSpace = `at://${authority}/space/app.bsky.group/deleteme`;
+		const { host: fHost } = makeHost();
+		const fApp = createSpaceRoutes(fHost);
+
+		// Hold a repo in the foreign space.
+		const write = await fApp.request("/xrpc/com.atproto.space.createRecord", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer operator-session",
+			},
+			body: JSON.stringify({
+				space: foreignSpace,
+				repo: OPERATOR,
+				collection: "app.bsky.feed.post",
+				rkey: "keepme",
+				record: { $type: "app.bsky.feed.post", text: "x" },
+			}),
+		});
+		expect(write.status).toBe(200);
+
+		const enc = (o: unknown) =>
+			btoa(JSON.stringify(o))
+				.replace(/\+/g, "-")
+				.replace(/\//g, "_")
+				.replace(/=+$/, "");
+		const notifyDeleted = async (aud: string) =>
+			fApp.request("/xrpc/com.atproto.space.notifySpaceDeleted", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${enc({ alg: "ES256K", typ: "JWT" })}.${enc({
+						iss: authority,
+						aud,
+						lxm: "com.atproto.space.notifySpaceDeleted",
+					})}.sig`,
+				},
+				body: JSON.stringify({ space: foreignSpace }),
+			});
+
+		const readRecord = () =>
+			fApp.request(
+				`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(foreignSpace)}&repo=${OPERATOR}&collection=app.bsky.feed.post&rkey=keepme`,
+				{ headers: { Authorization: "Bearer operator-session" } },
+			);
+
+		// A token the authority minted for some other service must not
+		// tombstone our copy.
+		const misdirected = await notifyDeleted("did:web:someone-else.test");
+		expect(misdirected.status).toBe(403);
+		expect((await readRecord()).status).toBe(200);
+
+		// Addressed to us (service-identifier form): the copy is dropped.
+		const addressed = await notifyDeleted(`${OPERATOR}#atproto_pds`);
+		expect(addressed.status).toBe(200);
+		expect((await readRecord()).status).toBe(404);
 	});
 
 	it("sends one best-effort notifyWrite for writes into foreign spaces (S3)", async () => {

--- a/packages/spaces/test/routes.test.ts
+++ b/packages/spaces/test/routes.test.ts
@@ -1,0 +1,1127 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import type { Context } from "hono";
+import { Secp256k1Keypair } from "@atproto/crypto";
+import {
+	LtHash,
+	createDpopProof,
+	createSpaceToken,
+	spaceHostAud,
+	verifyCommit,
+	verifyRepoCarFull,
+} from "@atproto/space";
+import type { SignedCommit } from "@atproto/space";
+import { JoseKey } from "@atproto/jwk-jose";
+import { fromBase64 } from "@atproto/lex-data";
+import { create as createCid, CODEC_RAW, toString as cidToString } from "@atcute/cid";
+import { createSpaceRoutes } from "../src/routes";
+import type { SpaceRoutesHost, SpaceScopeMatch } from "../src/routes";
+import { TEST_OPERATOR_DID, TEST_SIGNING_KEY } from "./fixtures/spaces-worker/index";
+
+const OPERATOR = TEST_OPERATOR_DID;
+const BOB = "did:web:bob.test";
+const ORIGIN = "https://pds.test";
+
+const operatorKeypair = await Secp256k1Keypair.import(TEST_SIGNING_KEY);
+const bobKeypair = await Secp256k1Keypair.create();
+
+/** did → did:key registry standing in for DID-document resolution. */
+const signingKeys = new Map<string, string>([
+	[OPERATOR, operatorKeypair.did()],
+	[BOB, bobKeypair.did()],
+]);
+
+interface OutboundCall {
+	url: string;
+	init?: RequestInit;
+}
+
+function makeHost(overrides: Partial<SpaceRoutesHost> = {}): {
+	host: SpaceRoutesHost;
+	outbound: OutboundCall[];
+	setOutboundResponse(fn: (url: string) => Response | null): void;
+} {
+	const outbound: OutboundCall[] = [];
+	let responder: (url: string) => Response | null = () => null;
+	const host: SpaceRoutesHost = {
+		operatorDid: OPERATOR,
+		publicOrigin: ORIGIN,
+		blobs: env.BLOBS,
+		getKeypair: async () => operatorKeypair,
+		getSigningKey: async (iss) => {
+			const key = signingKeys.get(iss);
+			if (!key) throw new Error(`Unknown issuer: ${iss}`);
+			return key;
+		},
+		resolveServiceEndpoint: async (service) =>
+			`https://${service.split("#")[0]!.replace("did:web:", "")}`,
+		resolveAuthorityEndpoint: async (did) =>
+			`https://${did.replace("did:web:", "")}`,
+		// Trusted test double: decodes the payload without signature checks.
+		// The real implementation lives in the host PDS.
+		verifyServiceJwt: async (token, lxm) => {
+			const payload = JSON.parse(
+				atob(token.split(".")[1]!.replace(/-/g, "+").replace(/_/g, "/")),
+			) as { iss: string; aud: string; lxm?: string };
+			if (payload.lxm !== lxm) throw new Error("lxm mismatch");
+			return { iss: payload.iss, aud: payload.aud };
+		},
+		authenticate: async (c: Context) => {
+			const auth = c.req.header("Authorization");
+			if (auth === "Bearer operator-session") {
+				return {
+					did: OPERATOR,
+					fullTrust: true,
+					allowsSpace: () => true,
+				};
+			}
+			if (auth?.startsWith("Bearer scoped:")) {
+				// "Bearer scoped:<json>" — an OAuth session allowing exactly
+				// the encoded matches.
+				const allowed = JSON.parse(auth.slice("Bearer scoped:".length)) as {
+					actions?: string[];
+					manage?: string[];
+				};
+				return {
+					did: OPERATOR,
+					fullTrust: false,
+					allowsSpace: (m: SpaceScopeMatch) =>
+						"manage" in m && m.manage
+							? (allowed.manage ?? []).includes(m.manage)
+							: (allowed.actions ?? []).includes(
+									(m as { action: string }).action,
+								),
+				};
+			}
+			return c.json(
+				{ error: "AuthenticationRequired", message: "No session" },
+				401,
+			);
+		},
+		validateRecord: ({ record }) => ({ record, status: "unknown" }),
+		getSpaceDO: (uri) =>
+			env.SPACES.get(env.SPACES.idFromName(uri)) as never,
+		getIndexDO: () =>
+			env.SPACES_INDEX.get(env.SPACES_INDEX.idFromName("spaces")) as never,
+		outboundFetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+			outbound.push({ url: String(input), init });
+			return responder(String(input)) ?? new Response("{}", { status: 200 });
+		}) as typeof fetch,
+		...overrides,
+	};
+	return {
+		host,
+		outbound,
+		setOutboundResponse: (fn) => {
+			responder = fn;
+		},
+	};
+}
+
+const { host } = makeHost();
+const app = createSpaceRoutes(host);
+
+let spaceN = 0;
+async function createSpace(
+	policy: Record<string, unknown> = {
+		$type: "com.atproto.simplespace.defs#memberListPolicy",
+	},
+	appAccess: Record<string, unknown> = {
+		$type: "com.atproto.simplespace.defs#open",
+	},
+): Promise<string> {
+	const res = await app.request("/xrpc/com.atproto.simplespace.createSpace", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: "Bearer operator-session",
+		},
+		body: JSON.stringify({
+			type: "app.bsky.group",
+			skey: `route${spaceN++}x`,
+			policy,
+			appAccess,
+		}),
+	});
+	expect(res.status).toBe(200);
+	const { uri } = (await res.json()) as { uri: string };
+	return uri;
+}
+
+async function createRecord(
+	space: string,
+	record: Record<string, unknown>,
+	rkey?: string,
+): Promise<{ uri: string; cid: string }> {
+	const res = await app.request("/xrpc/com.atproto.space.createRecord", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: "Bearer operator-session",
+		},
+		body: JSON.stringify({
+			space,
+			repo: OPERATOR,
+			collection: "app.bsky.feed.post",
+			...(rkey ? { rkey } : {}),
+			record,
+		}),
+	});
+	expect(res.status).toBe(200);
+	return (await res.json()) as { uri: string; cid: string };
+}
+
+/** Mint a delegation token + DPoP-bound credential for `user`. */
+async function obtainCredential(
+	space: string,
+	userKeypair: Secp256k1Keypair,
+	userDid: string,
+): Promise<{ credential: string; dpopKey: JoseKey; status: number; body: unknown }> {
+	const dpopKey = await JoseKey.generate(["ES256"]);
+	const delegation = await createSpaceToken(
+		"delegation",
+		{ iss: userDid, sub: space, aud: spaceHostAud(OPERATOR) },
+		userKeypair,
+	);
+	const proof = await createDpopProof(dpopKey, {
+		htm: "POST",
+		htu: `${ORIGIN}/xrpc/com.atproto.space.getSpaceCredential`,
+	});
+	const res = await app.request("/xrpc/com.atproto.space.getSpaceCredential", {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${delegation}`,
+			DPoP: proof,
+		},
+		body: JSON.stringify({ space }),
+	});
+	const body = (await res.json()) as { credential?: string };
+	return {
+		credential: body.credential ?? "",
+		dpopKey,
+		status: res.status,
+		body,
+	};
+}
+
+/** Perform a credential-authenticated GET. */
+async function credentialGet(
+	path: string,
+	credential: string,
+	dpopKey: JoseKey,
+): Promise<Response> {
+	const proof = await createDpopProof(dpopKey, {
+		htm: "GET",
+		htu: `${ORIGIN}${path.split("?")[0]}`,
+		credential,
+	});
+	return app.request(path, {
+		headers: {
+			Authorization: `DPoP ${credential}`,
+			DPoP: proof,
+		},
+	});
+}
+
+function commitFromJson(json: Record<string, unknown>): SignedCommit {
+	const bytes = (field: string) =>
+		fromBase64((json[field] as { $bytes: string }).$bytes);
+	return {
+		ver: json.ver as 1,
+		hash: bytes("hash"),
+		ikm: bytes("ikm"),
+		sig: bytes("sig"),
+		mac: bytes("mac"),
+		rev: json.rev as string,
+	};
+}
+
+describe("space routes: personal data (S1)", () => {
+	it("creates a space, writes and reads records with a session", async () => {
+		const space = await createSpace();
+		const created = await createRecord(space, {
+			$type: "app.bsky.feed.post",
+			text: "hello spaces",
+		});
+		expect(created.uri).toBe(
+			`${space}/${OPERATOR}/app.bsky.feed.post/${created.uri.split("/").pop()}`,
+		);
+
+		const rkey = created.uri.split("/").pop()!;
+		const res = await app.request(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(space)}&repo=${OPERATOR}&collection=app.bsky.feed.post&rkey=${rkey}`,
+			{ headers: { Authorization: "Bearer operator-session" } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { value: { text: string }; cid: string };
+		expect(body.value.text).toBe("hello spaces");
+		expect(body.cid).toBe(created.cid);
+	});
+
+	it("refuses an unauthenticated getRecord", async () => {
+		const space = await createSpace();
+		await createRecord(space, { $type: "app.bsky.feed.post", text: "x" }, "aaa");
+		const res = await app.request(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(space)}&repo=${OPERATOR}&collection=app.bsky.feed.post&rkey=aaa`,
+		);
+		expect(res.status).toBe(401);
+	});
+
+	it("returns RepoNotFound for a repo that is not the operator", async () => {
+		const space = await createSpace();
+		const res = await app.request(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(space)}&repo=${BOB}&collection=app.bsky.feed.post&rkey=aaa`,
+			{ headers: { Authorization: "Bearer operator-session" } },
+		);
+		expect(res.status).toBe(404);
+		expect(((await res.json()) as { error: string }).error).toBe(
+			"RepoNotFound",
+		);
+	});
+
+	it("requires createSpace before writing into an own-authority space", async () => {
+		const res = await app.request("/xrpc/com.atproto.space.createRecord", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer operator-session",
+			},
+			body: JSON.stringify({
+				space: `at://${OPERATOR}/space/app.bsky.group/nevercreated`,
+				repo: OPERATOR,
+				collection: "app.bsky.feed.post",
+				record: { $type: "app.bsky.feed.post", text: "x" },
+			}),
+		});
+		expect(res.status).toBe(404);
+		expect(((await res.json()) as { error: string }).error).toBe(
+			"SpaceNotFound",
+		);
+	});
+
+	it("enforces scoped sessions on writes and reads", async () => {
+		const space = await createSpace();
+		// Write-only scope cannot read.
+		const writeOnly = `Bearer scoped:${JSON.stringify({ actions: ["create"] })}`;
+		const write = await app.request("/xrpc/com.atproto.space.createRecord", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: writeOnly,
+			},
+			body: JSON.stringify({
+				space,
+				repo: OPERATOR,
+				collection: "app.bsky.feed.post",
+				rkey: "scoped",
+				record: { $type: "app.bsky.feed.post", text: "x" },
+			}),
+		});
+		expect(write.status).toBe(200);
+
+		const read = await app.request(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(space)}&repo=${OPERATOR}&collection=app.bsky.feed.post&rkey=scoped`,
+			{ headers: { Authorization: writeOnly } },
+		);
+		expect(read.status).toBe(403);
+
+		const readOnly = `Bearer scoped:${JSON.stringify({ actions: ["read_self"] })}`;
+		const read2 = await app.request(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(space)}&repo=${OPERATOR}&collection=app.bsky.feed.post&rkey=scoped`,
+			{ headers: { Authorization: readOnly } },
+		);
+		expect(read2.status).toBe(200);
+
+		const denyWrite = await app.request("/xrpc/com.atproto.space.createRecord", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: readOnly,
+			},
+			body: JSON.stringify({
+				space,
+				repo: OPERATOR,
+				collection: "app.bsky.feed.post",
+				record: { $type: "app.bsky.feed.post", text: "x" },
+			}),
+		});
+		expect(denyWrite.status).toBe(403);
+	});
+
+	it("applyWrites returns typed results in order", async () => {
+		const space = await createSpace();
+		await createRecord(space, { $type: "app.bsky.feed.post", text: "d" }, "del");
+		const res = await app.request("/xrpc/com.atproto.space.applyWrites", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer operator-session",
+			},
+			body: JSON.stringify({
+				space,
+				repo: OPERATOR,
+				writes: [
+					{
+						$type: "com.atproto.space.applyWrites#create",
+						collection: "app.bsky.feed.post",
+						rkey: "batch1",
+						value: { $type: "app.bsky.feed.post", text: "one" },
+					},
+					{
+						$type: "com.atproto.space.applyWrites#delete",
+						collection: "app.bsky.feed.post",
+						rkey: "del",
+					},
+				],
+			}),
+		});
+		expect(res.status).toBe(200);
+		const { results } = (await res.json()) as {
+			results: Array<{ $type: string; uri?: string }>;
+		};
+		expect(results[0]?.$type).toBe("com.atproto.space.applyWrites#createResult");
+		expect(results[0]?.uri).toContain("/app.bsky.feed.post/batch1");
+		expect(results[1]?.$type).toBe("com.atproto.space.applyWrites#deleteResult");
+	});
+
+	it("putRecord upserts and deleteRecord is idempotent", async () => {
+		const space = await createSpace();
+		const put = async (text: string) =>
+			app.request("/xrpc/com.atproto.space.putRecord", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer operator-session",
+				},
+				body: JSON.stringify({
+					space,
+					repo: OPERATOR,
+					collection: "app.bsky.feed.post",
+					rkey: "upsert",
+					record: { $type: "app.bsky.feed.post", text },
+				}),
+			});
+		const first = await put("v1");
+		expect(first.status).toBe(200);
+		const second = await put("v2");
+		expect(second.status).toBe(200);
+		const firstCid = ((await first.json()) as { cid: string }).cid;
+		const secondCid = ((await second.json()) as { cid: string }).cid;
+		expect(secondCid).not.toBe(firstCid);
+
+		const del = async () =>
+			app.request("/xrpc/com.atproto.space.deleteRecord", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer operator-session",
+				},
+				body: JSON.stringify({
+					space,
+					repo: OPERATOR,
+					collection: "app.bsky.feed.post",
+					rkey: "upsert",
+				}),
+			});
+		expect((await del()).status).toBe(200);
+		// Deleting again succeeds silently.
+		expect((await del()).status).toBe(200);
+	});
+});
+
+describe("space routes: credentials (S5)", () => {
+	it("issues, gates and revokes space credentials", async () => {
+		const space = await createSpace();
+		await createRecord(space, { $type: "app.bsky.feed.post", text: "m" }, "mem");
+
+		// Not a member yet: UserNotAuthorized.
+		const refused = await obtainCredential(space, bobKeypair, BOB);
+		expect(refused.status).toBe(403);
+		expect((refused.body as { error: string }).error).toBe("UserNotAuthorized");
+
+		// Add bob, obtain a credential.
+		const add = await app.request("/xrpc/com.atproto.simplespace.addMember", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer operator-session",
+			},
+			body: JSON.stringify({ space, did: BOB }),
+		});
+		expect(add.status).toBe(200);
+
+		const granted = await obtainCredential(space, bobKeypair, BOB);
+		expect(granted.status).toBe(200);
+		expect(granted.credential).toBeTruthy();
+
+		// The credential reads the space.
+		const read = await credentialGet(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(space)}&repo=${OPERATOR}&collection=app.bsky.feed.post&rkey=mem`,
+			granted.credential,
+			granted.dpopKey,
+		);
+		expect(read.status).toBe(200);
+
+		// Remove bob: next credential request fails, but the existing
+		// credential still works until expiry.
+		await app.request("/xrpc/com.atproto.simplespace.removeMember", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer operator-session",
+			},
+			body: JSON.stringify({ space, did: BOB }),
+		});
+		const refusedAgain = await obtainCredential(space, bobKeypair, BOB);
+		expect(refusedAgain.status).toBe(403);
+		expect((refusedAgain.body as { error: string }).error).toBe(
+			"UserNotAuthorized",
+		);
+
+		const stillReads = await credentialGet(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(space)}&repo=${OPERATOR}&collection=app.bsky.feed.post&rkey=mem`,
+			granted.credential,
+			granted.dpopKey,
+		);
+		expect(stillReads.status).toBe(200);
+	});
+
+	it("rejects a replayed delegation token", async () => {
+		const space = await createSpace({
+			$type: "com.atproto.simplespace.defs#publicPolicy",
+		});
+		const dpopKey = await JoseKey.generate(["ES256"]);
+		const delegation = await createSpaceToken(
+			"delegation",
+			{ iss: BOB, sub: space, aud: spaceHostAud(OPERATOR) },
+			bobKeypair,
+		);
+		const request = async () => {
+			const proof = await createDpopProof(dpopKey, {
+				htm: "POST",
+				htu: `${ORIGIN}/xrpc/com.atproto.space.getSpaceCredential`,
+			});
+			return app.request("/xrpc/com.atproto.space.getSpaceCredential", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${delegation}`,
+					DPoP: proof,
+				},
+				body: JSON.stringify({ space }),
+			});
+		};
+		expect((await request()).status).toBe(200);
+		const replayed = await request();
+		expect(replayed.status).toBe(401);
+		expect(((await replayed.json()) as { error: string }).error).toBe(
+			"InvalidDelegationToken",
+		);
+	});
+
+	it("rejects a replayed DPoP proof and a cross-space credential", async () => {
+		const spaceA = await createSpace({
+			$type: "com.atproto.simplespace.defs#publicPolicy",
+		});
+		const spaceB = await createSpace({
+			$type: "com.atproto.simplespace.defs#publicPolicy",
+		});
+		await createRecord(spaceA, { $type: "app.bsky.feed.post", text: "a" }, "ra");
+		await createRecord(spaceB, { $type: "app.bsky.feed.post", text: "b" }, "rb");
+
+		const granted = await obtainCredential(spaceA, bobKeypair, BOB);
+		expect(granted.status).toBe(200);
+
+		const path = `/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(spaceA)}&repo=${OPERATOR}&collection=app.bsky.feed.post&rkey=ra`;
+		const proof = await createDpopProof(granted.dpopKey, {
+			htm: "GET",
+			htu: `${ORIGIN}/xrpc/com.atproto.space.getRecord`,
+			credential: granted.credential,
+		});
+		const headers = {
+			Authorization: `DPoP ${granted.credential}`,
+			DPoP: proof,
+		};
+		expect((await app.request(path, { headers })).status).toBe(200);
+		// Same proof again: replayed.
+		const replayed = await app.request(path, { headers });
+		expect(replayed.status).toBe(401);
+
+		// Credential for space A cannot read space B.
+		const cross = await credentialGet(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(spaceB)}&repo=${OPERATOR}&collection=app.bsky.feed.post&rkey=rb`,
+			granted.credential,
+			granted.dpopKey,
+		);
+		expect(cross.status).toBe(401);
+	});
+
+	it("gates on the app allowList with client attestations", async () => {
+		const clientId = "https://app.test/client-metadata.json";
+		const clientKey = await JoseKey.generate(["ES256"], "client-key-1");
+		const { host: attHost, setOutboundResponse } = makeHost();
+		// Publish a clean JWKS entry (kty/crv/x/y/kid/alg): key_ops from the
+		// generated key would be rejected by workerd's ECDSA import.
+		const clientJwk = {
+			...clientKey.bareJwk,
+			kid: clientKey.kid,
+			alg: "ES256",
+		};
+		setOutboundResponse((url) => {
+			if (url === clientId) {
+				return Response.json({ jwks: { keys: [clientJwk] } });
+			}
+			return null;
+		});
+		const attApp = createSpaceRoutes(attHost);
+
+		const createRes = await attApp.request(
+			"/xrpc/com.atproto.simplespace.createSpace",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer operator-session",
+				},
+				body: JSON.stringify({
+					type: "app.bsky.group",
+					skey: "attested",
+					policy: { $type: "com.atproto.simplespace.defs#publicPolicy" },
+					appAccess: {
+						$type: "com.atproto.simplespace.defs#allowList",
+						allowed: [clientId],
+					},
+				}),
+			},
+		);
+		expect(createRes.status).toBe(200);
+		const { uri: space } = (await createRes.json()) as { uri: string };
+
+		const dpopKey = await JoseKey.generate(["ES256"]);
+		const requestCredential = async (attestation?: string) => {
+			const delegation = await createSpaceToken(
+				"delegation",
+				{ iss: BOB, sub: space, aud: spaceHostAud(OPERATOR) },
+				bobKeypair,
+			);
+			const proof = await createDpopProof(dpopKey, {
+				htm: "POST",
+				htu: `${ORIGIN}/xrpc/com.atproto.space.getSpaceCredential`,
+			});
+			return attApp.request("/xrpc/com.atproto.space.getSpaceCredential", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${delegation}`,
+					DPoP: proof,
+				},
+				body: JSON.stringify({
+					space,
+					...(attestation ? { clientAttestation: attestation } : {}),
+				}),
+			});
+		};
+
+		// No attestation: refused on the app perimeter.
+		const missing = await requestCredential();
+		expect(missing.status).toBe(403);
+		expect(((await missing.json()) as { error: string }).error).toBe(
+			"AppNotAuthorized",
+		);
+
+		// Valid attestation from the allowed client.
+		const makeAttestation = async (iss: string) =>
+			clientKey.createJwt(
+				{
+					alg: "ES256",
+					typ: "atproto-client-attestation+jwt",
+					kid: clientKey.kid,
+				},
+				{
+					iss,
+					sub: iss,
+					aud: spaceHostAud(OPERATOR),
+					jti: crypto.randomUUID(),
+					iat: Math.floor(Date.now() / 1000),
+					exp: Math.floor(Date.now() / 1000) + 60,
+				},
+			);
+		const granted = await requestCredential(await makeAttestation(clientId));
+		expect(granted.status).toBe(200);
+
+		// An attested client that is not on the list is refused.
+		const otherId = "https://other.test/client-metadata.json";
+		setOutboundResponse((url) =>
+			url === otherId || url === clientId
+				? Response.json({ jwks: { keys: [clientJwk] } })
+				: null,
+		);
+		const wrongClient = await requestCredential(
+			await makeAttestation(otherId),
+		);
+		expect(wrongClient.status).toBe(403);
+		expect(((await wrongClient.json()) as { error: string }).error).toBe(
+			"AppNotAuthorized",
+		);
+	});
+
+	it("consults the managing app and denies on failure", async () => {
+		const managingApp = "did:web:forum.test#forum";
+		const { host: maHost, outbound, setOutboundResponse } = makeHost();
+		const maApp = createSpaceRoutes(maHost);
+		const createRes = await maApp.request(
+			"/xrpc/com.atproto.simplespace.createSpace",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer operator-session",
+				},
+				body: JSON.stringify({
+					type: "app.bsky.group",
+					skey: "managed",
+					policy: {
+						$type: "com.atproto.simplespace.defs#managingAppPolicy",
+						managingApp,
+					},
+					appAccess: { $type: "com.atproto.simplespace.defs#open" },
+				}),
+			},
+		);
+		const { uri: space } = (await createRes.json()) as { uri: string };
+
+		setOutboundResponse((url) =>
+			url.includes("checkUserAccess")
+				? Response.json({ authorized: true })
+				: null,
+		);
+		const dpopKey = await JoseKey.generate(["ES256"]);
+		const request = async () => {
+			const delegation = await createSpaceToken(
+				"delegation",
+				{ iss: BOB, sub: space, aud: spaceHostAud(OPERATOR) },
+				bobKeypair,
+			);
+			const proof = await createDpopProof(dpopKey, {
+				htm: "POST",
+				htu: `${ORIGIN}/xrpc/com.atproto.space.getSpaceCredential`,
+			});
+			return maApp.request("/xrpc/com.atproto.space.getSpaceCredential", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${delegation}`,
+					DPoP: proof,
+				},
+				body: JSON.stringify({ space }),
+			});
+		};
+		expect((await request()).status).toBe(200);
+		const call = outbound.find((o) => o.url.includes("checkUserAccess"));
+		expect(call?.url).toContain(`user=${encodeURIComponent(BOB)}`);
+
+		// The managing app saying no (or erroring) denies.
+		setOutboundResponse((url) =>
+			url.includes("checkUserAccess")
+				? Response.json({ authorized: false })
+				: null,
+		);
+		expect((await request()).status).toBe(403);
+	});
+});
+
+describe("space routes: sync (S2-S4)", () => {
+	it("serves a verifiable signed commit", async () => {
+		const space = await createSpace();
+		await createRecord(space, { $type: "app.bsky.feed.post", text: "c" }, "c1");
+		const res = await app.request(
+			`/xrpc/com.atproto.space.getLatestCommit?space=${encodeURIComponent(space)}&repo=${OPERATOR}`,
+			{ headers: { Authorization: "Bearer operator-session" } },
+		);
+		expect(res.status).toBe(200);
+		const { commit } = (await res.json()) as {
+			commit: Record<string, unknown>;
+		};
+		const signed = commitFromJson(commit);
+		expect(
+			await verifyCommit(
+				signed,
+				{ space, author: OPERATOR, rev: signed.rev },
+				operatorKeypair.did(),
+			),
+		).toBe(true);
+	});
+
+	it("lets a syncer follow listRepoOps to a matching hash", async () => {
+		const space = await createSpace();
+		await createRecord(space, { $type: "app.bsky.feed.post", text: "1" }, "s1");
+		await createRecord(space, { $type: "app.bsky.feed.post", text: "2" }, "s2");
+
+		const res = await app.request(
+			`/xrpc/com.atproto.space.listRepoOps?space=${encodeURIComponent(space)}&repo=${OPERATOR}`,
+			{ headers: { Authorization: "Bearer operator-session" } },
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			ops: Array<{
+				collection: string;
+				rkey: string;
+				cid: string | null;
+				prev: string | null;
+				value?: unknown;
+			}>;
+			commit: Record<string, unknown>;
+			cursor?: string;
+		};
+		expect(body.cursor).toBeUndefined();
+		expect(body.ops).toHaveLength(2);
+		expect(body.ops[0]?.value).toBeDefined();
+
+		// Syncer folds the ops into its own set hash and compares.
+		const setHash = new LtHash();
+		for (const op of body.ops) {
+			if (op.prev) setHash.remove(`${op.collection}/${op.rkey}/${op.prev}`);
+			if (op.cid) setHash.add(`${op.collection}/${op.rkey}/${op.cid}`);
+		}
+		const signed = commitFromJson(body.commit);
+		expect(setHash.digest()).toEqual(signed.hash);
+	});
+
+	it("streams a CAR that the @atproto/space consumer verifies (S8)", async () => {
+		const space = await createSpace();
+		await createRecord(space, { $type: "app.bsky.feed.post", text: "car1" }, "k1");
+		await createRecord(space, { $type: "app.bsky.feed.post", text: "car2" }, "k2");
+
+		const res = await app.request(
+			`/xrpc/com.atproto.space.getRepo?space=${encodeURIComponent(space)}&repo=${OPERATOR}`,
+			{ headers: { Authorization: "Bearer operator-session" } },
+		);
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Content-Type")).toBe("application/vnd.ipld.car");
+		const car = new Uint8Array(await res.arrayBuffer());
+		const verified = await verifyRepoCarFull([car], {
+			space,
+			author: OPERATOR,
+			didKey: operatorKeypair.did(),
+		});
+		expect(verified.records).toHaveLength(2);
+		expect(
+			verified.records.map((r) => r.rkey).sort(),
+		).toEqual(["k1", "k2"]);
+	});
+
+	it("records writers from inbound notifyWrite and serves listRepos", async () => {
+		const space = await createSpace({
+			$type: "com.atproto.simplespace.defs#publicPolicy",
+		});
+		await createRecord(space, { $type: "app.bsky.feed.post", text: "w" }, "w1");
+
+		const hash = new LtHash().add("x").digest();
+		const serviceJwt = (iss: string, aud: string, lxm: string) => {
+			const enc = (o: unknown) =>
+				btoa(JSON.stringify(o))
+					.replace(/\+/g, "-")
+					.replace(/\//g, "_")
+					.replace(/=+$/, "");
+			return `${enc({ alg: "ES256K", typ: "JWT" })}.${enc({ iss, aud, lxm })}.sig`;
+		};
+
+		const notify = async (iss: string, repo: string) =>
+			app.request("/xrpc/com.atproto.space.notifyWrite", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${serviceJwt(iss, OPERATOR, "com.atproto.space.notifyWrite")}`,
+				},
+				body: JSON.stringify({
+					space,
+					repo,
+					rev: "3kzzzzzzzzzz2",
+					hash: { $bytes: btoa(String.fromCharCode(...hash)) },
+				}),
+			});
+
+		// iss must match the claimed writer.
+		const spoofed = await notify("did:web:mallory.test", BOB);
+		expect(spoofed.status).toBe(403);
+
+		const accepted = await notify(BOB, BOB);
+		expect(accepted.status).toBe(200);
+
+		// listRepos requires a space credential and shows both writers.
+		const granted = await obtainCredential(space, bobKeypair, BOB);
+		expect(granted.status).toBe(200);
+		const proof = await createDpopProof(granted.dpopKey, {
+			htm: "GET",
+			htu: `${ORIGIN}/xrpc/com.atproto.space.listRepos`,
+			credential: granted.credential,
+		});
+		const repos = await app.request(
+			`/xrpc/com.atproto.space.listRepos?space=${encodeURIComponent(space)}`,
+			{
+				headers: {
+					Authorization: `DPoP ${granted.credential}`,
+					DPoP: proof,
+				},
+			},
+		);
+		expect(repos.status).toBe(200);
+		const reposBody = (await repos.json()) as {
+			repos: Array<{ did: string; rev: string }>;
+		};
+		const dids = reposBody.repos.map((r) => r.did);
+		expect(dids).toContain(BOB);
+		expect(dids).toContain(OPERATOR);
+	});
+
+	it("sends one best-effort notifyWrite for writes into foreign spaces (S3)", async () => {
+		const authority = "did:web:elsewhere.test";
+		const foreignSpace = `at://${authority}/space/app.bsky.group/forum1`;
+		const { host: fHost, outbound } = makeHost();
+		const fApp = createSpaceRoutes(fHost);
+
+		const res = await fApp.request("/xrpc/com.atproto.space.createRecord", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer operator-session",
+			},
+			body: JSON.stringify({
+				space: foreignSpace,
+				repo: OPERATOR,
+				collection: "app.bsky.feed.post",
+				rkey: "foreign1",
+				record: { $type: "app.bsky.feed.post", text: "posted elsewhere" },
+			}),
+		});
+		expect(res.status).toBe(200);
+
+		await vi.waitFor(() => {
+			const call = outbound.find((o) =>
+				o.url.includes("com.atproto.space.notifyWrite"),
+			);
+			expect(call).toBeDefined();
+			expect(call!.url).toBe(
+				"https://elsewhere.test/xrpc/com.atproto.space.notifyWrite",
+			);
+			const body = JSON.parse(String(call!.init?.body)) as {
+				space: string;
+				repo: string;
+				rev: string;
+				hash: { $bytes: string };
+			};
+			expect(body.space).toBe(foreignSpace);
+			expect(body.repo).toBe(OPERATOR);
+			expect(body.hash.$bytes).toBeTruthy();
+		});
+
+		// The foreign space is now registered and readable locally.
+		const read = await fApp.request(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(foreignSpace)}&repo=${OPERATOR}&collection=app.bsky.feed.post&rkey=foreign1`,
+			{ headers: { Authorization: "Bearer operator-session" } },
+		);
+		expect(read.status).toBe(200);
+	});
+});
+
+describe("space routes: blobs (S6)", () => {
+	it("serves space blobs only with authorisation and no-store headers", async () => {
+		const space = await createSpace({
+			$type: "com.atproto.simplespace.defs#publicPolicy",
+		});
+		const bytes = new Uint8Array([1, 2, 3, 4, 5]);
+		const cidObj = await createCid(CODEC_RAW, bytes);
+		const cid = cidToString(cidObj);
+		// Simulate uploadBlob's staging write.
+		await env.BLOBS.put(`${OPERATOR}/staged/${cid}`, bytes, {
+			httpMetadata: { contentType: "image/png" },
+		});
+
+		await createRecord(
+			space,
+			{
+				$type: "app.bsky.feed.post",
+				embed: {
+					$type: "app.bsky.embed.images",
+					images: [
+						{
+							image: {
+								$type: "blob",
+								ref: { $link: cid },
+								mimeType: "image/png",
+								size: bytes.length,
+							},
+							alt: "",
+						},
+					],
+				},
+			},
+			"withblob",
+		);
+
+		const path = `/xrpc/com.atproto.space.getBlob?space=${encodeURIComponent(space)}&repo=${OPERATOR}&cid=${cid}`;
+		// No auth: refused.
+		expect((await app.request(path)).status).toBe(401);
+
+		// Session auth streams the blob with credential-safe cache headers.
+		const res = await app.request(path, {
+			headers: { Authorization: "Bearer operator-session" },
+		});
+		expect(res.status).toBe(200);
+		expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+		expect(res.headers.get("Vary")).toBe("Authorization, DPoP");
+		expect(res.headers.get("Content-Security-Policy")).toBe(
+			"default-src 'none'; sandbox",
+		);
+		expect(new Uint8Array(await res.arrayBuffer())).toEqual(bytes);
+
+		// An unreferenced CID is BlobNotFound even though it sits in staging.
+		const otherBytes = new Uint8Array([9, 9, 9]);
+		const otherCid = cidToString(await createCid(CODEC_RAW, otherBytes));
+		await env.BLOBS.put(`${OPERATOR}/staged/${otherCid}`, otherBytes);
+		const unreferenced = await app.request(
+			`/xrpc/com.atproto.space.getBlob?space=${encodeURIComponent(space)}&repo=${OPERATOR}&cid=${otherCid}`,
+			{ headers: { Authorization: "Bearer operator-session" } },
+		);
+		expect(unreferenced.status).toBe(404);
+		expect(((await unreferenced.json()) as { error: string }).error).toBe(
+			"BlobNotFound",
+		);
+
+		// listBlobs enumerates the referenced blob.
+		const list = await app.request(
+			`/xrpc/com.atproto.space.listBlobs?space=${encodeURIComponent(space)}&repo=${OPERATOR}`,
+			{ headers: { Authorization: "Bearer operator-session" } },
+		);
+		expect(((await list.json()) as { cids: string[] }).cids).toContain(cid);
+	});
+});
+
+describe("space routes: lifecycle (S7-ish)", () => {
+	it("deleteSpace tombstones: reads fail, credentials answer SpaceDeleted", async () => {
+		const space = await createSpace({
+			$type: "com.atproto.simplespace.defs#publicPolicy",
+		});
+		await createRecord(space, { $type: "app.bsky.feed.post", text: "x" }, "gone");
+
+		const del = await app.request("/xrpc/com.atproto.simplespace.deleteSpace", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: "Bearer operator-session",
+			},
+			body: JSON.stringify({ space }),
+		});
+		expect(del.status).toBe(200);
+
+		const read = await app.request(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(space)}&repo=${OPERATOR}&collection=app.bsky.feed.post&rkey=gone`,
+			{ headers: { Authorization: "Bearer operator-session" } },
+		);
+		expect(read.status).toBe(404);
+		expect(((await read.json()) as { error: string }).error).toBe(
+			"SpaceNotFound",
+		);
+
+		// A late getSpaceCredential gets SpaceDeleted, not SpaceNotFound.
+		const late = await obtainCredential(space, bobKeypair, BOB);
+		expect(late.status).toBe(400);
+		expect((late.body as { error: string }).error).toBe("SpaceDeleted");
+	});
+
+	it("updateSpace changes policy and getSpace reflects it", async () => {
+		const space = await createSpace();
+		const update = await app.request(
+			"/xrpc/com.atproto.simplespace.updateSpace",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer operator-session",
+				},
+				body: JSON.stringify({
+					space,
+					policy: { $type: "com.atproto.simplespace.defs#publicPolicy" },
+				}),
+			},
+		);
+		expect(update.status).toBe(200);
+		const got = await app.request(
+			`/xrpc/com.atproto.simplespace.getSpace?space=${encodeURIComponent(space)}`,
+			{ headers: { Authorization: "Bearer operator-session" } },
+		);
+		expect(got.status).toBe(200);
+		const body = (await got.json()) as {
+			policy: { $type: string };
+			appAccess: { $type: string };
+		};
+		expect(body.policy.$type).toBe(
+			"com.atproto.simplespace.defs#publicPolicy",
+		);
+		expect(body.appAccess.$type).toBe("com.atproto.simplespace.defs#open");
+	});
+
+	it("manage scopes gate simplespace methods", async () => {
+		const manageNone = `Bearer scoped:${JSON.stringify({ actions: ["read_self"] })}`;
+		const refused = await app.request(
+			"/xrpc/com.atproto.simplespace.createSpace",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: manageNone,
+				},
+				body: JSON.stringify({
+					type: "app.bsky.group",
+					skey: "denied1",
+					policy: { $type: "com.atproto.simplespace.defs#publicPolicy" },
+					appAccess: { $type: "com.atproto.simplespace.defs#open" },
+				}),
+			},
+		);
+		expect(refused.status).toBe(403);
+
+		const manageCreate = `Bearer scoped:${JSON.stringify({ manage: ["create"] })}`;
+		const allowed = await app.request(
+			"/xrpc/com.atproto.simplespace.createSpace",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: manageCreate,
+				},
+				body: JSON.stringify({
+					type: "app.bsky.group",
+					skey: "allowed1",
+					policy: { $type: "com.atproto.simplespace.defs#publicPolicy" },
+					appAccess: { $type: "com.atproto.simplespace.defs#open" },
+				}),
+			},
+		);
+		expect(allowed.status).toBe(200);
+	});
+
+	it("rejects unsupported policy and appAccess variants", async () => {
+		const res = await app.request(
+			"/xrpc/com.atproto.simplespace.createSpace",
+			{
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: "Bearer operator-session",
+				},
+				body: JSON.stringify({
+					type: "app.bsky.group",
+					skey: "badpolicy",
+					policy: { $type: "com.example.mysteryPolicy" },
+					appAccess: { $type: "com.atproto.simplespace.defs#open" },
+				}),
+			},
+		);
+		expect(res.status).toBe(400);
+		expect(((await res.json()) as { error: string }).error).toBe(
+			"UnsupportedPolicy",
+		);
+	});
+});

--- a/packages/spaces/vitest.config.ts
+++ b/packages/spaces/vitest.config.ts
@@ -1,5 +1,16 @@
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { defineConfig } from "vitest/config";
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+
+const require = createRequire(import.meta.url);
+// The vitest pool resolves `jose` to its Node build, whose KeyObject-based
+// signing fails under workerd's nodejs_compat. Production builds (wrangler)
+// pick the `workerd` condition; force the same WebCrypto build here.
+const joseBrowser = join(
+	dirname(require.resolve("jose/package.json")),
+	"dist/browser/index.js",
+);
 
 export default defineConfig({
 	plugins: [
@@ -11,6 +22,7 @@ export default defineConfig({
 		conditions: ["worker", "browser", "node", "require"],
 		alias: {
 			pino: "pino/browser.js",
+			jose: joseBrowser,
 		},
 	},
 	test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,9 @@ importers:
 
   packages/spaces:
     dependencies:
+      '@atcute/cid':
+        specifier: ^2.3.0
+        version: 2.4.1
       '@atcute/lexicons':
         specifier: ^1.2.6
         version: 1.3.0
@@ -331,13 +334,28 @@ importers:
       '@atproto/lex-cbor':
         specifier: ^0.1.6
         version: 0.1.6
+      '@atproto/lex-data':
+        specifier: ^0.1.7
+        version: 0.1.7
+      '@atproto/lex-json':
+        specifier: ^0.1.6
+        version: 0.1.6
       '@atproto/space':
         specifier: 0.0.0-spaces-alpha-20260818163953
         version: 0.0.0-spaces-alpha-20260818163953
+      hono:
+        specifier: ^4.11.3
+        version: 4.11.8
+      jose:
+        specifier: ^5.2.0
+        version: 5.10.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
         version: 0.18.2
+      '@atproto/jwk-jose':
+        specifier: ^0.2.1
+        version: 0.2.4
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.16.9
         version: 0.16.9(@cloudflare/workers-types@4.20260524.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.0-beta.1(@types/node@24.10.11)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -581,6 +599,10 @@ packages:
 
   '@atproto/did@0.5.4':
     resolution: {integrity: sha512-BlnwQ+obL+4ZA71KH/EzZ3TY+cpSxnLiUI85mjBJIQwvDF/oN2sQA18wIj9jpduviIt2b/cMtlJuzHjzBkfXvw==}
+    engines: {node: '>=22'}
+
+  '@atproto/jwk-jose@0.2.4':
+    resolution: {integrity: sha512-gzDoA0JTwnc0ZJOBLM7WX9xFxtynRS2K1Bofb8epzoMWDQvyvfbPcfkdPrKFM7NXCFUVpGpBnsCB8KFPTf1rCg==}
     engines: {node: '>=22'}
 
   '@atproto/jwk@0.6.0':
@@ -5224,6 +5246,11 @@ snapshots:
   '@atproto/did@0.5.4':
     dependencies:
       zod: 3.25.76
+
+  '@atproto/jwk-jose@0.2.4':
+    dependencies:
+      '@atproto/jwk': 0.7.4
+      jose: 5.10.0
 
   '@atproto/jwk@0.6.0':
     dependencies:


### PR DESCRIPTION
The Worker side of the engine:

- createSpaceRoutes(host): Hono routes for every com.atproto.space.*
  and com.atproto.simplespace.* endpoint — writes (createRecord,
  putRecord, deleteRecord, applyWrites with one rev per batch), reads
  and sync (getRecord, listRecords, getLatestCommit, listRepoOps with
  (rev, idx) cursors and head-page commits, getRepo CAR streaming via
  serializeRepo, listBlobs, credential-gated getBlob with
  private/no-store cache headers), the space-host role
  (getSpaceCredential, listRepos, registerNotify, unregisterNotify,
  notifyWrite in/out, notifySpaceDeleted) and simplespace management.
- Auth: space credentials (DPoP + typ sniffing, cnf.jkt binding, jti
  replay via the space DO), single-use delegation tokens, client
  attestations against the client's published JWKS, and a host-supplied
  session hook for OAuth/operator sessions with space: scope matching.
- simplespace policies: public, member-list, and managing-app (service
  JWT to checkUserAccess; error or timeout denies). App gating via
  allowList with attestation.
- Commit signing stays in the Worker with a fresh ikm per response; the
  DO never sees the signing key.
- Host boundary: everything account-specific arrives via
  SpaceRoutesHost; the factory never reads env.

Tested end-to-end against @atproto/space's own primitives: credentials
minted here verify there, listRepoOps folds to the commit hash, and
getRepo CARs pass verifyRepoCarFull.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>