### PR TITLE
feat(demo): enable atproto spaces on the demo PDS

### DIFF
--- a/demos/pds/wrangler.jsonc
+++ b/demos/pds/wrangler.jsonc
@@ -55,7 +55,10 @@
 		// Account DID - usually did:web:<hostname>
 		"DID": "did:web:pds.mk.gg",
 		// Account handle (e.g., "alice.example.com")
-		"HANDLE": "pds.mk.gg"
+		"HANDLE": "pds.mk.gg",
+		// Atproto spaces (ALPHA). Breaking upstream changes are absorbed by
+		// `pds spaces reset`, which wipes space data and nothing else.
+		"SPACES_ENABLED": "true"
 	},
 	// Secrets (set via `pds init` or `pds secret <name>`):
 	// - AUTH_TOKEN: Bearer token for API write operations


### PR DESCRIPTION
Flips `SPACES_ENABLED` on for pds.mk.gg. The DO bindings, v2 migration and spaces code landed with the stack; only the flag was missing.

Note: the R2 lifecycle rule for staged uploads still needs a one-time manual run against the production bucket:

```
wrangler r2 bucket lifecycle add pds-blobs --prefix "did:web:pds.mk.gg/staged/" --expire-days 7
```