### PR TITLE
Change default action to allow on OAuth screen

### DIFF
--- a/packages/oauth-provider/src/ui.ts
+++ b/packages/oauth-provider/src/ui.ts
@@ -776,6 +776,7 @@ export function renderConsentUI(options: ConsentUIOptions): string {
 
 		.buttons {
 			display: flex;
+			flex-direction: row-reverse;
 			gap: 12px;
 		}
 
@@ -986,8 +987,8 @@ export function renderConsentUI(options: ConsentUIOptions): string {
 			</div>
 
 			<div class="buttons">
-				<button type="submit" name="action" value="deny" class="btn-deny">Deny</button>
 				<button type="submit" name="action" value="allow" class="btn-allow"${hasResolutionFailure ? " disabled" : ""}>Allow</button>
+				<button type="submit" name="action" value="deny" class="btn-deny">Deny</button>
 			</div>
 		</form>
 


### PR DESCRIPTION
When I'm logging into services using my PDS, I often press the enter key after I put in my password. However this denies access rather than allows it, so I always end up having to login again.

This is a small change to make the default action on the OAuth screen "Allow" rather than "Deny". This feels like the desired behavior but if not, please disregard!