### PR TITLE
check: skip listAppPasswords when the PDS rejects OAuth sessions

### DIFF
--- a/apps/check/src/checks/account.ts
+++ b/apps/check/src/checks/account.ts
@@ -146,6 +146,16 @@ const listAppPasswords: Check = {
 		const client = authedClient(ctx.agent!);
 		const res = await client.get("com.atproto.server.listAppPasswords", {});
 		if (!res.ok) {
+			// The reference PDS forbids OAuth credentials on this endpoint
+			// ("OAuth credentials are not supported for this endpoint"), so a
+			// 403 from our DPoP session is conformant behavior, not a failure.
+			if (res.status === 403) {
+				return {
+					status: "skip",
+					message: "endpoint rejects OAuth sessions (matches reference PDS)",
+					evidence: { response: { status: res.status, body: res.data } },
+				};
+			}
 			return {
 				status: "fail",
 				message: `${res.data.error}: ${res.data.message ?? ""}`.trim(),


### PR DESCRIPTION
the `listAppPasswords` check runs against an OAuth (DPoP) session, but the reference PDS explicitly forbids OAuth credentials on this endpoint — its handler throws `ForbiddenError('OAuth credentials are not supported for this endpoint')` for any OAuth credential ([`listAppPasswords.ts`](https://github.com/bluesky-social/atproto/blob/main/packages/pds/src/api/com/atproto/server/listAppPasswords.ts)). so a 403 here is conformant behavior, and a PDS matching the reference currently fails the check. treat that 403 as a skip instead.

seen in the wild against a zds instance, which gates app-password management behind password sessions the same way and returned `AuthFactorTokenRequired: Password session required`:

```
✗ listAppPasswords — AuthFactorTokenRequired: Password session required
```

opened as a draft since you may prefer to key the skip off the error body rather than the bare status, or to surface it as a pass with a note.

![bufo-asks-politely-to-stop](https://all-the.bufo.zone/bufo-asks-politely-to-stop.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WEGRiZrVy9BCS4sXh2BKbg
