### PR TITLE
ci: pin npm to v11 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,11 @@ jobs:
         run: pnpm run build
       - run: pnpm run check
 
-      # Update npm to latest version so that OIDC works correctly
+      # npm >=11.5.1 is needed for OIDC trusted publishing, but npm 12 breaks
+      # changesets' published-version check when publishing with pnpm
+      # (changesets/changesets#2274) — keep this on 11 until that's fixed
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
The changesets v3 upgrade (#216) fixed the npm-tool publish path, but its Release run [still failed](https://github.com/ascorbic/cirrus/actions/runs/33241371223/job/99071183267) — now with a crash instead of a publish rejection:

```
TypeError: Cannot read properties of undefined (reading 'includes')
    at getUnpublishedPackages (.../getPublishPlan.mjs:613:26)
```

## Root cause

This is changesets/changesets#2274 (open, no fix released). Since we publish with pnpm, changesets v3 uses its pnpm tool, and pnpm ≤10 passes `pnpm info` straight through to the system `npm` binary. npm 12 (installed by the workflow's `npm install -g npm@latest` step) wraps `npm view --json` output in an array; v3's array-unwrap fix landed in `npm.ts` but not `pnpm.ts`, so `info.versions` is `undefined` and the publish plan crashes.

## Change

Pin the workflow's npm update to `npm@11` (currently 11.6.2):

- ≥11.5.1, so OIDC trusted publishing still works
- pre-12, so `npm view --json` returns an object and changesets' published-version check works

This is the same npm major every green run through June used. Revert to `npm@latest` once #2274 is fixed upstream (noted in a comment).
