### PR TITLE
fix(pds): serialize record blobs in canonical JSON form

### DIFF
--- a/.changeset/canonical-list-record-blobs.md
+++ b/.changeset/canonical-list-record-blobs.md
@@ -1,0 +1,5 @@
+---
+"@getcirrus/pds": patch
+---
+
+Return canonical AT Protocol blob objects from `com.atproto.repo.listRecords`. Repository iteration decodes blobs as compatibility `BlobRef` instances; these are now serialized through their JSON representation instead of leaking the internal `original` field and omitting the outer `$type: "blob"`.

--- a/packages/pds/src/repo/engine.ts
+++ b/packages/pds/src/repo/engine.ts
@@ -968,6 +968,19 @@ function serializeRecord(obj: unknown): unknown {
 		return { $bytes: btoa(binary) };
 	}
 
+	// @atproto/repo's walkRecords() decodes blobs as the legacy
+	// @atproto/lexicon BlobRef class. Honor its JSON representation before
+	// walking enumerable properties, otherwise the internal `original` field
+	// leaks into listRecords and the outer `$type: "blob"` is lost.
+	if (
+		typeof obj === "object" &&
+		"toJSON" in obj &&
+		typeof obj.toJSON === "function"
+	) {
+		const json = obj.toJSON();
+		if (json !== obj) return serializeRecord(json);
+	}
+
 	if (Array.isArray(obj)) {
 		return obj.map(serializeRecord);
 	}

--- a/packages/pds/test/blob-ref-normalization.test.ts
+++ b/packages/pds/test/blob-ref-normalization.test.ts
@@ -98,8 +98,43 @@ describe("Blob Reference Normalization", () => {
 
 		// The API response should have the blob ref serialized back to JSON format
 		const apiImage = getData.value.embed.images[0]!.image;
-		expect(apiImage.ref.$link).toBe(blobCid);
-		expect(apiImage.mimeType).toBe("image/png");
+		const expectedImage = {
+			$type: "blob",
+			ref: { $link: blobCid },
+			mimeType: "image/png",
+			size: pngHeader.length,
+		};
+		expect(apiImage).toEqual(expectedImage);
+		expect(apiImage).not.toHaveProperty("original");
+
+		// listRecords uses the same repository serialization path and must return
+		// the same canonical JSON blob shape.
+		const listResponse = await worker.fetch(
+			new Request(
+				`http://pds.test/xrpc/com.atproto.repo.listRecords?repo=${env.DID}&collection=app.bsky.feed.post&limit=100`,
+			),
+			env,
+		);
+		expect(listResponse.status).toBe(200);
+
+		const listData = (await listResponse.json()) as {
+			records: Array<{
+				uri: string;
+				value: {
+					embed: {
+						images: Array<{ image: typeof expectedImage }>;
+					};
+				};
+			}>;
+		};
+		const listedRecord = listData.records.find((record) =>
+			record.uri.endsWith(`/${rkey}`),
+		);
+		expect(listedRecord).toBeDefined();
+		expect(listedRecord!.value.embed.images[0]!.image).toEqual(expectedImage);
+		expect(listedRecord!.value.embed.images[0]!.image).not.toHaveProperty(
+			"original",
+		);
 
 		// Step 4: Inspect the raw stored record via the repo directly
 		// This verifies the internal representation uses CID objects, not JSON


### PR DESCRIPTION
To be upfront, this was debugged and fixed using agents. I deployed, tested, and confirmed the fix manually.

I ran into an issue with [nperez0111/bookhive](https://github.com/nperez0111/bookhive). Bookhive is able to push new entries to my `buzz.bookhive.book` collection. Upon login, their AppView would pull book entries from my PDS to update their database. If the schema validation fails it would silently drop all entries from their database resulting in an empty profile on their end. While this isn't the best error handling, this issue is caused by cirrus not returning the correct schema.

Cirrus returns this value: 

```json
{
  "$type": "buzz.bookhive.book",
  "cover": {
    "ref": {
      "$link": "bafkreibd7xhspgd2suofr7yr3k2mzwtxnsosr2eendhvtlx67dum2bceji"
    },
    "mimeType": "image/jpeg",
    "size": 46668,
    "original": {
      "$type": "blob",
      "ref": {
        "$link": "bafkreibd7xhspgd2suofr7yr3k2mzwtxnsosr2eendhvtlx67dum2bceji"
      },
      "mimeType": "image/jpeg",
      "size": 46668
    }
  },
  "owned": true,
  "title": "Dungeon Crawler Carl",
  ...
}
```

According to the lexicon, `cover` is of type `blob` and thus requires `"$type": "blob"` to be present which is not the case here. In fact, it even returns an extra `original` which does indeed look like what has to be returned instead.

This PR fixes this issue. 

After the fix, Cirrus returns the expected value:

```json
{
  "$type": "buzz.bookhive.book",
  "cover": {
    "$type": "blob",
    "ref": {
      "$link": "bafkreibd7xhspgd2suofr7yr3k2mzwtxnsosr2eendhvtlx67dum2bceji"
    },
    "mimeType": "image/jpeg",
    "size": 46668
  },
  "owned": true,
  "title": "Dungeon Crawler Carl",
  ...
}
```
