### PR TITLE
Add key ( required) to space declaration

### DIFF
--- a/packages/space-conformance/probe-lexicons/earth.cirrus.check.space.json
+++ b/packages/space-conformance/probe-lexicons/earth.cirrus.check.space.json
@@ -5,6 +5,7 @@
 	"defs": {
 		"main": {
 			"type": "space",
+			"key:":"literal:probe",
 			"name": "Conformance probe space",
 			"description": "Ephemeral probe spaces created by the @getcirrus/space-conformance suite (check.cirrus.earth). Each is created with a run-unique key and deleted when its check finishes.",
 			"collections": ["earth.cirrus.check.note", "earth.cirrus.check.withblob"]

--- a/packages/space-conformance/probe-lexicons/earth.cirrus.check.space.json
+++ b/packages/space-conformance/probe-lexicons/earth.cirrus.check.space.json
@@ -5,10 +5,13 @@
 	"defs": {
 		"main": {
 			"type": "space",
-			"key:": "literal:probe",
+			"key": "any",
 			"name": "Conformance probe space",
 			"description": "Ephemeral probe spaces created by the @getcirrus/space-conformance suite (check.cirrus.earth). Each is created with a run-unique key and deleted when its check finishes.",
-			"collections": ["earth.cirrus.check.note", "earth.cirrus.check.withblob"]
+			"collections": [
+				"earth.cirrus.check.note",
+				"earth.cirrus.check.withblob"
+			]
 		}
 	}
 }

--- a/packages/space-conformance/probe-lexicons/earth.cirrus.check.space.json
+++ b/packages/space-conformance/probe-lexicons/earth.cirrus.check.space.json
@@ -5,7 +5,7 @@
 	"defs": {
 		"main": {
 			"type": "space",
-			"key:":"literal:probe",
+			"key:": "literal:probe",
 			"name": "Conformance probe space",
 			"description": "Ephemeral probe spaces created by the @getcirrus/space-conformance suite (check.cirrus.earth). Each is created with a run-unique key and deleted when its check finishes.",
 			"collections": ["earth.cirrus.check.note", "earth.cirrus.check.withblob"]


### PR DESCRIPTION
According to the [space proposal](https://github.com/bluesky-social/proposals/tree/main/0016-permissioned-data#space-type-declarations) a key  definition is required in a space delaration 