### PR TITLE
chore(spaces): seed @getcirrus/spaces at 0.0.0 for first publish

### DIFF
--- a/.changeset/spaces-first-release.md
+++ b/.changeset/spaces-first-release.md
@@ -1,0 +1,5 @@
+---
+"@getcirrus/spaces": minor
+---
+
+First release of `@getcirrus/spaces`: the atproto spaces engine (alpha) for Cloudflare Workers. Provides the per-space and index Durable Objects, permissioned repo storage with LtHash commits and oplog sync, space credential / delegation / DPoP / client-attestation verification, simplespace policies, and the Hono route factory for `com.atproto.space.*` and `com.atproto.simplespace.*`, all behind the host PDS's `SPACES_ENABLED` flag.

--- a/.changeset/spaces-pds-integration.md
+++ b/.changeset/spaces-pds-integration.md
@@ -1,0 +1,7 @@
+---
+"@getcirrus/pds": minor
+"@getcirrus/oauth-provider": minor
+"create-pds": minor
+---
+
+Atproto spaces (alpha), behind the `SPACES_ENABLED` flag: space and simplespace endpoints, space Durable Objects, delegation and credential issuance, `space:` OAuth scopes with consent-screen support, the `pds spaces` CLI, a dashboard panel, and blob upload staging (uploads land in `staged/` until a record references them — add the R2 lifecycle rule documented in the wrangler template).

--- a/packages/spaces/package.json
+++ b/packages/spaces/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@getcirrus/spaces",
-	"version": "0.1.0",
+	"version": "0.0.0",
 	"description": "Atproto spaces engine (alpha) for Cloudflare Workers – permissioned repos, space hosting and credentials",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
The release on main failed with E404 publishing `@getcirrus/spaces@0.1.0` — the CI token can't create new npm packages, so new packages get manually seeded at 0.0.0 first ([failed run](https://github.com/ascorbic/cirrus/actions/runs/33245397222)).

- Sets `@getcirrus/spaces` to 0.0.0 (the manually published seed version)
- Adds the changesets the spaces stack merged without: a minor for `@getcirrus/spaces` (0.0.0 → 0.1.0 on the next release) and a minor for `@getcirrus/pds` / `@getcirrus/oauth-provider` / `create-pds` so the merged spaces work actually releases

`@getcirrus/spaces@0.0.0` is being published manually from the CLI alongside this PR.