### PR TITLE
feat(pds): mount atproto spaces behind SPACES_ENABLED

### DIFF
--- a/demos/pds/src/index.ts
+++ b/demos/pds/src/index.ts
@@ -1,2 +1,7 @@
 // Re-export the PDS worker - that's all you need!
-export { default, AccountDurableObject } from "@getcirrus/pds";
+export {
+	default,
+	AccountDurableObject,
+	SpaceDurableObject,
+	SpaceIndexDurableObject,
+} from "@getcirrus/pds";

--- a/demos/pds/wrangler.jsonc
+++ b/demos/pds/wrangler.jsonc
@@ -13,15 +13,30 @@
 			{
 				"name": "ACCOUNT",
 				"class_name": "AccountDurableObject"
+			},
+			{
+				"name": "SPACES",
+				"class_name": "SpaceDurableObject"
+			},
+			{
+				"name": "SPACES_INDEX",
+				"class_name": "SpaceIndexDurableObject"
 			}
 		]
 	},
-	// Enable SQLite for the Durable Object
+	// Enable SQLite for the Durable Objects
 	"migrations": [
 		{
 			"tag": "v1",
 			"new_sqlite_classes": [
 				"AccountDurableObject"
+			]
+		},
+		{
+			"tag": "v2",
+			"new_sqlite_classes": [
+				"SpaceDurableObject",
+				"SpaceIndexDurableObject"
 			]
 		}
 	],

--- a/packages/create-pds/templates/pds-worker/wrangler.jsonc
+++ b/packages/create-pds/templates/pds-worker/wrangler.jsonc
@@ -13,15 +13,31 @@
 			{
 				"name": "ACCOUNT",
 				"class_name": "AccountDurableObject"
+			},
+			{
+				"name": "SPACES",
+				"class_name": "SpaceDurableObject"
+			},
+			{
+				"name": "SPACES_INDEX",
+				"class_name": "SpaceIndexDurableObject"
 			}
 		]
 	},
-	// Enable SQLite for the Durable Object
+	// Enable SQLite for the Durable Objects. Adding the space classes (v2)
+	// is an additive migration and safe regardless of SPACES_ENABLED.
 	"migrations": [
 		{
 			"tag": "v1",
 			"new_sqlite_classes": [
 				"AccountDurableObject"
+			]
+		},
+		{
+			"tag": "v2",
+			"new_sqlite_classes": [
+				"SpaceDurableObject",
+				"SpaceIndexDurableObject"
 			]
 		}
 	],
@@ -48,6 +64,11 @@
 		// ⚠️  WARNING: This CANNOT be changed after deployment!
 		// ⚠️  Changing this value after your PDS is live will break your installation.
 		"DATA_LOCATION": ""
+		// Atproto spaces (ALPHA). Set to "true" to enable the space and
+		// simplespace endpoints. Everything is alpha: a breaking upstream
+		// change is absorbed by `pds spaces reset`, which wipes space data
+		// and nothing else.
+		// "SPACES_ENABLED": "true"
 	},
 	// Secrets (set via `pds init` or `pds secret <name>`):
 	// - AUTH_TOKEN: Bearer token for API write operations

--- a/packages/pds/package.json
+++ b/packages/pds/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@getcirrus/pds",
 	"version": "0.18.0",
-	"description": "Cirrus – A single-user AT Protocol PDS on Cloudflare Workers",
+	"description": "Cirrus \u2013 A single-user AT Protocol PDS on Cloudflare Workers",
 	"type": "module",
 	"main": "dist/index.js",
 	"bin": {
@@ -44,7 +44,9 @@
 		"hono": "^4.11.3",
 		"jose": "^6.1.3",
 		"picocolors": "^1.1.1",
-		"qrcode": "^1.5.4"
+		"qrcode": "^1.5.4",
+		"@getcirrus/spaces": "workspace:*",
+		"@atproto/space": "0.0.0-spaces-alpha-20260818163953"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.18.2",

--- a/packages/pds/src/did-resolver.ts
+++ b/packages/pds/src/did-resolver.ts
@@ -56,9 +56,13 @@ export class DidResolver {
 		});
 	}
 
