### PR TITLE
feat(space-conformance): CLI runner (space-conformance run/coverage)

### DIFF
--- a/packages/space-conformance/package.json
+++ b/packages/space-conformance/package.json
@@ -19,10 +19,11 @@
 		"check": "publint && attw --pack --profile esm-only"
 	},
 	"dependencies": {
-		"@atproto/space": "0.0.0-spaces-alpha-20260818163953",
 		"@atproto/crypto": "^0.4.5",
 		"@atproto/lex-cbor": "^0.1.6",
-		"@atproto/lex-data": "^0.1.7"
+		"@atproto/lex-data": "^0.1.7",
+		"@atproto/oauth-client-node": "0.0.0-spaces-alpha-20260818163953",
+		"@atproto/space": "0.0.0-spaces-alpha-20260818163953"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/cli": "^0.18.2",
@@ -45,5 +46,8 @@
 		"interop"
 	],
 	"author": "Matt Kane",
-	"license": "MIT"
+	"license": "MIT",
+	"bin": {
+		"space-conformance": "./dist/cli.js"
+	}
 }

--- a/packages/space-conformance/src/cli/main.ts
+++ b/packages/space-conformance/src/cli/main.ts
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+/**
+ * space-conformance CLI.
+ *
+ *   space-conformance run --target https://host [--did did:...] \
+ *     [--handle alice.example.com] [--oauth] [--standalone-host] \
+ *     [--destructive] [--tier must,should] [--report out.json] [--json]
+ *   space-conformance coverage [--json]
+ *
+ * Operator auth (any one of):
+ *   --oauth --handle you.example.com — browser sign-in via the atproto
+ *     OAuth loopback flow; no password ever touches this process. Works
+ *     against any PDS with an OAuth server.
+ *   --handle + password — signs in via com.atproto.server.createSession;
+ *     the password comes from SPACE_CONFORMANCE_PASSWORD or an interactive
+ *     hidden prompt, never argv. Use the main password: app passwords are
+ *     refused on space routes.
+ *   SPACE_CONFORMANCE_TOKEN env — a bearer the target accepts (a session
+ *     accessJwt, or a deployment-specific static token).
+ *   --operator-token TOKEN — same, via argv; prefer the env var, since
+ *     argv leaks into shell history and process listings.
+ *
+ * Exit code is non-zero when any `must` check fails or errors, so it
+ * gates CI.
+ */
+
+import { parseArgs } from "node:util";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createInterface } from "node:readline";
+import { coverageReport } from "../coverage.js";
+import { fullCatalog } from "../full.js";
+import { renderReport } from "../runner.js";
+import { runConformance } from "./run.js";
+import { oauthSignIn, type OAuthOperator } from "./oauth.js";
+import type { Tier } from "../model.js";
+
+/**
+ * Read a password from the terminal with echo suppressed. Only offered on
+ * a TTY — a piped stdin gets the env-var error instead, so scripts fail
+ * loudly rather than hanging on a prompt nobody sees.
+ */
+function promptPassword(prompt: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const stdin = process.stdin;
+		const stderr = process.stderr;
+		stderr.write(prompt);
+		const rl = createInterface({ input: stdin, terminal: true });
+		// Suppress echo: readline writes keystrokes via its output stream;
+		// giving it none and muting is fiddly, so toggle raw handling simply —
+		// print nothing per keypress by not attaching an output stream.
+		rl.question("", (answer) => {
+			stderr.write("\n");
+			rl.close();
+			resolve(answer);
+		});
+		rl.on("error", reject);
+	});
+}
+
+function suiteVersion(): string {
+	try {
+		const here = dirname(fileURLToPath(import.meta.url));
+		const pkg = JSON.parse(
+			readFileSync(join(here, "..", "package.json"), "utf8"),
+		) as { version?: string };
+		return pkg.version ?? "0.0.0";
+	} catch {
+		return "0.0.0";
+	}
+}
+
+function parseTiers(value: string | undefined): Tier[] | undefined {
+	if (!value) return undefined;
+	const tiers = value.split(",").map((t) => t.trim()) as Tier[];
+	for (const tier of tiers) {
+		if (tier !== "must" && tier !== "should" && tier !== "info") {
+			throw new Error(`unknown tier: ${tier}`);
+		}
+	}
+	return tiers;
+}
+
+async function main(argv: string[]): Promise<number> {
+	const command = argv[0];
+
+	if (command === "coverage") {
+		const { values } = parseArgs({
+			args: argv.slice(1),
+			options: { json: { type: "boolean" } },
+		});
+		const report = coverageReport(fullCatalog);
+		if (values.json) {
+			process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+		} else {
+			process.stdout.write(
+				`${report.covered.length}/${report.requirements.length} requirements covered, ${report.gaps.length} gaps\n`,
+			);
+			for (const gap of report.gaps) {
+				process.stdout.write(`  gap: ${gap.ref}\n`);
+			}
+			for (const d of report.danglingCitations) {
+				process.stdout.write(`  dangling: ${d.checkId} → ${d.ref}\n`);
+			}
+		}
+		return report.danglingCitations.length > 0 ? 1 : 0;
+	}
+
+	if (command === "run") {
+		const { values } = parseArgs({
+			args: argv.slice(1),
+			options: {
+				target: { type: "string" },
+				did: { type: "string" },
+				implementation: { type: "string" },
+				"operator-token": { type: "string" },
+				handle: { type: "string" },
+				oauth: { type: "boolean" },
+				"standalone-host": { type: "boolean" },
+				identities: { type: "boolean" },
+				destructive: { type: "boolean" },
+				slow: { type: "boolean" },
+				tier: { type: "string" },
+				report: { type: "string" },
+				json: { type: "boolean" },
+			},
+		});
+		if (!values.target) {
+			process.stderr.write("run requires --target <origin>\n");
+			return 2;
+		}
+
+		const origin = values.target.replace(/\/+$/, "");
+		const operatorToken =
+			values["operator-token"] ?? process.env.SPACE_CONFORMANCE_TOKEN;
+
+		// The browser OAuth flow: no password ever enters this process, and
+		// the session is DPoP-bound (unusable as a plain bearer).
+		let oauthOperator: OAuthOperator | undefined;
+		if (values.oauth) {
+			if (!values.handle) {
+				process.stderr.write("--oauth requires --handle <your handle>\n");
+				return 2;
+			}
+			oauthOperator = await oauthSignIn({
+				handle: values.handle,
+				targetOrigin: origin,
+				log: (message) => process.stderr.write(`${message}\n`),
+			});
+		}
+
+		// Secrets come from the environment or an interactive hidden prompt,
+		// never argv — argv leaks into shell history and process listings.
+		// (--operator-token remains for CI where the value already lives in a
+		// secret store, but SPACE_CONFORMANCE_TOKEN is the recommended route.)
+		let password = process.env.SPACE_CONFORMANCE_PASSWORD;
+		if (
+			!password &&
+			values.handle &&
+			!values.oauth &&
+			!operatorToken &&
+			process.stdin.isTTY
+		) {
+			password = await promptPassword(`Password for ${values.handle}: `);
+		}
+
+		const report = await runConformance({
+			origin,
+			did: values.did,
+			implementation: values.implementation,
+			operatorToken,
+			operatorFetch: oauthOperator?.fetch,
+			handle: values.handle,
+			password,
+			standaloneHost: values["standalone-host"],
+			identities: values.identities,
+			destructive: values.destructive,
+			slow: values.slow,
+			tiers: parseTiers(values.tier),
+			suiteVersion: suiteVersion(),
+		});
+		// Conformance sessions are ephemeral: revoke the OAuth tokens once
+		// the run is done, best-effort.
+		if (oauthOperator) await oauthOperator.signOut();
+		if (values.report) {
+			writeFileSync(values.report, `${JSON.stringify(report, null, 2)}\n`);
+		}
+		process.stdout.write(
+			values.json
+				? `${JSON.stringify(report, null, 2)}\n`
+				: `${renderReport(report)}\n`,
+		);
+		// Gate on must-tier failures AND must-tier errors; should/info never
+		// fail the run. A must check that errored (an unreachable, hung or
+		// malformed target) must exit non-zero too — otherwise a target
+		// whose XRPC surface is down but whose did.json resolves would pass
+		// CI green.
+		return report.summary.mustFail > 0 || report.summary.mustError > 0 ? 1 : 0;
+	}
+
+	process.stderr.write("usage: space-conformance <run|coverage> [options]\n");
+	return 2;
+}
+
+main(process.argv.slice(2)).then(
+	(code) => {
+		process.exitCode = code;
+	},
+	(err) => {
+		process.stderr.write(`${err instanceof Error ? err.stack : String(err)}\n`);
+		process.exitCode = 1;
+	},
+);

