### PR TITLE
fix(pds): never fail worker startup over missing space bindings

### DIFF
--- a/packages/pds/src/index.ts
+++ b/packages/pds/src/index.ts
@@ -29,7 +29,11 @@ import {
 	PASSKEY_ERROR_CSP,
 } from "./passkey-ui";
 import { renderDashboard } from "./dashboard";
-import { createSpacesApp, createSpacesAdminApp } from "./spaces";
+import {
+	createSpacesApp,
+	createSpacesAdminApp,
+	createSpacesUnavailableApp,
+} from "./spaces";
 import type { PDSEnv } from "./types";
 
 import { version } from "../package.json" with { type: "json" };
@@ -552,11 +556,20 @@ app.route("/", oauthApp);
 // Atproto spaces (alpha). When the flag is off none of the space or
 // simplespace routes are registered, so they fall through to the proxy
 // like any unknown method, and the DID document says nothing about spaces.
+//
+// The bindings check must not throw: deploy-time startup validation
+// evaluates this scope with vars visible but Durable Object bindings not
+// yet materialized, and a real misconfiguration should degrade spaces to
+// 503s rather than fail worker startup.
 if (env.SPACES_ENABLED === "true") {
-	app.route(
-		"/",
-		createSpacesApp({ env, didResolver, getKeypair }),
-	);
+	if (env.SPACES && env.SPACES_INDEX) {
+		app.route("/", createSpacesApp({ env, didResolver, getKeypair }));
+	} else {
+		console.error(
+			"SPACES_ENABLED is set but the SPACES / SPACES_INDEX Durable Object bindings are missing. Space endpoints will return 503.",
+		);
+		app.route("/", createSpacesUnavailableApp());
+	}
 }
 // The operator-only admin surface (spaces status and reset) mounts
 // whenever the bindings exist, so `pds spaces reset` still works with the

