### PR TITLE
ci: upgrade to pnpm 11

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,9 +9,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 10.26.2
+      - uses: pnpm/action-setup@v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -43,10 +43,6 @@ jobs:
       - name: Build Packages
         run: pnpm run build
       - run: pnpm run check
-
-      # Update npm to latest version so that OIDC works correctly
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 10.26.2
+      - uses: pnpm/action-setup@v6
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-link-workspace-packages=true

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
 		"typescript": "^5.9.3",
 		"vitest": "4.1.0-beta.1"
 	},
-	"packageManager": "pnpm@10.26.2"
+	"packageManager": "pnpm@11.24.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,12 @@ packages:
   - "demos/*"
   - "apps/*"
   - "docs"
+
+allowBuilds:
+  "@atcute/time-ms": false
+  core-js: false
+  esbuild: false
+  sharp: false
+  workerd: false
+
+linkWorkspacePackages: true


### PR DESCRIPTION
Proper fix for the Release failure in [run 33241371223](https://github.com/ascorbic/cirrus/actions/runs/33241371223/job/99071183267), superseding the npm-pin workaround in #217.

## Why this fixes it

The changesets v3 crash (changesets/changesets#2274) happens because pnpm ≤10 passes `pnpm info` through to the system `npm` binary, and npm 12 array-wraps `npm view --json` output. pnpm 11 implements `view`/`info` natively — verified its `--json` output is the bare object shape changesets' pnpm tool parses — and `pnpm publish` is native too, so the release job no longer touches npm at all. That makes the `npm install -g npm@latest` step (there for OIDC) obsolete, so it's deleted. pnpm 10's OIDC trusted publishing carries over to 11 (the pnpm 11 OIDC report, pnpm/pnpm#11513, was a stale `pnpm/action-setup` and is closed; pnpm itself publishes via OIDC on 11).

## Changes

- `packageManager` → `pnpm@11.24.0`
- `pnpm/action-setup` → `v6` in all five workflows (v2/v3/v4 before), dropping the hardcoded `version: 10.26.2` inputs so they all follow `packageManager`
- Removed the `Update npm` step from the release workflow
- pnpm 11 config split: moved `link-workspace-packages=true` from `.npmrc` (now ignored there) to `linkWorkspacePackages: true` in `pnpm-workspace.yaml`, and deleted `.npmrc`
- Added the `allowBuilds` block pnpm 11 now requires, with all entries `false` — matching pnpm 10's behavior, which already skipped these build scripts (they all ship prebuilt binaries via optional deps)

## Verification

- `pnpm build`, `pnpm test` (all suites pass, including the workers-pool tests), and `pnpm check` all green locally under pnpm 11.24.0
- `pnpm changeset status` runs clean; `pnpm view @getcirrus/pds --json` on pnpm 11 returns the object shape changesets expects
- Lockfile unchanged — pnpm 11 keeps lockfile v9
- Real test is the Release run after merge
