### PR TITLE
chore: make docs package private

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,6 +2,7 @@
   "name": "docs",
   "type": "module",
   "version": "0.0.1",
+	"private": true,
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
Mark the docs package as private to prevent it from being published to the npm registry.