--- a/packages/pds/src/spaces.ts
+++ b/packages/pds/src/spaces.ts
@@ -95,17 +95,47 @@ function locatedStub<T extends Rpc.DurableObjectBranded | undefined>(
 const SESSION_KID_ALLOWED = new Set(["#atproto", "#atproto_space"]);
 
 /**
+ * Fallback app mounted when SPACES_ENABLED is set but the SPACES /
+ * SPACES_INDEX Durable Object bindings are absent: every space and
+ * simplespace method answers 503 with a pointer at the fix, and
+ * everything else falls through.
+ *
+ * Nothing in this module may throw for a missing binding at module scope:
+ * Cloudflare's deploy-time startup validation evaluates the Worker with
+ * vars visible but Durable Object bindings not yet materialized, so a
+ * startup throw fails every deploy with the flag set — and a genuine
+ * misconfiguration should degrade the spaces surface, never take the
+ * public repo path down with it.
+ */
+export function createSpacesUnavailableApp(): Hono {
+	const app = new Hono();
+	app.all("/xrpc/:method", async (c, next) => {
+		const method = c.req.param("method");
+		if (
+			!method.startsWith("com.atproto.space.") &&
+			!method.startsWith("com.atproto.simplespace.")
+		) {
+			return next();
+		}
+		return c.json(
+			{
+				error: "ServiceUnavailable",
+				message:
+					"SPACES_ENABLED is set but the SPACES / SPACES_INDEX Durable Object bindings are missing. Add them to wrangler.jsonc (migration v2).",
+			},
+			503,
+		);
+	});
+	return app;
+}
+
+/**
  * Build the host adapter and the complete spaces Hono app: the engine's
  * space/simplespace routes plus the PDS-level getDelegationToken and
  * listSpaces.
  */
 export function createSpacesApp(deps: SpacesAppDeps): Hono {
 	const { env, didResolver, getKeypair } = deps;
-	if (!env.SPACES || !env.SPACES_INDEX) {
-		throw new Error(
-			"SPACES_ENABLED is set but the SPACES / SPACES_INDEX Durable Object bindings are missing. Add them to wrangler.jsonc (migration v2).",
-		);
-	}
 
 	/**
 	 * Resolve a DID's signing key to a did:key string, honouring the

--- a/packages/pds/src/spaces.ts
+++ b/packages/pds/src/spaces.ts
@@ -149,6 +149,13 @@ export function createSpacesApp(deps: SpacesAppDeps): Hono {
 		if (kid && !SESSION_KID_ALLOWED.has(kid)) {
 			throw new Error(`Unsupported signing key id: ${kid}`);
 		}
+		// The operator's own key never goes through resolution: a Worker
+		// cannot fetch its own hostname (same-zone subrequests are blocked),
+		// and the delegation-for-own-space flow verifies tokens this Worker
+		// minted seconds earlier. The public key is already in the env.
+		if (iss === env.DID) {
+			return `did:key:${env.SIGNING_KEY_PUBLIC}`;
+		}
 		const doc = await didResolver.resolve(iss, { forceRefresh });
 		if (!doc) throw new Error(`Could not resolve DID: ${iss}`);
 		const methods = (doc.verificationMethod ?? []) as Array<{

--- a/packages/pds/test/spaces.test.ts
+++ b/packages/pds/test/spaces.test.ts
@@ -1,6 +1,45 @@
 import { describe, expect, it } from "vitest";
+import { createDpopProof } from "@atproto/space";
 import { env, worker, runInDurableObject } from "./helpers";
 import { createSpacesUnavailableApp } from "../src/spaces";
+
+/**
+ * Minimal WebCrypto-backed DPoP key satisfying the `Key` surface
+ * `createDpopProof` uses (`bareJwk`, `algorithms`, `createJwt`). Avoids
+ * @atproto/jwk-jose, whose bundled jose resolves to its Node build under
+ * the vitest workers pool and fails to sign.
+ */
+async function makeDpopKey() {
+	const pair = await crypto.subtle.generateKey(
+		{ name: "ECDSA", namedCurve: "P-256" },
+		true,
+		["sign"],
+	);
+	const jwk = await crypto.subtle.exportKey("jwk", pair.publicKey);
+	const bareJwk = { kty: jwk.kty, crv: jwk.crv, x: jwk.x, y: jwk.y };
+	const b64url = (bytes: Uint8Array) =>
+		btoa(String.fromCharCode(...bytes))
+			.replace(/\+/g, "-")
+			.replace(/\//g, "_")
+			.replace(/=+$/, "");
+	const encode = (obj: unknown) =>
+		b64url(new TextEncoder().encode(JSON.stringify(obj)));
+	return {
+		bareJwk,
+		algorithms: ["ES256"] as const,
+		async createJwt(header: unknown, payload: unknown) {
+			const input = `${encode(header)}.${encode(payload)}`;
+			const sig = new Uint8Array(
+				await crypto.subtle.sign(
+					{ name: "ECDSA", hash: "SHA-256" },
+					pair.privateKey,
+					new TextEncoder().encode(input),
+				),
+			);
+			return `${input}.${b64url(sig)}`;
+		},
+	} as never;
+}
 
 const authed = {
 	"Content-Type": "application/json",
@@ -160,6 +199,64 @@ describe("spaces integration", () => {
 			sub: space,
 			aud: `${authority}#atproto_space_host`,
 		});
+	});
+
+	it("round-trips delegation to credential to read on one PDS (bulletin flow)", async () => {
+		// The exact flow bulletin.my runs against a self-hosted board: mint
+		// a delegation for the operator's own space, exchange it for a
+		// credential, read with it. Verification must not require resolving
+		// the operator's own DID document — a Worker cannot fetch its own
+		// hostname.
+		const space = await createSpace();
+		await post("/xrpc/com.atproto.space.createRecord", {
+			space,
+			repo: env.DID,
+			collection: "test.cirrus.note",
+			rkey: "roundtrip",
+			record: { $type: "test.cirrus.note", text: "note" },
+		});
+		// The operator is always authorized for their own space, so
+		// member-list policy passes without adding a member.
+
+		const delegationRes = await get(
+			`/xrpc/com.atproto.space.getDelegationToken?space=${encodeURIComponent(space)}`,
+			{ Authorization: `Bearer ${env.AUTH_TOKEN}` },
+		);
+		expect(delegationRes.status).toBe(200);
+		const { token } = (await delegationRes.json()) as { token: string };
+
+		const dpopKey = await makeDpopKey();
+		const exchangeProof = await createDpopProof(dpopKey, {
+			htm: "POST",
+			htu: `https://${env.PDS_HOSTNAME}/xrpc/com.atproto.space.getSpaceCredential`,
+		});
+		const credentialRes = await post(
+			"/xrpc/com.atproto.space.getSpaceCredential",
+			{ space },
+			{
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+				DPoP: exchangeProof,
+			},
+		);
+		expect(credentialRes.status).toBe(200);
+		const { credential } = (await credentialRes.json()) as {
+			credential: string;
+		};
+
+		const readProof = await createDpopProof(dpopKey, {
+			htm: "GET",
+			htu: `https://${env.PDS_HOSTNAME}/xrpc/com.atproto.space.getRecord`,
+			credential,
+		});
+		const read = await get(
+			`/xrpc/com.atproto.space.getRecord?space=${encodeURIComponent(space)}&repo=${env.DID}&collection=test.cirrus.note&rkey=roundtrip`,
+			{ Authorization: `DPoP ${credential}`, DPoP: readProof },
+		);
+		expect(read.status).toBe(200);
+		expect(
+			((await read.json()) as { value: { text: string } }).value.text,
+		).toBe("note");
 	});
 
 	it("lists spaces from the index", async () => {

--- a/packages/pds/test/spaces.test.ts
+++ b/packages/pds/test/spaces.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { env, worker, runInDurableObject } from "./helpers";
+import { createSpacesUnavailableApp } from "../src/spaces";
 
 const authed = {
 	"Content-Type": "application/json",
@@ -334,6 +335,28 @@ describe("spaces integration", () => {
 		const reset = await post("/xrpc/gg.mk.experimental.spacesReset", {});
 		expect(reset.status).toBe(200);
 		expect(await stub.rpcGetMeta()).toBe(null);
+	});
+
+	it("degrades to 503 when the flag is set without bindings", async () => {
+		// The fallback app mounted when SPACES / SPACES_INDEX are absent:
+		// space and simplespace methods answer 503, everything else falls
+		// through to later routes (the proxy).
+		const app = createSpacesUnavailableApp();
+		const space = await app.request(
+			"/xrpc/com.atproto.space.getRecord?space=x",
+		);
+		expect(space.status).toBe(503);
+		expect(((await space.json()) as { error: string }).error).toBe(
+			"ServiceUnavailable",
+		);
+		const simplespace = await app.request(
+			"/xrpc/com.atproto.simplespace.createSpace",
+			{ method: "POST" },
+		);
+		expect(simplespace.status).toBe(503);
+		// Non-space methods are untouched.
+		const other = await app.request("/xrpc/com.atproto.repo.getRecord");
+		expect(other.status).toBe(404);
 	});
 
 	it("keeps the firehose and public repo untouched by space writes", async () => {

--- a/packages/pds/vitest.config.ts
+++ b/packages/pds/vitest.config.ts
@@ -1,8 +1,37 @@
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { defineConfig } from "vitest/config";
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 
+// @atproto/space (and @atproto/jwk-jose) depend on jose@5, whose Node build
+// cannot sign or verify under workerd's nodejs_compat in the vitest pool;
+// production builds pick jose's `workerd` condition (the WebCrypto build).
+// Redirect only THOSE importers to the browser build — the PDS's own
+// session code uses jose@6 and must keep resolving normally.
+const spaceRequire = createRequire(
+	createRequire(import.meta.url).resolve("@atproto/space"),
+);
+const jose5Browser = join(
+	dirname(spaceRequire.resolve("jose/package.json")),
+	"dist/browser/index.js",
+);
+
 export default defineConfig({
 	plugins: [
+		{
+			name: "jose5-workerd-build",
+			enforce: "pre",
+			resolveId(source, importer) {
+				if (
+					source === "jose" &&
+					importer &&
+					/@atproto[+/](space|jwk)/.test(importer)
+				) {
+					return jose5Browser;
+				}
+				return null;
+			},
+		},
 		cloudflareTest({
 			wrangler: { configPath: "./test/fixtures/pds-worker/wrangler.jsonc" },
 			miniflare: {

--- a/packages/spaces/src/auth.ts
+++ b/packages/spaces/src/auth.ts
@@ -207,10 +207,13 @@ export async function verifyDelegationAuth(
 }
 
 function invalidCredential(err: unknown): SpaceError {
+	// Server-side detail for operators; clients get the generic message.
+	console.warn("space credential verification failed:", err);
 	return new SpaceError("InvalidCredential", authErrorMessage(err));
 }
 
 function invalidDelegation(err: unknown): SpaceError {
+	console.warn("delegation token verification failed:", err);
 	return new SpaceError("InvalidDelegationToken", authErrorMessage(err));
 }
 

--- a/plans/in-progress/spaces.md
+++ b/plans/in-progress/spaces.md
@@ -47,10 +47,11 @@ User stories S1–S9 all have automated coverage (54 engine/protocol tests,
 
 ## Not done / next
 
-- **Interop runs** against the reference alpha Docker image, rsky and
-  bulletin.my (spec's acceptance tests). Nothing has been exercised
-  against a real foreign PDS yet — only against `@atproto/space`'s own
-  verifier primitives.
+- **Interop runs** against the reference alpha Docker image and rsky.
+  bulletin.my's S1 flow is verified live against pds.mk.gg (2026-08-29):
+  OAuth with space: scopes, board space creation, delegation →
+  credential exchange, reads, registerNotify and listRepos all work.
+  Cross-PDS (S2–S4) remains unexercised against a real foreign PDS.
 - **R2 lifecycle rule** must be applied per-install
   (`wrangler r2 bucket lifecycle add pds-blobs --prefix "<did>/staged/" --expire-days 7`);
   `pds init` doesn't automate it yet.


### PR DESCRIPTION
Two runtime fixes found by enabling spaces on the live demo, both verified with manual deploys against pds.mk.gg:

**1. Worker startup failed with the flag set.** Cloudflare's deploy-time startup validation evaluates module scope with vars visible but DO bindings not materialized, so `createSpacesApp`'s module-scope throw failed every deploy with `SPACES_ENABLED` set (and only those — which is why the Workers Build broke exactly at #222). Now: bindings present → spaces mount; absent → a fallback app 503s space/simplespace methods with fix instructions and everything else falls through. A real misconfiguration degrades spaces instead of bricking the PDS.

**2. getSpaceCredential 401'd on the operator's own spaces.** bulletin.my's board flow failed because verifying the delegation token this Worker minted seconds earlier resolved the operator's own did:web document — and a Worker cannot fetch its own hostname. `getSigningKey` now short-circuits the operator DID to `did:key` from `SIGNING_KEY_PUBLIC`. A new test round-trips the exact bulletin flow (delegation → credential → credential-authenticated read) through the real worker; verification failures now log detail server-side for `wrangler tail`.

**Live result:** bulletin.my works end-to-end against pds.mk.gg — OAuth with `space:` scopes, board creation, credential exchange, reads, `registerNotify`, `listRepos`, and a sticky note with an image (staged blob → space promotion). 333 pds + 56 spaces tests green.