-	async resolve(did: string): Promise<DidDocument | null> {
-		// Check cache first
-		if (this.cache) {
+	async resolve(
+		did: string,
+		opts: { forceRefresh?: boolean } = {},
+	): Promise<DidDocument | null> {
+		// Check cache first (skipped on forceRefresh, e.g. after a signature
+		// failure that may indicate key rotation)
+		if (this.cache && !opts.forceRefresh) {
 			const cached = await this.cache.checkCache(did);
 			if (cached && !cached.expired) {
 				// Trigger background refresh if stale

--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -1,5 +1,6 @@
 // Public API
 export { AccountDurableObject } from "./account-do";
+export { SpaceDurableObject, SpaceIndexDurableObject } from "./spaces";
 export type { PDSEnv, DataLocation } from "./types";
 
 import { Hono } from "hono";
@@ -28,6 +29,7 @@ import {
 	PASSKEY_ERROR_CSP,
 } from "./passkey-ui";
 import { renderDashboard } from "./dashboard";
+import { createSpacesApp } from "./spaces";
 import type { PDSEnv } from "./types";
 
 import { version } from "../package.json" with { type: "json" };
@@ -545,6 +547,16 @@ app.post("/passkey/delete", requireAuth, async (c) => {
 // OAuth 2.1 endpoints for "Login with Bluesky"
 const oauthApp = createOAuthApp(getAccountDO);
 app.route("/", oauthApp);
+
+// Atproto spaces (alpha). When the flag is off none of the space or
+// simplespace routes are registered, so they fall through to the proxy
+// like any unknown method, and the DID document says nothing about spaces.
+if (env.SPACES_ENABLED === "true") {
+	app.route(
+		"/",
+		createSpacesApp({ env, didResolver, getKeypair }),
+	);
+}
 
 // getFeed is proxied to the AppView but the service-auth JWT must be addressed
 // to the feed generator, so it needs special handling ahead of the catch-all.

--- a/packages/pds/src/oauth.ts
+++ b/packages/pds/src/oauth.ts
@@ -180,6 +180,11 @@ function createCachedPermissionSetResolver(
 			}
 			return fetchAndStore(nsid);
 		},
+		// Space type declarations resolve at consent and grant time only —
+		// low volume, so no DO cache layer.
+		resolveSpaceDeclaration: network.resolveSpaceDeclaration
+			? (nsid) => network.resolveSpaceDeclaration!(nsid)
+			: undefined,
 	};
 }
 
@@ -230,6 +235,8 @@ export function getProvider(env: PDSEnv): ATProtoOAuthProvider {
 		},
 		// DO-SQLite-cached permission-set resolver for `include:` scopes.
 		permissionSetResolver: createCachedPermissionSetResolver(accountDO),
+		// space: scopes parse and grant only when the spaces alpha is on.
+		spacesEnabled: env.SPACES_ENABLED === "true",
 	});
 }
 

--- a/packages/pds/src/session.ts
+++ b/packages/pds/src/session.ts
@@ -23,6 +23,16 @@ function createSecretKey(secret: string): Uint8Array {
 	return new TextEncoder().encode(secret);
 }
 
+export interface SessionTokenOptions {
+	/**
+	 * Marks a session created with an app password. App passwords are a
+	 * deprecated credential class; surfaces like atproto spaces refuse
+	 * them. Carried as the `apf` claim on both token types so refresh
+	 * preserves it. The public repo path ignores it.
+	 */
+	appPassword?: boolean;
+}
+
 /**
  * Create an access token (short-lived, 2 hours)
  */
@@ -30,10 +40,14 @@ export async function createAccessToken(
 	jwtSecret: string,
 	userDid: string,
 	serviceDid: string,
+	options: SessionTokenOptions = {},
 ): Promise<string> {
 	const secret = createSecretKey(jwtSecret);
 
-	return new SignJWT({ scope: "com.atproto.access" })
+	return new SignJWT({
+		scope: "com.atproto.access",
+		...(options.appPassword ? { apf: true } : {}),
+	})
 		.setProtectedHeader({ alg: "HS256", typ: "at+jwt" })
 		.setIssuedAt()
 		.setAudience(serviceDid)
@@ -49,11 +63,15 @@ export async function createRefreshToken(
 	jwtSecret: string,
 	userDid: string,
 	serviceDid: string,
+	options: SessionTokenOptions = {},
 ): Promise<string> {
 	const secret = createSecretKey(jwtSecret);
 	const jti = crypto.randomUUID();
 
-	return new SignJWT({ scope: "com.atproto.refresh" })
+	return new SignJWT({
+		scope: "com.atproto.refresh",
+		...(options.appPassword ? { apf: true } : {}),
+	})
 		.setProtectedHeader({ alg: "HS256", typ: "refresh+jwt" })
 		.setIssuedAt()
 		.setAudience(serviceDid)

--- a/packages/pds/src/spaces.ts
+++ b/packages/pds/src/spaces.ts
@@ -1,0 +1,437 @@
+/**
+ * Atproto spaces (alpha) — PDS integration.
+ *
+ * The engine lives in @getcirrus/spaces; this module supplies the
+ * account-specific pieces: the concrete Durable Object classes, the host
+ * adapter (operator identity, DID resolution, session auth, record
+ * validation), and the user's-PDS role endpoints (getDelegationToken,
+ * listSpaces). Everything mounts behind the SPACES_ENABLED flag.
+ */
+
+import { Hono } from "hono";
+import type { Context } from "hono";
+import { Secp256k1Keypair, verifySignature } from "@atproto/crypto";
+import { createSpaceToken, spaceHostAud } from "@atproto/space";
+import {
+	SpaceDurableObject as EngineSpaceDurableObject,
+	SpaceIndexDurableObject as EngineSpaceIndexDurableObject,
+	createSpaceRoutes,
+	requireSpaceUri,
+	parseSpaceErrorCode,
+	spaceErrorStatus,
+} from "@getcirrus/spaces";
+import type {
+	SpaceHostConfig,
+	SpaceRoutesHost,
+	SpaceScopeMatch,
+	SpaceSessionAuth,
+	SpaceStub,
+	SpaceIndexStub,
+} from "@getcirrus/spaces";
+import { permissionsFor } from "@getcirrus/oauth-provider";
+import { getProvider } from "./oauth.js";
+import { verifyAccessToken, TokenExpiredError } from "./session.js";
+import { InvalidRecordError, validator } from "./validation.js";
+import type { DidResolver } from "./did-resolver.js";
+import type { PDSEnv } from "./types.js";
+
+/**
+ * The account's space DO: host identity comes from the PDS environment.
+ * This is the only place `env.DID` crosses into the engine.
+ */
+export class SpaceDurableObject extends EngineSpaceDurableObject<PDSEnv> {
+	private keypairPromise: Promise<Secp256k1Keypair> | null = null;
+
+	protected getHostConfig(): SpaceHostConfig {
+		return {
+			operatorDid: this.env.DID,
+			getKeypair: () => {
+				this.keypairPromise ??= Secp256k1Keypair.import(this.env.SIGNING_KEY);
+				return this.keypairPromise;
+			},
+		};
+	}
+}
+
+export class SpaceIndexDurableObject extends EngineSpaceIndexDurableObject<PDSEnv> {}
+
+export interface SpacesAppDeps {
+	env: PDSEnv;
+	didResolver: DidResolver;
+	getKeypair: () => Promise<Secp256k1Keypair>;
+}
+
+/** Data-location-aware stub creation, matching getAccountDO's handling. */
+export function getSpaceDO(env: PDSEnv, uri: string): SpaceStub {
+	return locatedStub(env, env.SPACES!, uri);
+}
+
+export function getSpaceIndexDO(env: PDSEnv): SpaceIndexStub {
+	return locatedStub(env, env.SPACES_INDEX!, "spaces");
+}
+
+function locatedStub<T extends Rpc.DurableObjectBranded | undefined>(
+	env: PDSEnv,
+	namespace: DurableObjectNamespace<T>,
+	name: string,
+): DurableObjectStub<T> {
+	const location = env.DATA_LOCATION;
+	// "eu" is a jurisdiction (hard guarantee) — space data must not end up
+	// in a different jurisdiction from the account. Everything else is a
+	// best-effort hint.
+	if (location === "eu") {
+		const jurisdiction = namespace.jurisdiction("eu");
+		return jurisdiction.get(jurisdiction.idFromName(name));
+	}
+	const id = namespace.idFromName(name);
+	if (location && location !== "auto") {
+		return namespace.get(id, { locationHint: location });
+	}
+	return namespace.get(id);
+}
+
+const SESSION_KID_ALLOWED = new Set(["#atproto", "#atproto_space"]);
+
+/**
+ * Build the host adapter and the complete spaces Hono app: the engine's
+ * space/simplespace routes plus the PDS-level getDelegationToken and
+ * listSpaces.
+ */
+export function createSpacesApp(deps: SpacesAppDeps): Hono {
+	const { env, didResolver, getKeypair } = deps;
+	if (!env.SPACES || !env.SPACES_INDEX) {
+		throw new Error(
+			"SPACES_ENABLED is set but the SPACES / SPACES_INDEX Durable Object bindings are missing. Add them to wrangler.jsonc (migration v2).",
+		);
+	}
+
+	/**
+	 * Resolve a DID's signing key to a did:key string, honouring the
+	 * requested kid with the proposal's #atproto_space → #atproto fallback.
+	 */
+	async function getSigningKey(
+		iss: string,
+		kid: string | undefined,
+		forceRefresh: boolean,
+	): Promise<string> {
+		if (kid && !SESSION_KID_ALLOWED.has(kid)) {
+			throw new Error(`Unsupported signing key id: ${kid}`);
+		}
+		const doc = await didResolver.resolve(iss, { forceRefresh });
+		if (!doc) throw new Error(`Could not resolve DID: ${iss}`);
+		const methods = (doc.verificationMethod ?? []) as Array<{
+			id: string;
+			publicKeyMultibase?: string;
+		}>;
+		const find = (fragment: string) =>
+			methods.find((m) => m.id === fragment || m.id.endsWith(fragment));
+		const method =
+			(kid ? find(kid) : undefined) ?? find("#atproto");
+		if (!method?.publicKeyMultibase) {
+			throw new Error(`No signing key in DID document for ${iss}`);
+		}
+		return `did:key:${method.publicKeyMultibase}`;
+	}
+
+	/** Resolve a `did[#fragment]` service identifier to its endpoint. */
+	async function resolveServiceEndpoint(
+		service: string,
+	): Promise<string | null> {
+		const [did, fragment] = service.split("#") as [string, string?];
+		const doc = await didResolver.resolve(did);
+		if (!doc) return null;
+		const services = (doc.service ?? []) as Array<{
+			id: string;
+			serviceEndpoint: unknown;
+		}>;
+		const entry = fragment
+			? services.find(
+					(s) => s.id === `#${fragment}` || s.id.endsWith(`#${fragment}`),
+				)
+			: services.find(
+					(s) => s.id === "#atproto_pds" || s.id.endsWith("#atproto_pds"),
+				);
+		return typeof entry?.serviceEndpoint === "string"
+			? entry.serviceEndpoint
+			: null;
+	}
+
+	/**
+	 * A space authority's host endpoint: the dedicated #atproto_space_host
+	 * entry when published, falling back to #atproto_pds.
+	 */
+	async function resolveAuthorityEndpoint(did: string): Promise<string | null> {
+		return (
+			(await resolveServiceEndpoint(`${did}#atproto_space_host`)) ??
+			(await resolveServiceEndpoint(did))
+		);
+	}
+
+	/**
+	 * Verify an inbound service-auth JWT from a foreign issuer (notifyWrite
+	 * and notifySpaceDeleted): ES256K signature against the issuer's
+	 * #atproto key, expiry, and the lxm method binding. Resolution failures
+	 * surface as auth errors, never 500s.
+	 */
+	async function verifyForeignServiceJwt(
+		token: string,
+		lxm: string,
+	): Promise<{ iss: string; aud: string }> {
+		const parts = token.split(".");
+		if (parts.length !== 3) throw new Error("Malformed service JWT");
+		const decode = (part: string) =>
+			JSON.parse(
+				atob(part.replace(/-/g, "+").replace(/_/g, "/")),
+			) as Record<string, unknown>;
+		const payload = decode(parts[1]!);
+		const iss = payload.iss;
+		const aud = payload.aud;
+		if (typeof iss !== "string" || typeof aud !== "string") {
+			throw new Error("Service JWT missing iss or aud");
+		}
+		if (payload.lxm !== lxm) {
+			throw new Error(`Service JWT not bound to ${lxm}`);
+		}
+		if (
+			typeof payload.exp !== "number" ||
+			payload.exp < Math.floor(Date.now() / 1000) - 5
+		) {
+			throw new Error("Service JWT expired");
+		}
+		const signingInput = new TextEncoder().encode(
+			`${parts[0]}.${parts[1]}`,
+		);
+		const sigB64 = parts[2]!.replace(/-/g, "+").replace(/_/g, "/");
+		const sig = Uint8Array.from(atob(sigB64), (ch) => ch.charCodeAt(0));
+		const verifyWith = async (forceRefresh: boolean) =>
+			verifySignature(
+				await getSigningKey(iss, undefined, forceRefresh),
+				signingInput,
+				sig,
+			);
+		// Forced refresh on failure survives key rotation.
+		if (!(await verifyWith(false)) && !(await verifyWith(true))) {
+			throw new Error("Invalid service JWT signature");
+		}
+		return { iss, aud };
+	}
+
+	/**
+	 * Session authentication for space routes. Accepts OAuth tokens
+	 * carrying space: grants and the operator's own full-access sessions
+	 * (AUTH_TOKEN, password and passkey sessions). App passwords are
+	 * excluded in the alpha; service JWTs never reach spaces.
+	 */
+	async function authenticate(
+		c: Context,
+	): Promise<SpaceSessionAuth | Response> {
+		const auth = c.req.header("Authorization");
+		if (!auth) {
+			return c.json(
+				{ error: "AuthMissing", message: "Authorization header required" },
+				401,
+			);
+		}
+
+		if (auth.startsWith("DPoP ")) {
+			const provider = getProvider(env);
+			const tokenData = await provider.verifyAccessToken(c.req.raw);
+			if (!tokenData) {
+				return c.json(
+					{
+						error: "AuthenticationRequired",
+						message: "Invalid OAuth access token",
+					},
+					401,
+				);
+			}
+			const perms = permissionsFor(tokenData.scope);
+			return {
+				did: tokenData.sub,
+				fullTrust: false,
+				allowsSpace: (match: SpaceScopeMatch) =>
+					perms.allowsSpace(match as never),
+			};
+		}
+
+		if (!auth.startsWith("Bearer ")) {
+			return c.json(
+				{ error: "AuthMissing", message: "Invalid authorization scheme" },
+				401,
+			);
+		}
+		const token = auth.slice(7);
+
+		if (token === env.AUTH_TOKEN) {
+			return { did: env.DID, fullTrust: true, allowsSpace: () => true };
+		}
+
+		try {
+			const payload = await verifyAccessToken(
+				token,
+				env.JWT_SECRET,
+				`did:web:${env.PDS_HOSTNAME}`,
+			);
+			if (payload.sub !== env.DID) {
+				return c.json(
+					{
+						error: "AuthenticationRequired",
+						message: "Invalid access token",
+					},
+					401,
+				);
+			}
+			if (payload.apf === true) {
+				// App passwords are a deprecated credential class; there is no
+				// reason to widen their reach into a new data model.
+				return c.json(
+					{
+						error: "AuthenticationRequired",
+						message: "App passwords cannot access atproto spaces",
+					},
+					403,
+				);
+			}
+			return { did: env.DID, fullTrust: true, allowsSpace: () => true };
+		} catch (err) {
+			if (err instanceof TokenExpiredError) {
+				return c.json({ error: "ExpiredToken", message: err.message }, 400);
+			}
+		}
+
+		return c.json(
+			{
+				error: "AuthenticationRequired",
+				message: "Invalid authentication token",
+			},
+			401,
+		);
+	}
+
+	const host: SpaceRoutesHost = {
+		operatorDid: env.DID,
+		publicOrigin: `https://${env.PDS_HOSTNAME}`,
+		blobs: env.BLOBS,
+		getKeypair,
+		getSigningKey,
+		resolveServiceEndpoint,
+		resolveAuthorityEndpoint,
+		verifyServiceJwt: verifyForeignServiceJwt,
+		authenticate,
+		validateRecord: ({ collection, record, rkey, validate }) => {
+			const result = validator.validate({ collection, record, rkey, validate });
+			return { record: result.record, status: result.status };
+		},
+		getSpaceDO: (uri) => getSpaceDO(env, uri),
+		getIndexDO: () => getSpaceIndexDO(env),
+	};
+
+	const app = createSpaceRoutes(host);
+
+	// ------------------------------------------------------------------
+	// User's-PDS role: delegation minting and the space index
+	// ------------------------------------------------------------------
+
+	app.get("/xrpc/com.atproto.space.getDelegationToken", async (c) => {
+		try {
+			const ref = requireSpaceUri(c.req.query("space"));
+			const session = await authenticate(c);
+			if (session instanceof Response) return session;
+			if (!session.fullTrust) {
+				// `read` (not read_self) is what getDelegationToken requires:
+				// the token unlocks reading other members' repos elsewhere.
+				const allowed = session.allowsSpace({
+					type: ref.type,
+					authority: ref.authority,
+					skey: ref.skey,
+					action: "read",
+				});
+				if (!allowed) {
+					return c.json(
+						{
+							error: "InsufficientScope",
+							message: "Token does not cover reading this space",
+						},
+						403,
+					);
+				}
+			}
+			const keypair = await getKeypair();
+			const token = await createSpaceToken(
+				"delegation",
+				{
+					iss: env.DID,
+					sub: ref.uri,
+					aud: spaceHostAud(ref.authority),
+				},
+				keypair,
+			);
+			return c.json({ token });
+		} catch (err) {
+			return spacesErrorResponse(c, err);
+		}
+	});
+
+	app.get("/xrpc/com.atproto.space.listSpaces", async (c) => {
+		try {
+			const session = await authenticate(c);
+			if (session instanceof Response) return session;
+			const type = c.req.query("type");
+			const authority = c.req.query("did");
+			if (!session.fullTrust) {
+				// An unfiltered listing needs a wildcard grant.
+				const allowed = session.allowsSpace({
+					type: type ?? "*",
+					authority: authority ?? "*",
+					skey: "*",
+					action: "read_self",
+				});
+				if (!allowed) {
+					return c.json(
+						{
+							error: "InsufficientScope",
+							message: "Token does not cover listing these spaces",
+						},
+						403,
+					);
+				}
+			}
+			const limitRaw = c.req.query("limit");
+			const limit = Math.min(
+				Math.max(limitRaw ? Number.parseInt(limitRaw, 10) || 50 : 50, 1),
+				100,
+			);
+			const index = getSpaceIndexDO(env);
+			const page = await index.rpcList({
+				type,
+				authority,
+				state: "active",
+				limit,
+				afterUri: c.req.query("cursor"),
+			});
+			const last = page.spaces[page.spaces.length - 1];
+			return c.json({
+				spaces: page.spaces.map((space) => ({ uri: space.uri })),
+				...(page.hasMore && last ? { cursor: last.uri } : {}),
+			});
+		} catch (err) {
+			return spacesErrorResponse(c, err);
+		}
+	});
+
+	return app;
+}
+
+function spacesErrorResponse(c: Context, err: unknown): Response {
+	if (err instanceof InvalidRecordError) {
+		return c.json({ error: "InvalidRecord", message: err.message }, 400);
+	}
+	const parsed = parseSpaceErrorCode(err);
+	if (parsed) {
+		return c.json(
+			{ error: parsed.code, message: parsed.message },
+			spaceErrorStatus(parsed.code) as 400,
+		);
+	}
+	throw err;
+}

--- a/packages/pds/src/spaces.ts
+++ b/packages/pds/src/spaces.ts
@@ -62,11 +62,11 @@ export interface SpacesAppDeps {
 }
 
 /** Data-location-aware stub creation, matching getAccountDO's handling. */
-export function getSpaceDO(env: PDSEnv, uri: string): SpaceStub {
+function getSpaceDO(env: PDSEnv, uri: string): SpaceStub {
 	return locatedStub(env, env.SPACES!, uri);
 }
 
-export function getSpaceIndexDO(env: PDSEnv): SpaceIndexStub {
+function getSpaceIndexDO(env: PDSEnv): SpaceIndexStub {
 	return locatedStub(env, env.SPACES_INDEX!, "spaces");
 }
 

--- a/packages/pds/src/types.ts
+++ b/packages/pds/src/types.ts
@@ -1,5 +1,9 @@
 import type { AuthVariables } from "./middleware/auth";
 import type { AccountDurableObject } from "./account-do";
+import type {
+	SpaceDurableObject,
+	SpaceIndexDurableObject,
+} from "./spaces";
 
 /**
  * Data location options for Durable Object placement.
@@ -59,6 +63,16 @@ export interface PDSEnv {
 	ACCOUNT: DurableObjectNamespace<AccountDurableObject>;
 	/** R2 bucket for blob storage (optional) */
 	BLOBS?: R2Bucket;
+	/**
+	 * Atproto spaces (alpha). Unset or anything but "true" disables every
+	 * space and simplespace route; they fall through to the proxy like any
+	 * unknown method.
+	 */
+	SPACES_ENABLED?: string;
+	/** Durable Object namespace for spaces (one per space URI). */
+	SPACES?: DurableObjectNamespace<SpaceDurableObject>;
+	/** Durable Object namespace for the space index singleton. */
+	SPACES_INDEX?: DurableObjectNamespace<SpaceIndexDurableObject>;
 	/** Account email address (optional, used by some clients) */
 	EMAIL?: string;
 	/** Initial activation state for new accounts (default: true) */

--- a/packages/pds/src/xrpc/identity.ts
+++ b/packages/pds/src/xrpc/identity.ts
@@ -52,6 +52,19 @@ export function buildDidDocument(env: PDSEnv) {
 				type: "AtprotoPersonalDataServer",
 				serviceEndpoint: `https://${env.PDS_HOSTNAME}`,
 			},
+			// Spaces alpha: advertise the space host endpoint. No dedicated
+			// #atproto_space verification key is added — the proposal falls
+			// back to #atproto, and a second key would create a rotation and
+			// backup story for no benefit on a single-user PDS.
+			...(env.SPACES_ENABLED === "true"
+				? [
+						{
+							id: "#atproto_space_host",
+							type: "AtprotoSpaceHost",
+							serviceEndpoint: `https://${env.PDS_HOSTNAME}`,
+						},
+					]
+				: []),
 		],
 	};
 }

--- a/packages/pds/src/xrpc/server.ts
+++ b/packages/pds/src/xrpc/server.ts
@@ -82,6 +82,7 @@ export async function createSession(
 	}
 
 	// Try app password first if it matches the format
+	let usedAppPassword = false;
 	if (isAppPassword(password)) {
 		const appPasswords = await accountDO.rpcGetAppPasswordHashes();
 		let matched = false;
@@ -101,6 +102,7 @@ export async function createSession(
 				401,
 			);
 		}
+		usedAppPassword = true;
 	} else {
 		// Verify account password
 		const passwordValid = await verifyPassword(
@@ -120,15 +122,18 @@ export async function createSession(
 
 	// Create tokens
 	const serviceDid = `did:web:${c.env.PDS_HOSTNAME}`;
+	const tokenOptions = { appPassword: usedAppPassword };
 	const accessJwt = await createAccessToken(
 		c.env.JWT_SECRET,
 		c.env.DID,
 		serviceDid,
+		tokenOptions,
 	);
 	const refreshJwt = await createRefreshToken(
 		c.env.JWT_SECRET,
 		c.env.DID,
 		serviceDid,
+		tokenOptions,
 	);
 
 	const { email: storedEmail } = await accountDO.rpcGetEmail();
@@ -185,16 +190,19 @@ export async function refreshSession(
 			);
 		}
 
-		// Create new tokens
+		// Create new tokens, preserving the app-password marker.
+		const tokenOptions = { appPassword: payload.apf === true };
 		const accessJwt = await createAccessToken(
 			c.env.JWT_SECRET,
 			c.env.DID,
 			serviceDid,
+			tokenOptions,
 		);
 		const refreshJwt = await createRefreshToken(
 			c.env.JWT_SECRET,
 			c.env.DID,
 			serviceDid,
+			tokenOptions,
 		);
 
 		const { email: storedEmail } = await accountDO.rpcGetEmail();

--- a/packages/pds/test/fixtures/pds-worker/index.ts
+++ b/packages/pds/test/fixtures/pds-worker/index.ts
@@ -2,4 +2,9 @@
  * Test fixture worker that imports from the library.
  * This simulates how a consumer would use the PDS package.
  */
-export { default, AccountDurableObject } from "../../../src/index";
+export {
+	default,
+	AccountDurableObject,
+	SpaceDurableObject,
+	SpaceIndexDurableObject,
+} from "../../../src/index";

--- a/packages/pds/test/fixtures/pds-worker/wrangler.jsonc
+++ b/packages/pds/test/fixtures/pds-worker/wrangler.jsonc
@@ -10,12 +10,24 @@
 				"name": "ACCOUNT",
 				"class_name": "AccountDurableObject",
 			},
+			{
+				"name": "SPACES",
+				"class_name": "SpaceDurableObject",
+			},
+			{
+				"name": "SPACES_INDEX",
+				"class_name": "SpaceIndexDurableObject",
+			},
 		],
 	},
 	"migrations": [
 		{
 			"tag": "v1",
 			"new_sqlite_classes": ["AccountDurableObject"],
+		},
+		{
+			"tag": "v2",
+			"new_sqlite_classes": ["SpaceDurableObject", "SpaceIndexDurableObject"],
 		},
 	],
 	"r2_buckets": [

--- a/packages/pds/test/spaces.test.ts
+++ b/packages/pds/test/spaces.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import { env, worker } from "./helpers";
+
+const authed = {
+	"Content-Type": "application/json",
+	Authorization: `Bearer ${env.AUTH_TOKEN}`,
+};
+
+function get(path: string, headers: Record<string, string> = {}) {
+	return worker.fetch(new Request(`http://pds.test${path}`, { headers }), env);
+}
+
+function post(
+	path: string,
+	body: unknown,
+	headers: Record<string, string> = authed,
+) {
+	return worker.fetch(
+		new Request(`http://pds.test${path}`, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+		}),
+		env,
+	);
+}
+
+let spaceN = 0;
+async function createSpace(): Promise<string> {
+	const res = await post("/xrpc/com.atproto.simplespace.createSpace", {
+		type: "app.bsky.group",
+		skey: `pds${spaceN++}x`,
+		policy: { $type: "com.atproto.simplespace.defs#memberListPolicy" },
+		appAccess: { $type: "com.atproto.simplespace.defs#open" },
+	});
+	expect(res.status).toBe(200);
+	return ((await res.json()) as { uri: string }).uri;
+}
+
+describe("spaces integration", () => {
+	it("advertises the space host in the DID document", async () => {
+		const res = await get("/.well-known/did.json");
+		const doc = (await res.json()) as {
+			service: Array<{ id: string; type: string; serviceEndpoint: string }>;
+			verificationMethod: Array<{ id: string }>;
+		};
+		const entry = doc.service.find((s) => s.id === "#atproto_space_host");
+		expect(entry).toMatchObject({
+			type: "AtprotoSpaceHost",
+			serviceEndpoint: `https://${env.PDS_HOSTNAME}`,
+		});
+		// No dedicated #atproto_space verification key: the proposal falls
+		// back to #atproto.
+		expect(
+			doc.verificationMethod.some((m) => m.id.endsWith("#atproto_space")),
+		).toBe(false);
+	});
+
+	it("stores and returns private records (S1)", async () => {
+		const space = await createSpace();
+		const create = await post("/xrpc/com.atproto.space.createRecord", {
+			space,
+			repo: env.DID,
+			collection: "test.cirrus.note",
+			rkey: "note1",
+			record: { $type: "test.cirrus.note", text: "private note" },
+		});
+		expect(create.status).toBe(200);
+		const created = (await create.json()) as { uri: string; cid: string };
+		expect(created.uri).toBe(
+			`${space}/${env.DID}/test.cirrus.note/note1`,
+		);
+
+		const read = await get(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(space)}&repo=${env.DID}&collection=test.cirrus.note&rkey=note1`,
+			{ Authorization: `Bearer ${env.AUTH_TOKEN}` },
+		);
+		expect(read.status).toBe(200);
+		expect(
+			((await read.json()) as { value: { text: string } }).value.text,
+		).toBe("private note");
+
+		// Unauthenticated read is refused.
+		const anon = await get(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(space)}&repo=${env.DID}&collection=test.cirrus.note&rkey=note1`,
+		);
+		expect(anon.status).toBe(401);
+
+		// The record does not exist in the public repo.
+		const publicRead = await get(
+			`/xrpc/com.atproto.repo.getRecord?repo=${env.DID}&collection=test.cirrus.note&rkey=note1`,
+		);
+		expect(publicRead.status).not.toBe(200);
+	});
+
+	it("keeps space blobs off the public sync endpoint (S6)", async () => {
+		const space = await createSpace();
+		const bytes = new Uint8Array([0x53, 0x50, 0x41, 0x43, 0x45, 0x42]);
+		const upload = await worker.fetch(
+			new Request("http://pds.test/xrpc/com.atproto.repo.uploadBlob", {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/octet-stream",
+					Authorization: `Bearer ${env.AUTH_TOKEN}`,
+				},
+				body: bytes,
+			}),
+			env,
+		);
+		expect(upload.status).toBe(200);
+		const { blob } = (await upload.json()) as {
+			blob: { ref: { $link: string } };
+		};
+		const cid = blob.ref.$link;
+
+		const write = await post("/xrpc/com.atproto.space.createRecord", {
+			space,
+			repo: env.DID,
+			collection: "test.cirrus.file",
+			rkey: "file1",
+			record: { $type: "test.cirrus.file", file: blob },
+		});
+		expect(write.status).toBe(200);
+
+		// The public endpoint refuses the CID even though it exists.
+		const publicBlob = await get(
+			`/xrpc/com.atproto.sync.getBlob?did=${env.DID}&cid=${cid}`,
+		);
+		expect(publicBlob.status).toBe(404);
+
+		// The space endpoint streams it with a covering session.
+		const spaceBlob = await get(
+			`/xrpc/com.atproto.space.getBlob?space=${encodeURIComponent(space)}&repo=${env.DID}&cid=${cid}`,
+			{ Authorization: `Bearer ${env.AUTH_TOKEN}` },
+		);
+		expect(spaceBlob.status).toBe(200);
+		expect(spaceBlob.headers.get("Cache-Control")).toBe("private, no-store");
+		expect(new Uint8Array(await spaceBlob.arrayBuffer())).toEqual(bytes);
+	});
+
+	it("mints delegation tokens (S2)", async () => {
+		const authority = "did:web:elsewhere.test";
+		const space = `at://${authority}/space/app.bsky.group/friends`;
+		const res = await get(
+			`/xrpc/com.atproto.space.getDelegationToken?space=${encodeURIComponent(space)}`,
+			{ Authorization: `Bearer ${env.AUTH_TOKEN}` },
+		);
+		expect(res.status).toBe(200);
+		const { token } = (await res.json()) as { token: string };
+		const [headerB64, payloadB64] = token.split(".") as [string, string];
+		const decode = (part: string) =>
+			JSON.parse(atob(part.replace(/-/g, "+").replace(/_/g, "/")));
+		expect(decode(headerB64)).toMatchObject({
+			typ: "atproto-space-delegation+jwt",
+			kid: "#atproto",
+		});
+		expect(decode(payloadB64)).toMatchObject({
+			iss: env.DID,
+			sub: space,
+			aud: `${authority}#atproto_space_host`,
+		});
+	});
+
+	it("lists spaces from the index", async () => {
+		const space = await createSpace();
+		const res = await get("/xrpc/com.atproto.space.listSpaces?limit=100", {
+			Authorization: `Bearer ${env.AUTH_TOKEN}`,
+		});
+		expect(res.status).toBe(200);
+		const { spaces } = (await res.json()) as {
+			spaces: Array<{ uri: string }>;
+		};
+		expect(spaces.map((s) => s.uri)).toContain(space);
+	});
+
+	it("refuses app-password sessions on spaces but not the public repo", async () => {
+		// Create an app password and log in with it.
+		const created = await post(
+			"/xrpc/com.atproto.server.createAppPassword",
+			{ name: "spaces-test" },
+		);
+		expect(created.status).toBe(200);
+		const { password } = (await created.json()) as { password: string };
+
+		const session = await post(
+			"/xrpc/com.atproto.server.createSession",
+			{ identifier: env.HANDLE, password },
+			{ "Content-Type": "application/json" },
+		);
+		expect(session.status).toBe(200);
+		const { accessJwt } = (await session.json()) as { accessJwt: string };
+		const appPassAuth = {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${accessJwt}`,
+		};
+
+		// Public repo write still works.
+		const publicWrite = await post(
+			"/xrpc/com.atproto.repo.createRecord",
+			{
+				repo: env.DID,
+				collection: "test.cirrus.note",
+				record: { $type: "test.cirrus.note", text: "from app password" },
+			},
+			appPassAuth,
+		);
+		expect(publicWrite.status).toBe(200);
+
+		// Spaces refuse the same session.
+		const space = await createSpace();
+		const spaceWrite = await post(
+			"/xrpc/com.atproto.space.createRecord",
+			{
+				space,
+				repo: env.DID,
+				collection: "test.cirrus.note",
+				record: { $type: "test.cirrus.note", text: "denied" },
+			},
+			appPassAuth,
+		);
+		expect(spaceWrite.status).toBe(403);
+		expect(((await spaceWrite.json()) as { message: string }).message).toMatch(
+			/App password/i,
+		);
+	});
+
+	it("keeps the firehose and public repo untouched by space writes", async () => {
+		const space = await createSpace();
+		const before = await (
+			await get(`/xrpc/com.atproto.sync.getLatestCommit?did=${env.DID}`)
+		).json();
+		await post("/xrpc/com.atproto.space.createRecord", {
+			space,
+			repo: env.DID,
+			collection: "test.cirrus.note",
+			record: { $type: "test.cirrus.note", text: "no firehose" },
+		});
+		const after = await (
+			await get(`/xrpc/com.atproto.sync.getLatestCommit?did=${env.DID}`)
+		).json();
+		expect(after).toEqual(before);
+	});
+});

--- a/packages/pds/vitest.config.ts
+++ b/packages/pds/vitest.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
 						"$2b$10$B6MKXNJ33Co3RoIVYAAvvO3jImuMiqL1T1YnFDN7E.hTZLtbB4SW6",
 					// Start accounts active by default in tests
 					INITIAL_ACTIVE: "true",
+					// Exercise the spaces alpha in tests
+					SPACES_ENABLED: "true",
 				},
 			},
 		}),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,12 +240,18 @@ importers:
       '@atproto/repo':
         specifier: ^0.8.12
         version: 0.8.12
+      '@atproto/space':
+        specifier: 0.0.0-spaces-alpha-20260818163953
+        version: 0.0.0-spaces-alpha-20260818163953
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
       '@getcirrus/oauth-provider':
         specifier: workspace:*
         version: link:../oauth-provider
+      '@getcirrus/spaces':
+        specifier: workspace:*
+        version: link:../spaces
       '@simplewebauthn/server':
         specifier: ^13.2.2
         version: 13.2.2


### PR DESCRIPTION
The account-specific half of the spaces alpha:

- SpaceDurableObject / SpaceIndexDurableObject subclasses supplying the
  engine's host config from the PDS environment (the only place env.DID
  crosses the boundary), with the account DO's DATA_LOCATION handling
  including the eu jurisdiction path
- host adapter: DID-doc signing-key resolution with #atproto_space →
  #atproto fallback and forced refresh on signature failure, service
  identifier resolution (#fragment, bare DID → #atproto_pds), authority
  endpoint resolution (#atproto_space_host → #atproto_pds), foreign
  service-JWT verification for inbound notifyWrite, and session auth
  that accepts OAuth space: grants and full-access operator sessions
- app passwords are excluded: app-password sessions now carry an apf
  claim (preserved across refresh) that spaces refuse and the public
  repo path ignores
- getDelegationToken (60 s, aud <authority>#atproto_space_host) and
  listSpaces from the index DO
- DID document gains the #atproto_space_host service entry when the
  flag is on; no second verification key
- OAuth provider gets spacesEnabled and space-declaration resolution
  through the cached permission-set resolver
- wrangler v2 migration (additive, ships regardless of the flag) in the
  template, demo and test fixture

When the flag is off, no space routes are registered — they fall
through to the proxy like any unknown method — and the DID document
says nothing about spaces.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>