--- a/packages/space-conformance/src/cli/oauth.ts
+++ b/packages/space-conformance/src/cli/oauth.ts
@@ -1,0 +1,191 @@
+/**
+ * OAuth loopback sign-in for the CLI — the `gh auth login` shape: start an
+ * ephemeral 127.0.0.1 callback server, register as an atproto loopback
+ * client, open the authorization URL in the user's browser, and exchange
+ * the callback for a DPoP-bound session.
+ *
+ * This is the auth path that involves no password at all and works against
+ * any PDS with an atproto OAuth server. The session's tokens are DPoP-bound
+ * — unusable as a plain bearer — so the run authenticates through
+ * `operator.fetch`, with the client library signing every request (and
+ * handling nonce challenges) rather than a static header.
+ */
+
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import {
+	NodeOAuthClient,
+	type NodeSavedSession,
+	type NodeSavedState,
+	type OAuthSession,
+} from "@atproto/oauth-client-node";
+
+/**
+ * The scope the conformance run signs in with: generic repo access (for
+ * uploadBlob) plus full record actions and space management on the probe
+ * space type under the user's own authority. Mirrors the web checker.
+ */
+const OAUTH_SCOPE =
+	"atproto transition:generic space:app.bsky.group?collection=*&manage=create&manage=update&manage=delete";
+
+/** How long to wait for the user to complete the browser flow. */
+const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface OAuthOperator {
+	/** Signs same-origin requests with the session's DPoP key. */
+	fetch: typeof fetch;
+	did: string;
+	/** Best-effort token revocation once the run is done. */
+	signOut(): Promise<void>;
+}
+
+/**
+ * A fetch that routes requests for `origin` through the session (which
+ * signs them) and everything else through the plain global fetch — the
+ * same shape as the web adapter, so checks keep their bare `ctx.fetch`
+ * for deliberately-anonymous requests.
+ */
+export function originGatedFetch(
+	signing: (pathname: string, init?: RequestInit) => Promise<Response>,
+	origin: string,
+): typeof fetch {
+	return (input, init) => {
+		const url = new URL(
+			typeof input === "string"
+				? input
+				: input instanceof URL
+					? input.toString()
+					: input.url,
+		);
+		if (url.origin === origin) {
+			return signing(url.pathname + url.search, init);
+		}
+		return fetch(input, init);
+	};
+}
+
+/** Open a URL in the platform browser, best-effort; never throws. */
+function openBrowser(url: string): void {
+	const [cmd, args] =
+		process.platform === "darwin"
+			? ["open", [url]]
+			: process.platform === "win32"
+				? ["cmd", ["/c", "start", "", url]]
+				: ["xdg-open", [url]];
+	try {
+		spawn(cmd, args, { stdio: "ignore", detached: true }).unref();
+	} catch {
+		// The URL is printed either way; opening is a convenience.
+	}
+}
+
+export async function oauthSignIn(options: {
+	handle: string;
+	targetOrigin: string;
+	log?: (message: string) => void;
+}): Promise<OAuthOperator> {
+	const log = options.log ?? (() => {});
+
+	// An ephemeral callback server; the OS picks the port, which then
+	// becomes part of the loopback client's registration.
+	let resolveParams!: (params: URLSearchParams) => void;
+	let rejectParams!: (err: Error) => void;
+	const paramsPromise = new Promise<URLSearchParams>((resolve, reject) => {
+		resolveParams = resolve;
+		rejectParams = reject;
+	});
+	const server = createServer((req, res) => {
+		const url = new URL(req.url ?? "/", "http://127.0.0.1");
+		if (url.pathname !== "/callback") {
+			res.writeHead(404).end();
+			return;
+		}
+		res
+			.writeHead(200, { "Content-Type": "text/html; charset=utf-8" })
+			.end(
+				"<!doctype html><meta charset=utf-8><title>space-conformance</title>" +
+					"<p style='font:16px system-ui;margin:3em'>Signed in — you can close this tab and return to the terminal.</p>",
+			);
+		resolveParams(url.searchParams);
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (address === null || typeof address !== "object") {
+		server.close();
+		throw new Error("could not bind the OAuth callback server");
+	}
+	const redirectUri = `http://127.0.0.1:${address.port}/callback`;
+
+	const timer = setTimeout(() => {
+		rejectParams(
+			new Error(
+				`timed out after ${CALLBACK_TIMEOUT_MS / 60000} minutes waiting for the browser sign-in`,
+			),
+		);
+	}, CALLBACK_TIMEOUT_MS);
+
+	try {
+		// A loopback client: the client_id itself carries the registration.
+		// One-shot in-memory stores — the session lives and dies with this
+		// process, which is the point of a conformance run.
+		const clientId = `http://localhost?${new URLSearchParams({
+			redirect_uri: redirectUri,
+			scope: OAUTH_SCOPE,
+		}).toString()}`;
+		const stateStore = new Map<string, NodeSavedState>();
+		const sessionStore = new Map<string, NodeSavedSession>();
+		const client = new NodeOAuthClient({
+			clientMetadata: {
+				client_id: clientId,
+				redirect_uris: [redirectUri as `http://127.0.0.1:${string}`],
+				scope: OAUTH_SCOPE,
+				token_endpoint_auth_method: "none",
+				grant_types: ["authorization_code", "refresh_token"],
+				response_types: ["code"],
+				dpop_bound_access_tokens: true,
+			},
+			stateStore: {
+				set: async (key, value) => void stateStore.set(key, value),
+				get: async (key) => stateStore.get(key),
+				del: async (key) => void stateStore.delete(key),
+			},
+			sessionStore: {
+				set: async (key, value) => void sessionStore.set(key, value),
+				get: async (key) => sessionStore.get(key),
+				del: async (key) => void sessionStore.delete(key),
+			},
+			// Local dev targets (wrangler dev, the reference harness) are http.
+			allowHttp: options.targetOrigin.startsWith("http://"),
+		});
+
+		const authorizeUrl = await client.authorize(options.handle, {
+			scope: OAUTH_SCOPE,
+		});
+		log(`Opening browser to authorize ${options.handle}…`);
+		log(`If it does not open, visit:\n  ${authorizeUrl.toString()}`);
+		openBrowser(authorizeUrl.toString());
+
+		const params = await paramsPromise;
+		const { session } = await client.callback(params);
+		log(`Signed in as ${session.did}`);
+		return {
+			did: session.did,
+			fetch: originGatedFetch(
+				(pathname, init) => session.fetchHandler(pathname, init),
+				options.targetOrigin,
+			),
+			signOut: () => sessionSignOut(session),
+		};
+	} finally {
+		clearTimeout(timer);
+		server.close();
+	}
+}
+
+async function sessionSignOut(session: OAuthSession): Promise<void> {
+	try {
+		await session.signOut();
+	} catch {
+		// Best-effort: the tokens die with the process either way.
+	}
+}

--- a/packages/space-conformance/src/cli/run.ts
+++ b/packages/space-conformance/src/cli/run.ts
@@ -1,0 +1,183 @@
+/**
+ * The CLI's core: resolve a target, assemble a context from what the
+ * invocation can provide, run the catalog. Exported separately from the
+ * bin so it can be driven in tests against an injected fetch without
+ * spawning a process.
+ */
+
+import { filterCatalog } from "../registry.js";
+import { runChecks, type RunReport } from "../runner.js";
+import { fullCatalog } from "../full.js";
+import { KeypairIdentityProvider } from "../identity.js";
+import type { Capability, CheckContext, Tier } from "../model.js";
+
+/** The alpha build the suite's verifiers are pinned to (from our deps). */
+const ALPHA_BUILD = "0.0.0-spaces-alpha-20260818163953";
+
+export interface RunConformanceOptions {
+	origin: string;
+	/** Target DID; resolved from the origin's did.json when omitted. */
+	did?: string;
+	implementation?: string;
+	/** Operator bearer token; enables the operator capability when present. */
+	operatorToken?: string;
+	/**
+	 * Mint the operator token by signing in: `com.atproto.server.createSession`
+	 * with this handle and {@link password}. Works against any standard PDS —
+	 * unlike a deployment-specific static token. Ignored when
+	 * {@link operatorToken} is set.
+	 */
+	handle?: string;
+	/**
+	 * The account password for {@link handle}. The bin only ever sources this
+	 * from the environment (`SPACE_CONFORMANCE_PASSWORD`) — never argv, which
+	 * leaks into shell history and process listings. Use the main password:
+	 * app passwords are refused on space routes.
+	 */
+	password?: string;
+	/**
+	 * An authenticated fetch for operator calls — a DPoP-bound OAuth session
+	 * from the loopback sign-in, which must sign each request individually
+	 * and so cannot be expressed as a bearer header. Takes precedence over
+	 * {@link operatorToken} and {@link handle}.
+	 */
+	operatorFetch?: typeof fetch;
+	/**
+	 * The target is a standalone space host rather than a full PDS: withhold
+	 * the `pds-blobs` and `pds-delegation` capabilities so the checks needing
+	 * `repo.uploadBlob` / `getDelegationToken` skip instead of false-failing.
+	 */
+	standaloneHost?: boolean;
+	/**
+	 * Provide harness identities. Only meaningful when the target can
+	 * resolve them — either an in-process fixture wired to the provider, or
+	 * a live deployment publishing the DIDs. A bare CLI against a remote
+	 * host cannot, so identity-requiring checks skip by default.
+	 */
+	identities?: boolean;
+	tiers?: Tier[];
+	destructive?: boolean;
+	slow?: boolean;
+	suiteVersion: string;
+	/** Injectable for tests; defaults to the global fetch. */
+	fetch?: typeof fetch;
+}
+
+export async function runConformance(
+	options: RunConformanceOptions,
+): Promise<RunReport> {
+	const doFetch = options.fetch ?? fetch;
+	// A trailing slash on --target would otherwise produce a double slash in
+	// the DID-document URL, which some hosts 404.
+	const origin = options.origin.replace(/\/+$/, "");
+	const did = options.did ?? (await resolveDid(doFetch, origin));
+
+	let operatorToken = options.operatorToken;
+	if (!operatorToken && !options.operatorFetch && options.handle) {
+		if (!options.password) {
+			throw new Error(
+				"--handle needs a password: set SPACE_CONFORMANCE_PASSWORD in the environment (or use --oauth)",
+			);
+		}
+		operatorToken = await createSession(
+			doFetch,
+			origin,
+			options.handle,
+			options.password,
+		);
+	}
+
+	const capabilities: Capability[] = [];
+	if (operatorToken || options.operatorFetch) {
+		capabilities.push("operator");
+		// A full PDS exposes the blob endpoints and getDelegationToken; only a
+		// standalone space host lacks them.
+		if (!options.standaloneHost) {
+			capabilities.push("pds-blobs", "pds-delegation");
+		}
+	}
+	if (options.identities) capabilities.push("identities");
+
+	const context: Omit<CheckContext, "state" | "log"> = {
+		target: {
+			origin,
+			did,
+			implementation: options.implementation,
+		},
+		fetch: doFetch,
+		...(options.operatorFetch
+			? { operator: { oauth: true, fetch: options.operatorFetch } }
+			: operatorToken
+				? {
+						operator: {
+							oauth: false,
+							async authorize(init) {
+								init.headers.set("Authorization", `Bearer ${operatorToken}`);
+							},
+						},
+					}
+				: {}),
+		...(options.identities
+			? { identities: new KeypairIdentityProvider() }
+			: {}),
+	};
+
+	const catalog = filterCatalog(fullCatalog, {
+		tiers: options.tiers,
+		capabilities,
+		destructive: options.destructive,
+		slow: options.slow,
+	});
+
+	return runChecks({
+		catalog,
+		context,
+		suiteVersion: options.suiteVersion,
+		alphaBuild: ALPHA_BUILD,
+	});
+}
+
+/**
+ * Sign in at the target and return the session's access token. This is the
+ * portable way to get operator auth: every standard PDS implements
+ * `com.atproto.server.createSession`, where a static bearer like Cirrus's
+ * AUTH_TOKEN is deployment-specific.
+ */
+async function createSession(
+	doFetch: typeof fetch,
+	origin: string,
+	identifier: string,
+	password: string,
+): Promise<string> {
+	const res = await doFetch(`${origin}/xrpc/com.atproto.server.createSession`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ identifier, password }),
+	});
+	const body = (await res.json().catch(() => ({}))) as {
+		accessJwt?: string;
+		error?: string;
+		message?: string;
+	};
+	if (!res.ok || !body.accessJwt) {
+		throw new Error(
+			`createSession failed for ${identifier} at ${origin}: ${res.status} ${body.error ?? ""} ${body.message ?? ""}`.trim(),
+		);
+	}
+	return body.accessJwt;
+}
+
+async function resolveDid(
+	doFetch: typeof fetch,
+	origin: string,
+): Promise<string> {
+	const res = await doFetch(`${origin}/.well-known/did.json`);
+	if (!res.ok) {
+		throw new Error(
+			`could not resolve target DID from ${origin}/.well-known/did.json (${res.status}); pass --did`,
+		);
+	}
+	const doc = (await res.json()) as { id?: string };
+	if (!doc.id) throw new Error("did.json has no id; pass --did");
+	return doc.id;
+}

