### PR TITLE
docs: atproto spaces concepts and enable guide

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -50,6 +50,11 @@ export default defineConfig({
 						},
 						{ label: "Authentication methods", slug: "concepts/auth" },
 						{ label: "The firehose", slug: "concepts/firehose" },
+					{
+						label: "Atproto spaces (alpha)",
+						slug: "concepts/spaces",
+						badge: { text: "alpha", variant: "caution" },
+					},
 						{ label: "Data placement", slug: "concepts/data-placement" },
 						{ label: "Costs and limits", slug: "concepts/costs-and-limits" },
 					],
@@ -80,6 +85,11 @@ export default defineConfig({
 							slug: "guides/app-password",
 						},
 						{ label: "Update a deployed PDS", slug: "guides/update" },
+					{
+						label: "Enable spaces",
+						slug: "guides/enable-spaces",
+						badge: { text: "alpha", variant: "caution" },
+					},
 						{
 							label: "Troubleshoot common errors",
 							slug: "guides/troubleshoot",

--- a/docs/src/content/docs/concepts/spaces.md
+++ b/docs/src/content/docs/concepts/spaces.md
@@ -1,0 +1,69 @@
+---
+title: Atproto spaces (alpha)
+description: How Cirrus implements permissioned data — private and shared spaces — and how space data is kept isolated from your public repository.
+---
+
+**Spaces** are the AT Protocol's proposal for permissioned data ([proposal 0016](https://github.com/bluesky-social/proposals/tree/main/0016-permissioned-data)): records that live on your PDS like public records do, but are only readable by people the space's owner has authorized. A private bookmarks collection, a members-only forum, a shared group — each is a space.
+
+Cirrus implements the spaces alpha behind the `SPACES_ENABLED` flag. Everything about it — the protocol, the lexicons, the dependencies — is **alpha** and can break between builds. See [Enable spaces](/guides/enable-spaces/) for setup, and read the caveats below before turning it on.
+
+## What a space is
+
+A space is identified by a URI like:
+
+```
+at://did:web:alice.example.com/space/app.bsky.group/3kbcq3p7ad400
+```
+
+That's an **authority** (the DID that owns the space and decides who may read it), a **type** (an NSID describing what kind of space it is), and a **key** distinguishing multiple spaces of the same type.
+
+Every participant stores *their own* records for a space in their own PDS — their **permissioned repo** for that space. Reading a space means collecting the repos of its writers from wherever each is hosted.
+
+## The three roles Cirrus plays
+
+Because Cirrus is single-user, one account wears three hats:
+
+- **Repo host** — serving your own permissioned repos, one per space you have written into, whether you own the space or not.
+- **Space host** — for spaces you own: issuing credentials to readers, tracking who has written, notifying syncers after writes, and managing membership.
+- **Your PDS** — minting short-lived delegation tokens so apps you've signed into can read spaces hosted elsewhere.
+
+## How access control works
+
+Reading a space requires a **space credential** from its authority. The flow:
+
+1. Your app asks your PDS for a **delegation token** — a 60-second, single-use JWT proving the app acts for you.
+2. The app exchanges it at the space's authority for a **credential** — a two-hour, DPoP-bound JWT.
+3. Every read presents the credential plus a fresh DPoP proof.
+
+Whether the authority grants a credential is its policy. Cirrus implements the `simplespace` policies:
+
+- **public** — anyone with an account may read.
+- **member-list** — only DIDs on the space's member list (managed from the CLI or dashboard).
+- **managing-app** — a nominated app service is asked to decide, per request.
+
+Spaces can additionally gate on *which app* is asking, via an allow-list of OAuth client IDs backed by client attestations.
+
+Writes never use credentials: they're ordinary authenticated requests to your own PDS, covered by OAuth `space:` grants or your own full-access session. App passwords are deliberately excluded.
+
+## Blobs
+
+A blob referenced only from a space record is fetchable only through the credential-gated `com.atproto.space.getBlob` — never from the public `sync.getBlob`, even by someone who knows its CID. To enforce this cheaply, uploads are staged (`<did>/staged/<cid>` in R2) until a record references them, then copied to a public or per-space key. This staging applies to the public path too, flag or no flag: it closes the gap where any uploaded blob was public the moment it was uploaded.
+
+## Isolation, by construction
+
+Space state never touches your public repository. It lives in its own Durable Objects (one per space, plus a small index) and its own R2 prefix (`<did>/space/`). The account Durable Object — your MST, your firehose — has no space tables and no space code paths.
+
+This is what makes the alpha safe to run: when an alpha build breaks the schema, the space Durable Objects refuse to open and every space endpoint returns a clear error, while your public repo and firehose carry on untouched. Recovery is one command:
+
+```bash
+pds spaces reset
+```
+
+which deletes all space data — and *can only* delete space data. There is no migration between alpha schema versions, matching the upstream policy.
+
+## Alpha caveats
+
+- **Interop is the point, stability is not.** Cirrus targets the reference alpha PDS and apps like bulletin.my. Expect breaking changes; expect `pds spaces reset` to be part of upgrading.
+- **No migration of space data.** The protocol has no import yet. `pds spaces export` writes one CAR per space so data isn't lost, but it can't yet be imported anywhere.
+- **Access control, not encryption.** Space data is not encrypted at rest beyond what R2 and Durable Object storage already do. Your PDS (and any space host) can read what it stores.
+- **Pinned dependencies.** The `@atproto/space` and `@atproto/oauth-scopes` alpha builds are pinned exactly and excluded from automatic updates.

--- a/docs/src/content/docs/guides/enable-spaces.md
+++ b/docs/src/content/docs/guides/enable-spaces.md
@@ -1,0 +1,97 @@
+---
+title: Enable spaces (alpha)
+description: Turn on the atproto spaces alpha — flag, bindings, R2 lifecycle rule — and manage spaces from the CLI and dashboard.
+---
+
+Spaces are **alpha**. Read [the concepts page](/concepts/spaces/) first, especially the caveats: breaking upstream changes are absorbed by wiping space data, and nothing else.
+
+## Prerequisites
+
+- A deployed Cirrus PDS on `@getcirrus/pds` ≥ the first spaces release.
+- Blob storage (the `BLOBS` R2 bucket) if you want blobs in spaces.
+
+## 1. Add the Durable Object bindings
+
+New projects scaffolded by `create-pds` already have these. Existing deployments need the two space classes in `wrangler.jsonc`:
+
+```jsonc
+"durable_objects": {
+	"bindings": [
+		{ "name": "ACCOUNT", "class_name": "AccountDurableObject" },
+		{ "name": "SPACES", "class_name": "SpaceDurableObject" },
+		{ "name": "SPACES_INDEX", "class_name": "SpaceIndexDurableObject" }
+	]
+},
+"migrations": [
+	{ "tag": "v1", "new_sqlite_classes": ["AccountDurableObject"] },
+	{ "tag": "v2", "new_sqlite_classes": ["SpaceDurableObject", "SpaceIndexDurableObject"] }
+]
+```
+
+If your worker entry re-exports from `@getcirrus/pds`, export the new classes too:
+
+```ts
+export {
+	default,
+	AccountDurableObject,
+	SpaceDurableObject,
+	SpaceIndexDurableObject,
+} from "@getcirrus/pds";
+```
+
+The `v2` migration is additive and safe to deploy whether or not you enable the flag.
+
+## 2. Add the R2 lifecycle rule
+
+Blob uploads are staged under `<did>/staged/` until a record references them. Abandoned uploads should expire:
+
+```bash
+wrangler r2 bucket lifecycle add pds-blobs --prefix "<your-did>/staged/" --expire-days 7
+```
+
+Replace `pds-blobs` with your bucket name and `<your-did>` with your DID.
+
+## 3. Turn on the flag
+
+In `wrangler.jsonc`:
+
+```jsonc
+"vars": {
+	// ...
+	"SPACES_ENABLED": "true"
+}
+```
+
+Deploy. Your DID document gains an `#atproto_space_host` service entry, and the `com.atproto.space.*` and `com.atproto.simplespace.*` endpoints go live. With the flag off, none of those routes exist and the DID document says nothing about spaces.
+
+## Manage spaces from the CLI
+
+```bash
+pds spaces status                # flag, schema version, counts
+pds spaces list                  # every space this PDS holds data in
+pds spaces create --type app.bsky.group --policy member-list
+pds spaces members add <space-uri> <did>
+pds spaces members remove <space-uri> <did>
+pds spaces members list <space-uri>
+pds spaces delete <space-uri>
+pds spaces export --out ./spaces-export   # one CAR per space
+pds spaces reset                 # wipe ALL space data (and nothing else)
+```
+
+`create` accepts `--policy public | member-list | managing-app` (with `--managing-app <did#service>`), and repeatable `--allow <client-id>` flags to restrict which apps may access the space.
+
+The dashboard at `/status` gains a **Spaces** panel showing each space's role, record and member counts, with delete and member management for spaces you host. It asks for your admin token (`AUTH_TOKEN`) on first use.
+
+## Grant apps access
+
+Apps request access with OAuth `space:` scopes, e.g. `space:my.app.bookmarks` for the app's own space type under your authority. The consent screen shows the space type's human name and warns loudly about wildcard grants. App passwords cannot access spaces.
+
+## When an alpha build breaks the schema
+
+After upgrading across an incompatible alpha build, space endpoints return a 503 pointing here, and `pds spaces status` shows which spaces are outdated. Your public repo, blobs, firehose and OAuth state are unaffected. Reset and start fresh:
+
+```bash
+pds spaces reset
+```
+
+It prints exactly what it will delete and asks for confirmation. `reset` and `status` work even while the flag is off.


### PR DESCRIPTION
The spaces stack (#208–#213) shipped without docs. This adds:

- **Concepts → Atproto spaces (alpha)**: what spaces are, the three roles a single-user PDS plays, the credential/delegation flow, simplespace policies, blob gating and staging, the isolation-by-construction story behind `pds spaces reset`, and the alpha caveats.
- **Guides → Enable spaces (alpha)**: DO bindings + v2 migration for existing deployments, the R2 `staged/` lifecycle rule, the `SPACES_ENABLED` flag, the `pds spaces` CLI, the dashboard panel, `space:` scopes, and schema-outdated recovery.

Both sidebar entries carry an alpha caution badge. `pnpm build` passes (36 pages).