--- a/packages/space-conformance/test/cli.test.ts
+++ b/packages/space-conformance/test/cli.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import { runConformance } from "../src/cli/run";
+import { originGatedFetch } from "../src/cli/oauth";
+
+const DID = "did:web:target.test";
+
+/**
+ * A minimal fake target: a valid DID document plus refusing auth
+ * endpoints. Enough to exercise the base (no-crypto) checks and prove the
+ * crypto checks skip cleanly when no operator/identities are supplied.
+ */
+function fakeTarget(): typeof fetch {
+	return (async (input: RequestInfo | URL) => {
+		const url = new URL(String(input));
+		if (url.pathname === "/.well-known/did.json") {
+			return Response.json({
+				id: DID,
+				service: [
+					{
+						id: "#atproto_space_host",
+						type: "AtprotoSpaceHost",
+						serviceEndpoint: "https://target.test",
+					},
+				],
+				verificationMethod: [{ id: `${DID}#atproto` }],
+			});
+		}
+		if (url.pathname.startsWith("/xrpc/com.atproto.space.getLatestCommit")) {
+			return Response.json({ error: "InvalidRequest" }, { status: 400 });
+		}
+		// Everything else (space reads, credential requests) is unauthenticated.
+		return Response.json({ error: "AuthMissing" }, { status: 401 });
+	}) as typeof fetch;
+}
+
+describe("runConformance (CLI core)", () => {
+	it("runs base checks against a target and skips crypto checks without capabilities", async () => {
+		const report = await runConformance({
+			origin: "https://target.test",
+			fetch: fakeTarget(),
+			suiteVersion: "0.0.0-test",
+			implementation: "fake",
+		});
+		// DID resolved from did.json.
+		expect(report.target.did).toBe(DID);
+		const byId = Object.fromEntries(report.results.map((r) => [r.id, r]));
+		// Base checks ran and passed.
+		expect(byId["discovery.space-host-service"]!.status).toBe("pass");
+		expect(byId["auth.getrecord-unauthenticated-refused"]!.status).toBe("pass");
+		expect(byId["request.invalid-space-uri-rejected"]!.status).toBe("pass");
+		// Crypto checks skipped for want of operator/identities — reported,
+		// not silently passed.
+		expect(byId["credential.round-trip"]!.status).toBe("skipped");
+		expect(byId["writes.create-and-read"]!.status).toBe("skipped");
+		expect(report.summary.mustFail).toBe(0);
+		expect(report.summary.skipped).toBeGreaterThan(0);
+	});
+
+	it("respects an explicit --did and tier filter", async () => {
+		const report = await runConformance({
+			origin: "https://target.test",
+			did: "did:plc:abc123",
+			tiers: ["must"],
+			fetch: fakeTarget(),
+			suiteVersion: "0.0.0-test",
+		});
+		expect(report.target.did).toBe("did:plc:abc123");
+		// should-tier checks are excluded from running — they appear only as
+		// skipped results (their tier is retained for the report).
+		const should = report.results.filter((r) => r.tier === "should");
+		expect(should.length).toBeGreaterThan(0);
+		expect(should.every((r) => r.status === "skipped")).toBe(true);
+	});
+
+	it("mints a session from --handle + env password and sends it as the operator bearer", async () => {
+		// The portable auth path: createSession at the target, then every
+		// operator call carries the minted accessJwt. A static token is
+		// deployment-specific; this works against any standard PDS.
+		const authHeaders: Array<string | null> = [];
+		const sessionTarget = (async (
+			input: RequestInfo | URL,
+			init?: RequestInit,
+		) => {
+			const url = new URL(String(input));
+			if (url.pathname === "/.well-known/did.json") {
+				return Response.json({
+					id: DID,
+					service: [
+						{
+							id: "#atproto_space_host",
+							type: "AtprotoSpaceHost",
+							serviceEndpoint: "https://target.test",
+						},
+					],
+					verificationMethod: [{ id: `${DID}#atproto` }],
+				});
+			}
+			if (url.pathname === "/xrpc/com.atproto.server.createSession") {
+				const body = JSON.parse(String(init?.body)) as {
+					identifier: string;
+					password: string;
+				};
+				expect(body).toEqual({
+					identifier: "alice.example.com",
+					password: "hunter2",
+				});
+				return Response.json({ accessJwt: "sess-tok", did: DID });
+			}
+			if (url.pathname === "/xrpc/com.atproto.simplespace.createSpace") {
+				authHeaders.push(new Headers(init?.headers).get("Authorization"));
+			}
+			return Response.json({ error: "AuthMissing" }, { status: 401 });
+		}) as typeof fetch;
+
+		const report = await runConformance({
+			origin: "https://target.test",
+			handle: "alice.example.com",
+			password: "hunter2",
+			destructive: true,
+			fetch: sessionTarget,
+			suiteVersion: "0.0.0-test",
+		});
+		// The minted token authenticated the operator calls.
+		expect(authHeaders.length).toBeGreaterThan(0);
+		expect(authHeaders.every((h) => h === "Bearer sess-tok")).toBe(true);
+		// Operator auth against a (presumed) full PDS also enables the blob
+		// and delegation capabilities, so those checks ran (they fail against
+		// this refusing fake — the point is they were not skipped).
+		const byId = Object.fromEntries(report.results.map((r) => [r.id, r]));
+		expect(byId["credential.self-round-trip"]!.status).not.toBe("skipped");
+		expect(byId["blobs.space-blob-not-public"]!.status).not.toBe("skipped");
+	});
+
+	it("withholds the full-PDS capabilities for a standalone space host", async () => {
+		const report = await runConformance({
+			origin: "https://target.test",
+			operatorToken: "static-tok",
+			standaloneHost: true,
+			destructive: true,
+			fetch: fakeTarget(),
+			suiteVersion: "0.0.0-test",
+		});
+		const byId = Object.fromEntries(report.results.map((r) => [r.id, r]));
+		expect(byId["credential.self-round-trip"]!.status).toBe("skipped");
+		expect(byId["blobs.space-blob-not-public"]!.status).toBe("skipped");
+	});
+
+	it("origin-gates the OAuth signing fetch: target requests sign, others stay anonymous", async () => {
+		// The deliberately-anonymous probes (unauth reads, public getBlob)
+		// must NOT pick up the session — only same-origin operator calls do.
+		const signed: string[] = [];
+		const gated = originGatedFetch(async (pathname) => {
+			signed.push(pathname);
+			return Response.json({ ok: true });
+		}, "https://target.test");
+		await gated("https://target.test/xrpc/com.atproto.space.createRecord?x=1");
+		// A cross-origin request falls through to the global fetch — which in
+		// this test environment will fail to connect; the point is it was NOT
+		// routed through the signer.
+		await gated("https://elsewhere.test/xrpc/whatever").catch(() => {});
+		expect(signed).toEqual(["/xrpc/com.atproto.space.createRecord?x=1"]);
+	});
+
+	it("refuses --handle without the env password, naming the variable", async () => {
+		await expect(
+			runConformance({
+				origin: "https://target.test",
+				handle: "alice.example.com",
+				fetch: fakeTarget(),
+				suiteVersion: "0.0.0-test",
+			}),
+		).rejects.toThrow(/SPACE_CONFORMANCE_PASSWORD/);
+	});
+
+	it("surfaces a target that fails a base check as a must failure", async () => {
+		// A target whose DID document lacks the space host entry must fail
+		// discovery.
+		const brokenTarget = (async (input: RequestInfo | URL) => {
+			const url = new URL(String(input));
+			if (url.pathname === "/.well-known/did.json") {
+				return Response.json({
+					id: DID,
+					service: [],
+					verificationMethod: [{ id: `${DID}#atproto` }],
+				});
+			}
+			return Response.json({ error: "AuthMissing" }, { status: 401 });
+		}) as typeof fetch;
+		const report = await runConformance({
+			origin: "https://target.test",
+			fetch: brokenTarget,
+			suiteVersion: "0.0.0-test",
+		});
+		const discovery = report.results.find(
+			(r) => r.id === "discovery.space-host-service",
+		);
+		expect(discovery!.status).toBe("fail");
+		expect(report.summary.mustFail).toBeGreaterThan(0);
+	});
+
+	it("counts must-tier errors so an unreachable target does not pass green", async () => {
+		// did.json resolves, but every XRPC call throws (target down). The
+		// base must-checks error rather than fail — the CLI must still gate.
+		const halfDown = (async (input: RequestInfo | URL) => {
+			const url = new URL(String(input));
+			if (url.pathname === "/.well-known/did.json") {
+				return Response.json({
+					id: DID,
+					service: [
+						{
+							id: "#atproto_space_host",
+							type: "AtprotoSpaceHost",
+							serviceEndpoint: "https://target.test",
+						},
+					],
+					verificationMethod: [{ id: `${DID}#atproto` }],
+				});
+			}
+			throw new Error("connection refused");
+		}) as typeof fetch;
+		const report = await runConformance({
+			origin: "https://target.test",
+			fetch: halfDown,
+			suiteVersion: "0.0.0-test",
+		});
+		// Some base must-checks errored; the CLI gates on mustFail OR mustError.
+		expect(report.summary.mustError).toBeGreaterThan(0);
+		const wouldExitNonZero =
+			report.summary.mustFail > 0 || report.summary.mustError > 0;
+		expect(wouldExitNonZero).toBe(true);
+	});
+
+	it("tolerates a trailing slash on the target origin", async () => {
+		const report = await runConformance({
+			origin: "https://target.test/",
+			fetch: fakeTarget(),
+			suiteVersion: "0.0.0-test",
+		});
+		// Resolved (no double-slash 404) and the origin is normalized.
+		expect(report.target.did).toBe(DID);
+		expect(report.target.origin).toBe("https://target.test");
+	});
+
+	it("errors clearly when the DID cannot be resolved", async () => {
+		const noDoc = (async () =>
+			Response.json({ error: "not found" }, { status: 404 })) as typeof fetch;
+		await expect(
+			runConformance({
+				origin: "https://target.test",
+				fetch: noDoc,
+				suiteVersion: "0.0.0-test",
+			}),
+		).rejects.toThrow(/could not resolve target DID/);
+	});
+});

--- a/packages/space-conformance/tsdown.config.ts
+++ b/packages/space-conformance/tsdown.config.ts
@@ -2,7 +2,11 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig([
 	{
-		entry: { index: "src/index.ts", full: "src/full.ts" },
+		entry: {
+			index: "src/index.ts",
+			full: "src/full.ts",
+			cli: "src/cli/main.ts",
+		},
 		format: ["esm"],
 		fixedExtension: false,
 		dts: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       '@atproto/lex-data':
         specifier: ^0.1.7
         version: 0.1.7
+      '@atproto/oauth-client-node':
+        specifier: 0.0.0-spaces-alpha-20260818163953
+        version: 0.0.0-spaces-alpha-20260818163953
       '@atproto/space':
         specifier: 0.0.0-spaces-alpha-20260818163953
         version: 0.0.0-spaces-alpha-20260818163953
@@ -605,6 +608,42 @@ packages:
   '@atcute/varint@2.0.2':
     resolution: {integrity: sha512-/+hS1juMgnmf6eL6lICUkTw7wcGTo3I+Q0L1PI521mUz77rGSC6nXAUNKtvm2wYJpuWdEGq+GILGoYkOArn0TQ==}
 
+  '@atproto-labs/did-resolver@0.3.7':
+    resolution: {integrity: sha512-F3M3U5cU1QSAXX3J5auGEc5N2pgDgpirAjvyDFsytXuyWfrjWfTPd/H+DZrrED7gK+noW0cAWtxxjdX7/cTSVQ==}
+    engines: {node: '>=22'}
+
+  '@atproto-labs/fetch-node@0.3.7':
+    resolution: {integrity: sha512-WZvjXIeEHGeOPmeckyGiSGeoHhkvzwnKtSrRSxgnHakkNqlKNLmPbUIYOIiJgiYgBSOCbse5NpPLRu3Zdw2+gA==}
+    engines: {node: '>=22'}
+
+  '@atproto-labs/fetch@0.3.5':
+    resolution: {integrity: sha512-iDFZEoNqfL17EVKE+uNzdUD7YF8LWhEhxeBtP6x+PNuAxoXv3ip9vLmB8nNzNxFwVn++FipfDtSiPqmziv1bdA==}
+    engines: {node: '>=22'}
+
+  '@atproto-labs/handle-resolver-node@0.2.8':
+    resolution: {integrity: sha512-S4HR3s15TP85LpBvK2pfmJgXRFEX9rPFpcRfBPeW1Rh2Bj8ixN5VZwOgABz2fHTyMidEZLyFGxc0G5HlVh0aWw==}
+    engines: {node: '>=22'}
+
+  '@atproto-labs/handle-resolver@0.4.8':
+    resolution: {integrity: sha512-38I+j8Efs+cCgW/NX9RFKKu7qv/AF+FqxlKS8sWjXlNZSHQZqPj5cnKVQhSsJCs4ypPB84iKch8w4/STd33bLg==}
+    engines: {node: '>=22'}
+
+  '@atproto-labs/identity-resolver@0.4.7':
+    resolution: {integrity: sha512-lKDaiBHoxrqTOFdSKAAPpplEtbbFrH4djGjnXJtOSMnZ46k7+G7AkCr1xycGGPOBYfyF54zRnTp0Tt8iu86qWg==}
+    engines: {node: '>=22'}
+
+  '@atproto-labs/pipe@0.2.4':
+    resolution: {integrity: sha512-n67jCcrC+ouAeO10cWkpPzzLMlDi/lDCU30Us+LGqhOPhT6c4t5ASdBLQi9W3jUQtRzQBt3G9zipF+xKWNvVbw==}
+    engines: {node: '>=22'}
+
+  '@atproto-labs/simple-store-memory@0.2.6':
+    resolution: {integrity: sha512-DD1v7MEfYF3BAcEpMTTpzfBLWLoI2HuyBhku2YpjHoqPrRrhCtE1alkxfPHjtjJVIjuU/XNU0cF/wB3+5FiKsA==}
+    engines: {node: '>=22'}
+
+  '@atproto-labs/simple-store@0.5.1':
+    resolution: {integrity: sha512-vfvoDhu6ds6BT3Pqe+d2/LBU1WpDRtt69y6zltlfMCoucPm82m1j50/Wb6xTvv+oZ+2j0JyZVXsmXQ12SWYQJg==}
+    engines: {node: '>=22'}
+
   '@atproto/api@0.18.20':
     resolution: {integrity: sha512-BZYZkh2VJIFCXEnc/vzKwAwWjAQQTgbNJ8FBxpBK+z+KYh99O0uPCsRYKoCQsRrnkgrhzdU9+g2G+7zanTIGbw==}
 
@@ -642,6 +681,10 @@ packages:
     resolution: {integrity: sha512-gzDoA0JTwnc0ZJOBLM7WX9xFxtynRS2K1Bofb8epzoMWDQvyvfbPcfkdPrKFM7NXCFUVpGpBnsCB8KFPTf1rCg==}
     engines: {node: '>=22'}
 
+  '@atproto/jwk-webcrypto@0.3.4':
+    resolution: {integrity: sha512-UsFIUozqnRecXPo6HgKV4PW4FqYHxX1V3iAe0rRV6Q2RSfYD8V2mZ89pv8NpvJynnaqJArBQ7HZlcg0F4tRYhA==}
+    engines: {node: '>=22'}
+
   '@atproto/jwk@0.6.0':
     resolution: {integrity: sha512-bDoJPvt7TrQVi/rBfBrSSpGykhtIriKxeYCYQTiPRKFfyRhbgpElF0wPXADjIswnbzZdOwbY63az4E/CFVT3Tw==}
 
@@ -676,8 +719,20 @@ packages:
     resolution: {integrity: sha512-mvrAd0lbyuecIHjyld8QN6MN6CBf4j0GCxLzegsvLh0SvDf+GbYWklkcQqmITL44yFQOwmA/QNIQj0Uvh7+R/g==}
     engines: {node: '>=22'}
 
+  '@atproto/lexicon@0.0.0-spaces-alpha-20260818163953':
+    resolution: {integrity: sha512-ncg3KVMl4aLj+fEJp1vu3Og6ZkKo/tBzz+5XClsk8zYAwRe6qNsJ+cYW5GrECxPvxuCvUra7ko9wMCwz3VJFmg==}
+    engines: {node: '>=22'}
+
   '@atproto/lexicon@0.6.1':
     resolution: {integrity: sha512-/vI1kVlY50Si+5MXpvOucelnYwb0UJ6Qto5mCp+7Q5C+Jtp+SoSykAPVvjVtTnQUH2vrKOFOwpb3C375vSKzXw==}
+
+  '@atproto/oauth-client-node@0.0.0-spaces-alpha-20260818163953':
+    resolution: {integrity: sha512-XEJS6GMk5mG136FVcoSzzFynnMKGsJ3J2Z0oVWotwkYdCyawN1UCoxtKalMqzFRSsk6uWyiNKig1OK+XwC+weQ==}
+    engines: {node: '>=22'}
+
+  '@atproto/oauth-client@0.0.0-spaces-alpha-20260818163953':
+    resolution: {integrity: sha512-LYCLFJuIkf3hgZxpFdN+tIkOtdRtszshS8aURcv/tEwlDWwIL86nryf/ORh+FCo/AxgJpXEZmr/zkyNBlGmdlw==}
+    engines: {node: '>=22'}
 
   '@atproto/oauth-scopes@0.0.0-spaces-alpha-20260818163953':
     resolution: {integrity: sha512-bQz4BwNk/FAPd8bXGO3EyhlIKu/UJzN5XIgmNeiZXtJbhbe30J78A3WnvBuA+SILiGFw7/M9hfgq9FcJKCzjCw==}
@@ -685,6 +740,10 @@ packages:
 
   '@atproto/oauth-types@0.6.3':
     resolution: {integrity: sha512-jdKuoPknJuh/WjI+mYk7agSbx9mNVMbS6Dr3k1z2YMY2oRiCQjxYBuo4MLKATbxj05nMQaZRWlHRUazoAu5Cng==}
+
+  '@atproto/oauth-types@0.7.5':
+    resolution: {integrity: sha512-x75O0HsKB1IGfBikAQrrTX6EL8Rt4Q0+wMcwhZQRGPk/N/WqbYbsW3Powj4R8ZJKSfWCpVfaw32Piu1pTi891Q==}
+    engines: {node: '>=22'}
 
   '@atproto/repo@0.8.12':
     resolution: {integrity: sha512-QpVTVulgfz5PUiCTELlDBiRvnsnwrFWi+6CfY88VwXzrRHd9NE8GItK7sfxQ6U65vD/idH8ddCgFrlrsn1REPQ==}
@@ -703,6 +762,10 @@ packages:
 
   '@atproto/syntax@0.4.3':
     resolution: {integrity: sha512-YoZUz40YAJr5nPwvCDWgodEOlt5IftZqPJvA0JDWjuZKD8yXddTwSzXSaKQAzGOpuM+/A3uXRtPzJJqlScc+iA==}
+
+  '@atproto/xrpc@0.0.0-spaces-alpha-20260818163953':
+    resolution: {integrity: sha512-AW2zqwpUh8C4pkiDNbmM1FLjmVm5TShaGKDlGAiTMuxf43rfQ+FeBucb9H5w2iaIUQJ594dN3lHXijBATkGNcw==}
+    engines: {node: '>=22'}
 
   '@atproto/xrpc@0.7.7':
     resolution: {integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==}
@@ -3203,6 +3266,10 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  ipaddr.js@2.5.0:
+    resolution: {integrity: sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==}
+    engines: {node: '>= 10'}
+
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
@@ -3399,6 +3466,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.5.0:
     resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
@@ -4379,6 +4449,10 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
   undici@7.18.2:
     resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
     engines: {node: '>=20.18.1'}
@@ -4386,6 +4460,10 @@ packages:
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
@@ -5221,6 +5299,55 @@ snapshots:
 
   '@atcute/varint@2.0.2': {}
 
+  '@atproto-labs/did-resolver@0.3.7':
+    dependencies:
+      '@atproto-labs/fetch': 0.3.5
+      '@atproto-labs/pipe': 0.2.4
+      '@atproto-labs/simple-store': 0.5.1
+      '@atproto-labs/simple-store-memory': 0.2.6
+      '@atproto/did': 0.5.4
+      zod: 3.25.76
+
+  '@atproto-labs/fetch-node@0.3.7':
+    dependencies:
+      '@atproto-labs/fetch': 0.3.5
+      '@atproto-labs/pipe': 0.2.4
+      ipaddr.js: 2.5.0
+      undici_v6: undici@6.28.0
+      undici_v7: undici@7.24.8
+      undici_v8: undici@8.10.0
+
+  '@atproto-labs/fetch@0.3.5':
+    dependencies:
+      '@atproto-labs/pipe': 0.2.4
+
+  '@atproto-labs/handle-resolver-node@0.2.8':
+    dependencies:
+      '@atproto-labs/fetch-node': 0.3.7
+      '@atproto-labs/handle-resolver': 0.4.8
+      '@atproto/did': 0.5.4
+
+  '@atproto-labs/handle-resolver@0.4.8':
+    dependencies:
+      '@atproto-labs/simple-store': 0.5.1
+      '@atproto-labs/simple-store-memory': 0.2.6
+      '@atproto/did': 0.5.4
+      zod: 3.25.76
+
+  '@atproto-labs/identity-resolver@0.4.7':
+    dependencies:
+      '@atproto-labs/did-resolver': 0.3.7
+      '@atproto-labs/handle-resolver': 0.4.8
+
+  '@atproto-labs/pipe@0.2.4': {}
+
+  '@atproto-labs/simple-store-memory@0.2.6':
+    dependencies:
+      '@atproto-labs/simple-store': 0.5.1
+      lru-cache: 10.4.3
+
+  '@atproto-labs/simple-store@0.5.1': {}
+
   '@atproto/api@0.18.20':
     dependencies:
       '@atproto/common-web': 0.4.16
@@ -5289,6 +5416,12 @@ snapshots:
       '@atproto/jwk': 0.7.4
       jose: 5.10.0
 
+  '@atproto/jwk-webcrypto@0.3.4':
+    dependencies:
+      '@atproto/jwk': 0.7.4
+      '@atproto/jwk-jose': 0.2.4
+      zod: 3.25.76
+
   '@atproto/jwk@0.6.0':
     dependencies:
       multiformats: 9.9.0
@@ -5347,12 +5480,47 @@ snapshots:
       '@atproto/lex-data': 0.1.7
       tslib: 2.8.1
 
+  '@atproto/lexicon@0.0.0-spaces-alpha-20260818163953':
+    dependencies:
+      '@atproto/common-web': 0.0.0-spaces-alpha-20260818163953
+      '@atproto/syntax': 0.0.0-spaces-alpha-20260818163953
+      multiformats: 13.4.2
+      zod: 3.25.76
+
   '@atproto/lexicon@0.6.1':
     dependencies:
       '@atproto/common-web': 0.4.16
       '@atproto/syntax': 0.4.3
       iso-datestring-validator: 2.2.2
       multiformats: 9.9.0
+      zod: 3.25.76
+
+  '@atproto/oauth-client-node@0.0.0-spaces-alpha-20260818163953':
+    dependencies:
+      '@atproto-labs/did-resolver': 0.3.7
+      '@atproto-labs/handle-resolver-node': 0.2.8
+      '@atproto-labs/simple-store': 0.5.1
+      '@atproto/did': 0.5.4
+      '@atproto/jwk': 0.7.4
+      '@atproto/jwk-jose': 0.2.4
+      '@atproto/jwk-webcrypto': 0.3.4
+      '@atproto/oauth-client': 0.0.0-spaces-alpha-20260818163953
+      '@atproto/oauth-types': 0.7.5
+
+  '@atproto/oauth-client@0.0.0-spaces-alpha-20260818163953':
+    dependencies:
+      '@atproto-labs/did-resolver': 0.3.7
+      '@atproto-labs/fetch': 0.3.5
+      '@atproto-labs/handle-resolver': 0.4.8
+      '@atproto-labs/identity-resolver': 0.4.7
+      '@atproto-labs/simple-store': 0.5.1
+      '@atproto-labs/simple-store-memory': 0.2.6
+      '@atproto/did': 0.5.4
+      '@atproto/jwk': 0.7.4
+      '@atproto/oauth-types': 0.7.5
+      '@atproto/xrpc': 0.0.0-spaces-alpha-20260818163953
+      core-js: 3.49.0
+      multiformats: 13.4.2
       zod: 3.25.76
 
   '@atproto/oauth-scopes@0.0.0-spaces-alpha-20260818163953':
@@ -5364,6 +5532,12 @@ snapshots:
     dependencies:
       '@atproto/did': 0.3.0
       '@atproto/jwk': 0.6.0
+      zod: 3.25.76
+
+  '@atproto/oauth-types@0.7.5':
+    dependencies:
+      '@atproto/did': 0.5.4
+      '@atproto/jwk': 0.7.4
       zod: 3.25.76
 
   '@atproto/repo@0.8.12':
@@ -5399,6 +5573,11 @@ snapshots:
   '@atproto/syntax@0.4.3':
     dependencies:
       tslib: 2.8.1
+
+  '@atproto/xrpc@0.0.0-spaces-alpha-20260818163953':
+    dependencies:
+      '@atproto/lexicon': 0.0.0-spaces-alpha-20260818163953
+      zod: 3.25.76
 
   '@atproto/xrpc@0.7.7':
     dependencies:
@@ -7810,6 +7989,8 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  ipaddr.js@2.5.0: {}
+
   iron-webcrypto@1.2.1: {}
 
   is-alphabetical@2.0.1: {}
@@ -7956,6 +8137,8 @@ snapshots:
       p-locate: 4.1.0
 
   longest-streak@3.1.0: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.5.0: {}
 
@@ -9398,9 +9581,13 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici@6.28.0: {}
+
   undici@7.18.2: {}
 
   undici@7.24.8: {}
+
+  undici@8.10.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
Runner #1 of three. `space-conformance run --target <origin>` resolves
the target DID from its did.json, assembles a context from what the
invocation provides (an --operator-token enables the operator
capability), runs the catalog, and exits non-zero on any must-tier
failure so it gates CI. --tier, --destructive, --report and --json
flags. `space-conformance coverage` prints the computed method/error
coverage and any dangling citations.

A bare CLI can't publish resolvable harness DIDs, so identity-requiring
checks skip honestly against a remote target — the vitest adapter and
the hermetic matrix cover those. Exported as runConformance() so the
core is testable against an injected fetch without spawning the bin.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>